### PR TITLE
Add ability to pass in environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,14 @@ This command will run the test based on the `./.sauce/config.yml` file.
 ```sh
 saucectl run --config <path>
 ```
-Using the `--config` will run the tests specified by that config file.
+Using the `--config` flag will run the tests specified by that config file.
+
+#### `env`
+```sh
+saucectl run --env <key1>=<value1> --env <key2>=<value2> ...
+```
+Using the `--env` flag will define environment variables that are then available
+for use by the test framework.
 
 #### `region`
 ```sh

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -64,32 +64,32 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 	}
 
 	log.Info().Str("config", cfgFilePath).Msg("Reading config file")
-	configObject, err := config.NewJobConfiguration(cfgFilePath)
+	cfg, err := config.NewJobConfiguration(cfgFilePath)
 	if err != nil {
 		return 1, err
 	}
 
 	// Merge envs from CLI args and job config. CLI args take precedence.
 	for k, v := range envs {
-		configObject.Envs[k] = v
+		cfg.Envs[k] = v
 	}
 
 	if testTimeout != 0 {
-		configObject.Timeout = testTimeout
+		cfg.Timeout = testTimeout
 	}
-	if configObject.Timeout == 0 {
-		configObject.Timeout = defaultTimeout
+	if cfg.Timeout == 0 {
+		cfg.Timeout = defaultTimeout
 	}
 
-	if configObject.Sauce.Region == "" {
-		configObject.Sauce.Region = defaultRegion
+	if cfg.Sauce.Region == "" {
+		cfg.Sauce.Region = defaultRegion
 	}
 
 	if region != "" {
-		configObject.Sauce.Region = region
+		cfg.Sauce.Region = region
 	}
 
-	tr, err := runner.New(configObject, cli)
+	tr, err := runner.New(cfg, cli)
 	if err != nil {
 		return 1, err
 	}

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -26,7 +26,7 @@ var (
 	cfgLogDir   string
 	testTimeout int
 	region      string
-	envs        map[string]string
+	env         map[string]string
 )
 
 // Command creates the `run` command
@@ -51,7 +51,7 @@ func Command(cli *command.SauceCtlCli) *cobra.Command {
 	cmd.Flags().StringVarP(&cfgLogDir, "logDir", "l", defaultLogFir, "log path")
 	cmd.Flags().IntVarP(&testTimeout, "timeout", "t", 0, "test timeout in seconds (default: 60sec)")
 	cmd.Flags().StringVarP(&region, "region", "r", "", "The sauce labs region. (default: us-west-1)")
-	cmd.Flags().StringToStringVarP(&envs, "env", "e", map[string]string{}, "Set environment variables, e.g. -e foo=bar.")
+	cmd.Flags().StringToStringVarP(&env, "env", "e", map[string]string{}, "Set environment variables, e.g. -e foo=bar.")
 	return cmd
 }
 
@@ -69,9 +69,9 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 		return 1, err
 	}
 
-	// Merge envs from CLI args and job config. CLI args take precedence.
-	for k, v := range envs {
-		cfg.Envs[k] = v
+	// Merge env from CLI args and job config. CLI args take precedence.
+	for k, v := range env {
+		cfg.Env[k] = v
 	}
 
 	if testTimeout != 0 {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -56,7 +56,7 @@ type JobConfiguration struct {
 	Image        ImageDefinition   `yaml:"image"`
 	Timeout      int               `yaml:"timeout"`
 	Sauce        SauceConfig       `yaml:"sauce"`
-	Envs         map[string]string `yaml:"envs"`
+	Env          map[string]string `yaml:"env"`
 }
 
 // SauceConfig represents sauce labs related settings.
@@ -119,8 +119,8 @@ func NewJobConfiguration(cfgFilePath string) (JobConfiguration, error) {
 	}
 
 	// go-yaml doesn't have the ability to define default values, so we have to do it here
-	if c.Envs == nil {
-		c.Envs = make(map[string]string)
+	if c.Env == nil {
+		c.Env = make(map[string]string)
 	}
 
 	return c, nil

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -48,14 +48,15 @@ type ImageDefinition struct {
 
 // JobConfiguration describes testrunner config format
 type JobConfiguration struct {
-	APIVersion   string          `yaml:"apiVersion"`
-	Kind         string          `yaml:"kind"`
-	Metadata     Metadata        `yaml:"metadata"`
-	Capabilities []Capabilities  `yaml:"capabilities"`
-	Files        []string        `yaml:"files"`
-	Image        ImageDefinition `yaml:"image"`
-	Timeout      int             `yaml:"timeout"`
-	Sauce        SauceConfig     `yaml:"sauce"`
+	APIVersion   string            `yaml:"apiVersion"`
+	Kind         string            `yaml:"kind"`
+	Metadata     Metadata          `yaml:"metadata"`
+	Capabilities []Capabilities    `yaml:"capabilities"`
+	Files        []string          `yaml:"files"`
+	Image        ImageDefinition   `yaml:"image"`
+	Timeout      int               `yaml:"timeout"`
+	Sauce        SauceConfig       `yaml:"sauce"`
+	Envs         map[string]string `yaml:"envs"`
 }
 
 // SauceConfig represents sauce labs related settings.
@@ -106,16 +107,21 @@ func NewRunnerConfiguration(cfgFilePath string) (RunnerConfiguration, error) {
 
 // NewJobConfiguration creates a new job configuration based on a config file
 func NewJobConfiguration(cfgFilePath string) (JobConfiguration, error) {
-	var obj JobConfiguration
+	var c JobConfiguration
 
 	yamlFile, err := readYaml(cfgFilePath)
 	if err != nil {
 		return JobConfiguration{}, fmt.Errorf("failed to locate job configuration: %v", err)
 	}
 
-	if err = yaml.Unmarshal(yamlFile, &obj); err != nil {
+	if err = yaml.Unmarshal(yamlFile, &c); err != nil {
 		return JobConfiguration{}, fmt.Errorf("failed to parse job configuration: %v", err)
 	}
 
-	return obj, nil
+	// go-yaml doesn't have the ability to define default values, so we have to do it here
+	if c.Envs == nil {
+		c.Envs = make(map[string]string)
+	}
+
+	return c, nil
 }

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -195,6 +195,12 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.JobConfigur
 			fmt.Sprintf("BROWSER_NAME=%s", browserName),
 		},
 	}
+
+	// Add any defined env variables from the job config / CLI args.
+	for k, v := range c.Envs {
+		containerConfig.Env = append(containerConfig.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	container, err := handler.client.ContainerCreate(ctx, containerConfig, hostConfig, networkConfig, "")
 	if err != nil {
 		return nil, err

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -197,7 +197,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.JobConfigur
 	}
 
 	// Add any defined env variables from the job config / CLI args.
-	for k, v := range c.Envs {
+	for k, v := range c.Env {
 		containerConfig.Env = append(containerConfig.Env, fmt.Sprintf("%s=%s", k, v))
 	}
 

--- a/cli/runner/ci.go
+++ b/cli/runner/ci.go
@@ -79,6 +79,12 @@ func (r *ciRunner) Run() (int, error) {
 		fmt.Sprintf("TEST_TIMEOUT=%d", r.jobConfig.Timeout),
 		fmt.Sprintf("BROWSER_NAME=%s", r.jobConfig.Capabilities[0].BrowserName),
 	)
+
+	// Add any defined env variables from the job config / CLI args.
+	for k, v := range r.jobConfig.Envs {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	cmd.Stdout = r.cli.Out()
 	cmd.Stderr = r.cli.Out()
 	cmd.Dir = r.runnerConfig.RootDir

--- a/cli/runner/ci.go
+++ b/cli/runner/ci.go
@@ -81,7 +81,7 @@ func (r *ciRunner) Run() (int, error) {
 	)
 
 	// Add any defined env variables from the job config / CLI args.
-	for k, v := range r.jobConfig.Envs {
+	for k, v := range r.jobConfig.Env {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}
 


### PR DESCRIPTION
## Proposed changes

Add ability to pass in environment variables via job configuration or CLI args.
CLI args take precedence over the job configuration.

## Types of changes

What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
