### PR TITLE
Add suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,23 @@
 default:
-	@echo "saucectl CLI"
-	# ToDo(Christian): add some output for documentation purposes
+	@grep -E '[a-zA-Z]+:.*?@ .*$$' $(MAKEFILE_LIST)| tr -d '#' | awk 'BEGIN {FS = ":.*?@ "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+#install: @ Install all depencies defined in package.json
 install:
 	brew install golangci/tap/golangci-lint
 	go get ./...
 
+#build: @ Build the CLI
 build:
 	go build cmd/saucectl/saucectl.go
 
+#lint: @ Run the linter
 lint:
-	golangci-lint run ./... --disable structcheck
+	golint ./...
 
+#format: @ Format code with gofmt
 format:
 	gofmt -w .
 
+#test: @ Run tests
 test:
-	go test -coverprofile=coverage.out ./...
-	goverreport -sort=block -order=desc -threshold=44
+	go test -v ./...

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -52,11 +52,20 @@ type Project struct {
 	Kind         string            `yaml:"kind"`
 	Metadata     Metadata          `yaml:"metadata"`
 	Capabilities []Capabilities    `yaml:"capabilities"`
+	Suites       []Suite           `yaml:"suites"`
 	Files        []string          `yaml:"files"`
 	Image        ImageDefinition   `yaml:"image"`
 	Timeout      int               `yaml:"timeout"`
 	Sauce        SauceConfig       `yaml:"sauce"`
 	Env          map[string]string `yaml:"env"`
+}
+
+// Suite represents the test suite configuration.
+type Suite struct {
+	Name         string       `yaml:"name"`
+	Capabilities Capabilities `yaml:"capabilities"`
+	Root         string       `yaml:"root"`
+	Match        []string     `yaml:"match"`
 }
 
 // SauceConfig represents sauce labs related settings.


### PR DESCRIPTION
## Proposed changes

This PR is part of the config variant 2 changes and introduces the notion of `Suites`.
No actual new features have been introduced, nor would anything happen if the user were to specify suites as part of their config at the moment. This change merely adds the capability to parse a config with suites defined.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
