### PR TITLE
Update test file matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ specify it through `saucectl run -c ./path/to/config.yml`.
 As an example, this repository uses two configurations for its pipeline. One
 for [Puppeteer](./.sauce/puppeteer.yml), and one for [Playwright](./.sauce/playwright.yml).
 
-> **NOTE:** Test files need to match `(spec|test)` in their file name so they will be automatically detected as testfiles
+> **NOTE:** Test files need to match `(spec|test)` in their file name so they will be automatically detected as testfiles.
 
 <!-- [END gettingstarted] -->
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ metadata:
     - other tag
   build: Release $CI_COMMIT_SHORT_SHA
 files:
-  - ./tests/**
+  - ./tests/**/*.js
 image:
   base: saucelabs/sauce-puppeteer-runner
   version: latest
@@ -112,6 +112,8 @@ specify it through `saucectl run -c ./path/to/config.yml`.
 
 As an example, this repository uses two configurations for its pipeline. One
 for [Puppeteer](./.sauce/puppeteer.yml), and one for [Playwright](./.sauce/playwright.yml).
+
+> **NOTE:** Test files need to match `(spec|test)` in their file name so they will be automatically detected as testfiles
 
 <!-- [END gettingstarted] -->
 


### PR DESCRIPTION
### Description
- Tests files are not found if the tests don't have `spec|test` in the file name
- `- ./tests/**` doesn't find any files

```log
➜ saucectl run

> sauce-puppeteer-runner@0.0.0 test /home/seluser
> DISPLAY="$(cat DISPLAY)" DEBUG="puppeteer:*" jest --config=./.config/jest.config.js

No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
In /home/seluser
  11 files checked.
  testMatch: **/seluser/tests/?(*.)+(spec|test).[jt]s?(x), **/seluser/tests/**/?(*.)+(spec|test).[jt]s?(x) - 0 matches
  testPathIgnorePatterns: /node_modules/ - 11 matches
  testRegex:  - 0 matches
Pattern:  - 0 matches
npm ERR! Test failed.  See above for more details.
```

### Motivation and Context
Docs are not clear about the file name structure and the glob example is not working

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist- [ ] I have read the [contributing](https://github.com/saucelabs/saucectl/blob/master/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
