### PR TITLE
Allow region selection

### DIFF
--- a/cli/command/new/templates.go
+++ b/cli/command/new/templates.go
@@ -14,6 +14,8 @@ files:
 image:
   base: {{ .Name }}
   version: {{ .Version }}
+sauce:
+  region: {{ .Region }}
 `
 
 // SetupTemplate describes a template for a setup

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -74,12 +74,12 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 		configObject.Timeout = defaultTimeout
 	}
 
-	if configObject.Region == "" {
-		configObject.Region = defaultRegion
+	if configObject.Sauce.Region == "" {
+		configObject.Sauce.Region = defaultRegion
 	}
 
 	if region != "" {
-		configObject.Region = region
+		configObject.Sauce.Region = region
 	}
 
 	tr, err := runner.New(configObject, cli)

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -20,10 +20,12 @@ var (
 
 	defaultLogFir  = "<cwd>/logs"
 	defaultTimeout = 60
+	defaultRegion = "us-west-1"
 
 	cfgFilePath string
 	cfgLogDir   string
 	testTimeout int
+	region      string
 )
 
 // Command creates the `run` command
@@ -47,6 +49,7 @@ func Command(cli *command.SauceCtlCli) *cobra.Command {
 	cmd.Flags().StringVarP(&cfgFilePath, "config", "c", defaultCfgPath, "config file (e.g. ./.sauce/config.yaml")
 	cmd.Flags().StringVarP(&cfgLogDir, "logDir", "l", defaultLogFir, "log path")
 	cmd.Flags().IntVarP(&testTimeout, "timeout", "t", 0, "test timeout in seconds (default: 60sec)")
+	cmd.Flags().StringVarP(&region, "region", "r", "", "The sauce labs region. (default: us-west-1)")
 	return cmd
 }
 
@@ -69,6 +72,14 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 	}
 	if configObject.Timeout == 0 {
 		configObject.Timeout = defaultTimeout
+	}
+
+	if configObject.Region == "" {
+		configObject.Region = defaultRegion
+	}
+
+	if region != "" {
+		configObject.Region = region
 	}
 
 	tr, err := runner.New(configObject, cli)

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -55,6 +55,7 @@ type JobConfiguration struct {
 	Files        []string        `yaml:"files"`
 	Image        ImageDefinition `yaml:"image"`
 	Timeout      int             `yaml:"timeout"`
+	Region       string          `yaml:"region"`
 }
 
 // RunnerConfiguration describes configurations for the testrunner

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -55,7 +55,12 @@ type JobConfiguration struct {
 	Files        []string        `yaml:"files"`
 	Image        ImageDefinition `yaml:"image"`
 	Timeout      int             `yaml:"timeout"`
-	Region       string          `yaml:"region"`
+	Sauce        SauceConfig     `yaml:"sauce"`
+}
+
+// SauceConfig represents sauce labs related settings.
+type SauceConfig struct {
+	Region string `yaml:"region"`
 }
 
 // RunnerConfiguration describes configurations for the testrunner

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -190,6 +190,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.JobConfigur
 			fmt.Sprintf("SAUCE_ACCESS_KEY=%s", os.Getenv("SAUCE_ACCESS_KEY")),
 			fmt.Sprintf("SAUCE_BUILD_NAME=%s", c.Metadata.Build),
 			fmt.Sprintf("SAUCE_DEVTOOLS_PORT=%d", port),
+			fmt.Sprintf("SAUCE_REGION=%s", c.Region),
 			fmt.Sprintf("TEST_TIMEOUT=%d", c.Timeout),
 			fmt.Sprintf("BROWSER_NAME=%s", browserName),
 		},

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -44,17 +44,17 @@ type Image struct {
 
 var DefaultPlaywright = Image{
 	Name:    "saucelabs/stt-playwright-jest-node",
-	Version: "v0.1.0",
+	Version: "v0.1.1",
 }
 
 var DefaultPuppeteer = Image{
 	Name:    "saucelabs/stt-puppeteer-jest-node",
-	Version: "v0.1.0",
+	Version: "v0.1.1",
 }
 
 var DefaultTestcafe = Image{
 	Name:    "saucelabs/stt-testcafe-node",
-	Version: "v0.1.0",
+	Version: "v0.1.1",
 }
 
 // ClientInterface describes the interface used to handle docker commands

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -190,7 +190,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.JobConfigur
 			fmt.Sprintf("SAUCE_ACCESS_KEY=%s", os.Getenv("SAUCE_ACCESS_KEY")),
 			fmt.Sprintf("SAUCE_BUILD_NAME=%s", c.Metadata.Build),
 			fmt.Sprintf("SAUCE_DEVTOOLS_PORT=%d", port),
-			fmt.Sprintf("SAUCE_REGION=%s", c.Region),
+			fmt.Sprintf("SAUCE_REGION=%s", c.Sauce.Region),
 			fmt.Sprintf("TEST_TIMEOUT=%d", c.Timeout),
 			fmt.Sprintf("BROWSER_NAME=%s", browserName),
 		},

--- a/cli/runner/ci.go
+++ b/cli/runner/ci.go
@@ -75,6 +75,7 @@ func (r *ciRunner) Run() (int, error) {
 	cmd.Env = append(
 		os.Environ(),
 		fmt.Sprintf("SAUCE_BUILD_NAME=%s", r.jobConfig.Metadata.Build),
+		fmt.Sprintf("SAUCE_REGION=%s", r.jobConfig.Region),
 		fmt.Sprintf("TEST_TIMEOUT=%d", r.jobConfig.Timeout),
 		fmt.Sprintf("BROWSER_NAME=%s", r.jobConfig.Capabilities[0].BrowserName),
 	)

--- a/cli/runner/ci.go
+++ b/cli/runner/ci.go
@@ -75,7 +75,7 @@ func (r *ciRunner) Run() (int, error) {
 	cmd.Env = append(
 		os.Environ(),
 		fmt.Sprintf("SAUCE_BUILD_NAME=%s", r.jobConfig.Metadata.Build),
-		fmt.Sprintf("SAUCE_REGION=%s", r.jobConfig.Region),
+		fmt.Sprintf("SAUCE_REGION=%s", r.jobConfig.Sauce.Region),
 		fmt.Sprintf("TEST_TIMEOUT=%d", r.jobConfig.Timeout),
 		fmt.Sprintf("BROWSER_NAME=%s", r.jobConfig.Capabilities[0].BrowserName),
 	)


### PR DESCRIPTION
## Proposed changes

Currently, we only support the sauce labs us-west-1 region (we target this environment by default).
This change will keep up defaulting to us-west-1 for consistency, but allow for other regions to be specified.

The region can be specified via the config and the CLI args.

The user will also receive a sauce region prompt when running the `new` command.

## Types of changes

What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
