### PR TITLE
Folder support

### DIFF
--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -234,6 +233,7 @@ func (handler *Handler) CopyTestFilesToContainer(ctx context.Context, srcContain
 	return nil
 }
 
+// FindTestFiles returns the names of all files matching the patterns.
 func (handler *Handler) FindTestFiles(patterns []string) []string {
 	var files []string
 	for _, pattern := range patterns {
@@ -267,18 +267,18 @@ func (handler *Handler) CopyToContainer(ctx context.Context, containerID string,
 	}
 	defer srcArchive.Close()
 
-	dstInfo := archive.CopyInfo{Path: targetDir}
+	dstInfo := archive.CopyInfo{}
 	if !srcInfo.IsDir {
-		dstInfo.Path = path.Join(targetDir, filepath.Base(srcInfo.Path))
+		dstInfo.Path = filepath.Base(srcInfo.Path)
 	}
 
-	dstDir, preparedArchive, err := archive.PrepareArchiveCopy(srcArchive, srcInfo, dstInfo)
+	_, preparedArchive, err := archive.PrepareArchiveCopy(srcArchive, srcInfo, dstInfo)
 	if err != nil {
 		return err
 	}
 	defer preparedArchive.Close()
 
-	return handler.client.CopyToContainer(ctx, containerID, dstDir, preparedArchive, types.CopyToContainerOptions{})
+	return handler.client.CopyToContainer(ctx, containerID, targetDir, preparedArchive, types.CopyToContainerOptions{})
 }
 
 // CopyFromContainer downloads a file from the testrunner container

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -231,15 +231,15 @@ func (handler *Handler) CopyTestFilesToContainer(ctx context.Context, srcContain
 			continue
 		}
 
-		for _, file := range matches {
+		for _, fpath := range matches {
 			pwd, err := os.Getwd()
 			if err != nil {
 				continue
 			}
 
-			srcFile := file
+			srcFile := fpath
 			if !filepath.IsAbs(srcFile) {
-				srcFile = filepath.Join(pwd, file)
+				srcFile = filepath.Join(pwd, fpath)
 			}
 			file, err := os.Stat(srcFile)
 			if err != nil {

--- a/cli/docker/docker.go
+++ b/cli/docker/docker.go
@@ -251,6 +251,11 @@ func (handler *Handler) FindTestFiles(patterns []string) []string {
 
 // CopyToContainer copies the given file to the container.
 func (handler *Handler) CopyToContainer(ctx context.Context, containerID string, srcFile string, targetDir string) error {
+	srcFile, err := filepath.Abs(srcFile)
+	if err != nil {
+		return err
+	}
+
 	srcInfo, err := archive.CopyInfoSourcePath(srcFile, true)
 	if err != nil {
 		return err
@@ -264,7 +269,7 @@ func (handler *Handler) CopyToContainer(ctx context.Context, containerID string,
 
 	dstInfo := archive.CopyInfo{Path: targetDir}
 	if !srcInfo.IsDir {
-		dstInfo.Path = path.Join(targetDir, path.Base(srcInfo.Path))
+		dstInfo.Path = path.Join(targetDir, filepath.Base(srcInfo.Path))
 	}
 
 	dstDir, preparedArchive, err := archive.PrepareArchiveCopy(srcArchive, srcInfo, dstInfo)

--- a/cli/docker/docker_test.go
+++ b/cli/docker/docker_test.go
@@ -313,11 +313,11 @@ func TestHandler_CopyToContainer(t *testing.T) {
 			name: "copy entire folder",
 			fields: fields{&mocks.FakeClient{CopyToContainerFn: func(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error {
 				expect := []string{
-					"bar/",
-					"bar/some.foo.js",
-					"bar/some.other.bar.js",
-					"bar/subdir/",
-					"bar/subdir/some.subdir.js",
+					"./",
+					"./some.foo.js",
+					"./some.other.bar.js",
+					"./subdir/",
+					"./subdir/some.subdir.js",
 				}
 
 				return expectTar(expect, content)

--- a/cli/docker/docker_test.go
+++ b/cli/docker/docker_test.go
@@ -359,7 +359,7 @@ func expectTar(files []string, r io.Reader) error {
 	}
 
 	if !reflect.DeepEqual(files, found) {
-		return errors.New(fmt.Sprintf("expected %v but found %v", files, found))
+		return fmt.Errorf("expected %v but found %v", files, found)
 	}
 
 	return nil

--- a/cli/mocks/docker.go
+++ b/cli/mocks/docker.go
@@ -19,7 +19,7 @@ type FakeClient struct {
 	ContainerCreateSuccess      bool
 	ContainerStartSuccess       bool
 	ContainerInspectSuccess     bool
-	CopyToContainerSuccess      bool
+	CopyToContainerFn  		    func(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
 	ContainerStatPathSuccess    bool
 	CopyFromContainerSuccess    bool
 	ContainerExecCreateSuccess  bool
@@ -88,10 +88,7 @@ func (fc *FakeClient) ContainerInspect(ctx context.Context, containerID string) 
 
 // CopyToContainer mock function
 func (fc *FakeClient) CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error {
-	if fc.CopyToContainerSuccess {
-		return nil
-	}
-	return errors.New("CopyToContainerFailure")
+	return fc.CopyToContainerFn(ctx, container, path, content, options)
 }
 
 // ContainerStatPath mock function


### PR DESCRIPTION
## Proposed changes

This change introduces the capability of copying over entire folders (and their files and subfolders). This extends the current support of file patterns.

e.g. if you had a project test folder structure like this:
```
tests
tests/foo.spec.js
tests/subdir/bar.spec.js
```

then specifying the entire folder in the `config.yaml`, would copy over all of its contents to the container like this:
```
files:
  - ./tests/
```


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

