### PR TITLE
Document which instances are accessible through the global scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The examples here show how Pipeline testing can be used. Try them and find your 
 
 #### Puppeteer Snippet:
 
-Our Puppeteer testrunner image exposes `browser` into the global scope which represents an instance of its [`Browser class`](https://pptr.dev/#?product=Puppeteer&version=v3.0.4&show=api-class-browser). The browser is will be initiated and shutdown by the testrunner setup.
+Our Puppeteer testrunner image exposes `browser` into the global scope which represents an instance of its [`Browser class`](https://pptr.dev/#?product=Puppeteer&version=v3.0.4&show=api-class-browser). The browser will be initiated and shutdown by the testrunner setup.
 
 ```js
 describe('saucectl demo test', () => {

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ All images are hosted on Docker Hub.
 The examples here show how Pipeline testing can be used. Try them and find your own use cases. Every testrunner image comes with a preconfigured setup that allows you to focus on writing tests instead of tweaking with the configurations. Our initial testrunner flavors come either with Puppeteer or Playwright as an automation framework. They will start the browser for you and expose the `browser` object ([Puppeteer](https://pptr.dev/#?product=Puppeteer&version=v3.0.3&show=api-class-browser) / [Playwright](https://playwright.dev/#version=v1.0.1&path=docs%2Fcore-concepts.md&q=browser)) to the global scope for you to be accessible in the test:
 
 #### Puppeteer Snippet:
+
+Our Puppeteer testrunner image exposes `browser` into the global scope which represents an instance of its [`Browser class`](https://pptr.dev/#?product=Puppeteer&version=v3.0.4&show=api-class-browser). The browser is will be initiated and shutdown by the testrunner setup.
+
 ```js
 describe('saucectl demo test', () => {
 	test('should verify title of the page', async () => {
@@ -148,6 +151,9 @@ describe('saucectl demo test', () => {
 ```
 
 #### Playwright Snippet:
+
+The Playwright testrunner image also exposes a global `browser` variable that represents Playwrights [`Browser class`](https://playwright.dev/#version=v1.0.2&path=docs%2Fcore-concepts.md&q=browser). In addition to that you also have access to a pre-generated [browser context](https://playwright.dev/#version=v1.0.2&path=docs%2Fcore-concepts.md&q=browser-contexts) via `context` as well as to a [page frame](https://playwright.dev/#version=v1.0.2&path=docs%2Fcore-concepts.md&q=pages-and-frames) via `page`.
+
 ```js
 describe('saucectl demo test', () => {
 	test('should verify title of the page', async () => {


### PR DESCRIPTION
### Description
This patch adds documentation on which objects are being exposed to the global scope in the Puppeteer and Playwright test runner.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/saucelabs/saucectl/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
