### PR TITLE
Ensure teardown is run

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -76,6 +76,12 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 	if err != nil {
 		return 1, err
 	}
+	defer func() {
+		log.Info().Msg("Tearing down environment")
+		if err != tr.Teardown(cfgLogDir) {
+			log.Error().Err(err).Msg("Failed to tear down environment")
+		}
+	}()
 
 	log.Info().Msg("Setting up test environment")
 	if err := tr.Setup(); err != nil {
@@ -85,11 +91,6 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 	log.Info().Msg("Starting tests")
 	exitCode, err := tr.Run()
 	if err != nil {
-		return 1, err
-	}
-
-	log.Info().Msg("Tearing down environment")
-	if err != tr.Teardown(cfgLogDir) {
 		return 1, err
 	}
 


### PR DESCRIPTION
## Proposed changes

Prior to this change, there was always a chance of a container left orphaned in the background if some step in the container setup or test execution fails.
This change ensures that a container is cleaned up regardless of what phase it is in.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
