### PR TITLE
Fix links in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ export SAUCE_ACCESS_KEY=<your-access-key>
 
 If you are using a cloud CI/CD tool, we strongly suggest to protect these values
 through secrets or context variables. You can get your `SAUCE_ACCESS_KEY` from
-Account > User Settings in [Sauce Labs](https://accounts.saucelabs.com/).
+Account > User Settings in [Sauce Labs](https://app.saucelabs.com/).
 
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ export SAUCE_ACCESS_KEY=<your-access-key>
 
 If you are using a cloud CI/CD tool, we strongly suggest to protect these values
 through secrets or context variables. You can get your `SAUCE_ACCESS_KEY` from
-Account > User Settings in [Sauce Labs](https://saucelabs.com/).
+Account > User Settings in [Sauce Labs](https://accounts.saucelabs.com/).
 
 
 ## Getting started
@@ -177,7 +177,7 @@ examples are included, the mechanism works with any CI/CD provider that supports
 <!-- [START collaboration] -->
 ## Collaboration
 There is a lot we can imagine doing next. It starts with hearing from you.
-Submit issues and features [here](https://github.com/saucelabs/saucectl/issues/new/chooses) - everything helps!
+Submit issues and features [here](https://github.com/saucelabs/saucectl/issues/new/choose) - everything helps!
 <!-- [END collaboration] -->
 
 <!-- [START contribution] -->


### PR DESCRIPTION
### Description
- issue link was broken
- link for getting the user settings of Sauce Labs linked to the website instead of the login page

### Motivation and Context
The links were directing people to a 404 or incorrect page

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/saucelabs/saucectl/blob/master/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
