### PR TITLE
Use the new image naming scheme

### DIFF
--- a/cli/command/new/templates.go
+++ b/cli/command/new/templates.go
@@ -12,7 +12,7 @@ metadata:
 files:
   - ./tests/example.test.js
 image:
-  base: saucelabs/sauce-{{ .Framework }}
+  base: {{ .Name }}
   version: {{ .Version }}
 `
 

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -36,6 +36,22 @@ var (
 	}
 )
 
+// Image represents docker image metadata.
+type Image struct {
+	Name    string
+	Version string
+}
+
+var DefaultPlaywright = Image{
+	Name:    "saucelabs/stt-playwright-jest-node",
+	Version: "v0.1.0",
+}
+
+var DefaultPuppeteer = Image{
+	Name:    "saucelabs/stt-puppeteer-jest-node",
+	Version: "v0.1.0",
+}
+
 // ClientInterface describes the interface used to handle docker commands
 type ClientInterface interface {
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)


### PR DESCRIPTION
## Proposed changes

The `new` command generates a sample config that references the new playwright/puppeteer image.
This change was necessary to adhere to the new image naming and versioning that our playwright/puppeteer images now use.

## Types of changes

What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)