### PR TITLE
Use the correct port for socat

### DIFF
--- a/cli/runner/local.go
+++ b/cli/runner/local.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/phayes/freeport"
 	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/cli/config"
 	"github.com/saucelabs/saucectl/cli/docker"
@@ -100,15 +99,10 @@ func (r *localRunner) Setup() error {
 		return err
 	}
 
-	port, err := freeport.GetFreePort()
-	if err != nil {
-		return err
-	}
-
 	// start port forwarding
 	sockatCmd := []string{
 		"socat",
-		fmt.Sprintf("tcp-listen:%d,reuseaddr,fork", port),
+		"tcp-listen:9222,reuseaddr,fork",
 		"tcp:localhost:9223",
 	}
 


### PR DESCRIPTION
## Proposed changes

Uses the correct port for socat port forwarding.

Previously, a dynamic port was allocated and forward to. That wasn't the port used by saucectl's port bindings however. Furthermore, we don't need to dynamically allocate a port inside the container.

## Types of changes

What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
