### PR TITLE
Use devx sauce bot account for releasing brew updates

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,9 @@ brews:
     name: saucectl
     homepage: "https://saucelabs.com/"
     description: "A command line interface to run testrunner tests."
+    commit_author:
+      name: devx-sauce-bot
+      email: devx.bot@saucelabs.com
     dependencies:
       - docker
 archives:


### PR DESCRIPTION
## Proposed changes

The default was the "goreleaserbot". Now that we have a devx sauce bot account (say hello to https://github.com/devx-sauce-bot), we can use that one for pipelines.
