### PR TITLE
Add rudimentary support for suites

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Workaround for container permissions
         run: |
           sudo chown -R $USER:$(id -gn $USER) /github/home
-          sudo chown -R $USER:$USER /__w/
+          sudo chown -R $USER:$USER /__w/ /home/runner/work/
 
       - name: Download saucectl binary
         uses: actions/download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,7 @@ jobs:
           BUILD_ENV: GitHub Actions
   cypress:
     runs-on: ubuntu-latest
+    if: false # skip for now due to flakiness
     container:
       image: saucelabs/stt-cypress-mocha-node:v0.1.5
 
@@ -155,8 +156,8 @@ jobs:
           sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
           sudo env "PATH=$PATH:/usr/local/go/bin" CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
 
-#      - name: Workaround for container folder
-#        run: sudo ln -s /home/seluser/.cache /github/home/.cache
+      - name: Workaround for container folder
+        run: sudo ln -s /home/seluser/.cache /github/home/.cache
 
       - name: Run Sauce Pipeline Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,10 @@ jobs:
 
       - name: Build project
         run: |
-          apt install software-properties-common
-          add-apt-repository ppa:longsleep/golang-backports
-          apt update
-          apt install golang-go
+          sudo apt install software-properties-common
+          sudo add-apt-repository ppa:longsleep/golang-backports
+          sudo apt update
+          sudo apt install golang-go
           CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
 
       - name: Workaround for container permissions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,6 @@ jobs:
       - name: Workaround for container permissions
         run: |
           sudo chown -R $USER:$(id -gn $USER) /github/home
-          sudo chown -R $USER:$USER /__w/ /home/
 
       - name: Download saucectl binary
         uses: actions/download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,8 +68,7 @@ jobs:
         run: |
           sudo curl -L -O https://golang.org/dl/go1.15.linux-amd64.tar.gz
           sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
-          export PATH=$PATH:/usr/local/go/bin
-          CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
+          sudo env "PATH=$PATH:/usr/local/go/bin" CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
 
       - name: Run Sauce Pipeline Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,8 @@ jobs:
       image: saucelabs/stt-puppeteer-jest-node:v0.2.0
 
     steps:
+      - name: Fix Permissions
+        run: sudo chown -R $USER:$USER /home/github/actions-runner/_work/saucectl
       # appears that checkout@v2 uses javascript which is not compatible
       # with the included node version in the container image.
       - name: Checkout Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Workaround for container permissions
         run: sudo chown -R $USER:$(id -gn $USER) /github/home
 
-      - name: Workaround for container folder
-        run: sudo ln -s /home/seluser/.cache /github/home/.cache
+#      - name: Workaround for container folder
+#        run: sudo ln -s /home/seluser/.cache /github/home/.cache
 
       - name: Build project
         run: |
@@ -119,8 +119,8 @@ jobs:
       - name: Workaround for container permissions
         run: sudo chown -R $USER:$(id -gn $USER) /github/home
 
-      - name: Workaround for container folder
-        run: sudo ln -s /home/seluser/.cache /github/home/.cache
+#      - name: Workaround for container folder
+#        run: sudo ln -s /home/seluser/.cache /github/home/.cache
 
       - name: Build project
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,6 @@ jobs:
 
       - name: Run Sauce Pipeline Test
         run: |
-          ./saucectl run -c ./.sauce/puppeteer.yml
+          ./saucectl run -c ./.sauce/puppeteer.yml --verbose
         env:
           BUILD_ID: ${{ github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,14 +55,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v1
 
-      - name: Workaround for container permissions
-        run: |
-          sudo chown -R $USER:$(id -gn $USER) /github/home
-
       - name: Download saucectl binary
         uses: actions/download-artifact@v2
         with:
           name: saucectlbin
+
+      - name: Workaround for container permissions
+        run: |
+          sudo chown -R $USER:$(id -gn $USER) /github/home
 
       - name: Run Sauce Pipeline Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,14 +90,14 @@ jobs:
       - name: Workaround for container permissions
         run: sudo chown -R $USER:$(id -gn $USER) /github/home
 
-#      - name: Workaround for container folder
-#        run: sudo ln -s /home/seluser/.cache /github/home/.cache
-
       - name: Build project
         run: |
           sudo curl -L -O https://golang.org/dl/go1.15.linux-amd64.tar.gz
           sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
           sudo env "PATH=$PATH:/usr/local/go/bin" CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
+
+      - name: Workaround for container folder
+        run: sudo ln -s /home/seluser/.cache /github/home/.cache
 
       - name: Run Sauce Pipeline Test
         run: |
@@ -120,14 +120,14 @@ jobs:
       - name: Workaround for container permissions
         run: sudo chown -R $USER:$(id -gn $USER) /github/home
 
-#      - name: Workaround for container folder
-#        run: sudo ln -s /home/seluser/.cache /github/home/.cache
-
       - name: Build project
         run: |
           sudo curl -L -O https://golang.org/dl/go1.15.linux-amd64.tar.gz
           sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
           sudo env "PATH=$PATH:/usr/local/go/bin" CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
+
+      - name: Workaround for container folder
+        run: sudo ln -s /home/seluser/.cache /github/home/.cache
 
       - name: Run Sauce Pipeline Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,15 +50,15 @@ jobs:
       image: saucelabs/stt-puppeteer-jest-node:v0.2.0
 
     steps:
-      - name: Fix Permissions
-        run: sudo chown -R $USER:$USER /home/github/actions-runner/_work
       # appears that checkout@v2 uses javascript which is not compatible
       # with the included node version in the container image.
       - name: Checkout Code
         uses: actions/checkout@v1
 
       - name: Workaround for container permissions
-        run: sudo chown -R $USER:$(id -gn $USER) /github/home
+        run: |
+          sudo chown -R $USER:$(id -gn $USER) /github/home
+          sudo chown -R $USER:$USER /__w/
 
       - name: Download saucectl binary
         uses: actions/download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     needs: basic
     runs-on: ubuntu-latest
     container:
-      image: saucelabs/stt-puppeteer-jest-node:v0.2.0
+      image: saucelabs/stt-puppeteer-jest-node:v0.1.2
 
     steps:
       # appears that checkout@v2 uses javascript which is not compatible

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Workaround for container permissions
         run: |
           sudo chown -R $USER:$(id -gn $USER) /github/home
-          sudo chown -R $USER:$USER /__w/ /home/runner/
+          sudo chown -R $USER:$USER /__w/ /home/
 
       - name: Download saucectl binary
         uses: actions/download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,3 +135,32 @@ jobs:
         env:
           BUILD_ID: ${{ github.run_id }}
           BUILD_ENV: GitHub Actions
+  cypress:
+    runs-on: ubuntu-latest
+    container:
+      image: saucelabs/stt-cypress-mocha-node:v0.1.5
+
+    steps:
+      # appears that checkout@v2 uses javascript which is not compatible
+      # with the included node version in the container image.
+      - name: Checkout Code
+        uses: actions/checkout@v1
+
+      - name: Workaround for container permissions
+        run: sudo chown -R $USER:$(id -gn $USER) /github/home
+
+      - name: Build project
+        run: |
+          sudo curl -L -O https://golang.org/dl/go1.15.linux-amd64.tar.gz
+          sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
+          sudo env "PATH=$PATH:/usr/local/go/bin" CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
+
+#      - name: Workaround for container folder
+#        run: sudo ln -s /home/seluser/.cache /github/home/.cache
+
+      - name: Run Sauce Pipeline Test
+        run: |
+          ./saucectl run -c ./.sauce/cypress.yml
+        env:
+          BUILD_ID: ${{ github.run_id }}
+          BUILD_ENV: GitHub Actions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Workaround for container permissions
         run: |
           sudo chown -R $USER:$(id -gn $USER) /github/home
-          sudo chown -R $USER:$USER /__w/ /home/runner/work/
+          sudo chown -R $USER:$USER /__w/ /home/runner/
 
       - name: Download saucectl binary
         uses: actions/download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,9 @@ jobs:
 
       - name: Build project
         run: |
-          sudo apt install software-properties-common
-          sudo add-apt-repository ppa:longsleep/golang-backports
-          sudo apt update
-          sudo apt install golang-go
+          curl -L -O https://golang.org/dl/go1.15.linux-amd64.tar.gz
+          sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
+          export PATH=$PATH:/usr/local/go/bin
           CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
 
       - name: Workaround for container permissions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,12 @@ jobs:
           ./saucectl run -c ./.sauce/puppeteer.yml --verbose
         env:
           BUILD_ID: ${{ github.run_id }}
+
+      - name: Test With Suites
+        run: |
+          ./saucectl run -c ./.sauce/puppeteer-suites.yml --verbose
+        env:
+          BUILD_ID: ${{ github.run_id }}
   playwright:
     if: false # skip for now due to flakiness
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,32 @@ jobs:
         run: |
           go test -coverprofile=coverage.out ./...
           goverreport -sort=block -order=desc -threshold=44
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: saucectlbin
+          path: saucectl
+  puppeteer:
+    runs-on: ubuntu-latest
+    container:
+      image: saucelabs/stt-puppeteer-jest-node:v0.2.0
+
+    steps:
+      # appears that checkout@v2 uses javascript which is not compatible
+      # with the included node version in the container image.
+      - name: Checkout Code
+        uses: actions/checkout@v1
+
+      - name: Workaround for container permissions
+        run: sudo chown -R $USER:$(id -gn $USER) /github/home
+
+      - name: Download saucectl binary
+        uses: actions/download-artifact@v2
+        with:
+          name: saucectlbin
+
+      - name: Run Sauce Pipeline Test
+        run: |
+          saucectl run -c ./.sauce/puppeteer.yml
+        env:
+          BUILD_ID: ${{ github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,10 +55,17 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v1
 
-      - name: Download saucectl binary
-        uses: actions/download-artifact@v2
-        with:
-          name: saucectlbin
+#      - name: Download saucectl binary
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: saucectlbin
+
+      - name: Build project
+        run: |
+          add-apt-repository ppa:longsleep/golang-backports
+          apt update
+          apt install golang-go
+          CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
 
       - name: Workaround for container permissions
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v1
 
+## This is currently not working since the container image doesn't run with root
 #      - name: Download saucectl binary
 #        uses: actions/download-artifact@v2
 #        with:
@@ -75,3 +76,32 @@ jobs:
           ./saucectl run -c ./.sauce/puppeteer.yml --verbose
         env:
           BUILD_ID: ${{ github.run_id }}
+  playwright:
+    runs-on: ubuntu-latest
+    container:
+      image: saucelabs/stt-playwright-jest-node:v0.1.3
+
+    steps:
+      # appears that checkout@v2 uses javascript which is not compatible
+      # with the included node version in the container image.
+      - name: Checkout Code
+        uses: actions/checkout@v1
+
+      - name: Workaround for container permissions
+        run: sudo chown -R $USER:$(id -gn $USER) /github/home
+
+      - name: Workaround for container folder
+        run: sudo ln -s /home/seluser/.cache /github/home/.cache
+
+      - name: Build project
+        run: |
+          sudo curl -L -O https://golang.org/dl/go1.15.linux-amd64.tar.gz
+          sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
+          sudo env "PATH=$PATH:/usr/local/go/bin" CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
+
+      - name: Run Sauce Pipeline Test
+        run: |
+          ./saucectl run -c ./.sauce/playwright.yml
+        env:
+          BUILD_ID: ${{ github.run_id }}
+          BUILD_ENV: GitHub Actions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,7 @@ jobs:
           BUILD_ID: ${{ github.run_id }}
           BUILD_ENV: GitHub Actions
   testcafe:
+    if: false
     runs-on: ubuntu-latest
     container:
       image: saucelabs/stt-testcafe-node:v0.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,7 @@ jobs:
         env:
           BUILD_ID: ${{ github.run_id }}
   playwright:
+    if: false # skip for now due to flakiness
     runs-on: ubuntu-latest
     container:
       image: saucelabs/stt-playwright-jest-node:v0.1.3
@@ -106,7 +107,6 @@ jobs:
           BUILD_ID: ${{ github.run_id }}
           BUILD_ENV: GitHub Actions
   testcafe:
-    if: false
     runs-on: ubuntu-latest
     container:
       image: saucelabs/stt-testcafe-node:v0.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build project
         run: |
-          curl -L -O https://golang.org/dl/go1.15.linux-amd64.tar.gz
+          sudo curl -L -O https://golang.org/dl/go1.15.linux-amd64.tar.gz
           sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
           export PATH=$PATH:/usr/local/go/bin
           CGO_ENABLED=0 go build cmd/saucectl/saucectl.go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
       - master
 
 jobs:
-  test:
+  basic:
     runs-on: ubuntu-latest
     container:
       image: golang:1.14-alpine
@@ -44,6 +44,7 @@ jobs:
           name: saucectlbin
           path: saucectl
   puppeteer:
+    needs: basic
     runs-on: ubuntu-latest
     container:
       image: saucelabs/stt-puppeteer-jest-node:v0.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,6 @@ jobs:
 
       - name: Run Sauce Pipeline Test
         run: |
-          saucectl run -c ./.sauce/puppeteer.yml
+          ./saucectl run -c ./.sauce/puppeteer.yml
         env:
           BUILD_ID: ${{ github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Fix Permissions
-        run: sudo chown -R $USER:$USER /home/github/actions-runner/_work/saucectl
+        run: sudo chown -R $USER:$USER /home/github/actions-runner/_work
       # appears that checkout@v2 uses javascript which is not compatible
       # with the included node version in the container image.
       - name: Checkout Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Build project
         run: |
+          apt install software-properties-common
           add-apt-repository ppa:longsleep/golang-backports
           apt update
           apt install golang-go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,36 @@ jobs:
 
       - name: Run Sauce Pipeline Test
         run: |
-          ./saucectl run -c ./.sauce/playwright.yml
+          ./saucectl run -c ./.sauce/playwright.yml --verbose
+        env:
+          BUILD_ID: ${{ github.run_id }}
+          BUILD_ENV: GitHub Actions
+  testcafe:
+    runs-on: ubuntu-latest
+    container:
+      image: saucelabs/stt-testcafe-node:v0.1.2
+
+    steps:
+      # appears that checkout@v2 uses javascript which is not compatible
+      # with the included node version in the container image.
+      - name: Checkout Code
+        uses: actions/checkout@v1
+
+      - name: Workaround for container permissions
+        run: sudo chown -R $USER:$(id -gn $USER) /github/home
+
+      - name: Workaround for container folder
+        run: sudo ln -s /home/seluser/.cache /github/home/.cache
+
+      - name: Build project
+        run: |
+          sudo curl -L -O https://golang.org/dl/go1.15.linux-amd64.tar.gz
+          sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
+          sudo env "PATH=$PATH:/usr/local/go/bin" CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
+
+      - name: Run Sauce Pipeline Test
+        run: |
+          ./saucectl run -c ./.sauce/testcafe.yml --verbose
         env:
           BUILD_ID: ${{ github.run_id }}
           BUILD_ENV: GitHub Actions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,16 +60,16 @@ jobs:
 #        with:
 #          name: saucectlbin
 
+      - name: Workaround for container permissions
+        run: |
+          sudo chown -R $USER:$(id -gn $USER) /github/home
+
       - name: Build project
         run: |
           curl -L -O https://golang.org/dl/go1.15.linux-amd64.tar.gz
           sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
           export PATH=$PATH:/usr/local/go/bin
           CGO_ENABLED=0 go build cmd/saucectl/saucectl.go
-
-      - name: Workaround for container permissions
-        run: |
-          sudo chown -R $USER:$(id -gn $USER) /github/home
 
       - name: Run Sauce Pipeline Test
         run: |

--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+metadata:
+  name: Testing Cypress Support
+  tags:
+    - e2e
+  build: "$BUILD_ID"
+files:
+  - ./tests/e2e/cypress/example.test.js

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+metadata:
+  name: Testing Playwright Support
+  tags:
+    - e2e
+  build: "$BUILD_ID"
+files:
+  - ./tests/e2e/playwright/example.test.js

--- a/.sauce/puppeteer-suites.yml
+++ b/.sauce/puppeteer-suites.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+metadata:
+  name: Testing Suite Support
+  tags:
+    - e2e
+    - suites
+  build: "$BUILD_ID"
+files:
+  - ./tests/e2e/puppeteer/example.test.js
+suites:
+  - name: "firefox"
+    capabilities:
+      browserName: "firefox"
+  - name: "chromium"
+    capabilities:
+      browserName: "chromium"
+image:
+  base: saucelabs/stt-puppeteer-jest-node
+  version: v0.1.2
+sauce:
+  region: us-west-1

--- a/.sauce/puppeteer.yml
+++ b/.sauce/puppeteer.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+metadata:
+  name: Testing Puppeteer Support
+  tags:
+    - e2e
+  build: "$BUILD_ID"
+files:
+  - ./tests/e2e/puppeteer/

--- a/.sauce/puppeteer.yml
+++ b/.sauce/puppeteer.yml
@@ -5,4 +5,4 @@ metadata:
     - e2e
   build: "$BUILD_ID"
 files:
-  - ./tests/e2e/puppeteer/
+  - ./tests/e2e/puppeteer/example.test.js

--- a/.sauce/testcafe.yml
+++ b/.sauce/testcafe.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+metadata:
+  name: Testing TestCafe Support
+  tags:
+    - e2e
+  build: "$BUILD_ID"
+files:
+  - ./tests/e2e/testcafe/example.test.js

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -141,7 +141,7 @@ func newRunner(p config.Project, s config.Suite, cli *command.SauceCtlCli) (runn
 // Its main use is for when no suites are defined in the config.
 func newDefaultSuite(p config.Project) config.Suite {
 	// TODO remove this method once saucectl fully transitions to the new config
-	s := config.Suite{Name: "default", Files: p.Files}
+	s := config.Suite{Name: "default"}
 	if len(p.Capabilities) > 0 {
 		s.Capabilities = p.Capabilities[0]
 	}

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -75,7 +75,26 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 	mergeArgs(&cfg)
 	cfg.Metadata.ExpandEnv()
 
-	tr, err := newRunner(cfg, cli)
+	if len(cfg.Suites) == 0 {
+		// As saucectl is transitioning into supporting test suites, we'll try to support this transition without
+		// a breaking change (if possible). This means that a suite may not necessarily be defined by the user.
+		// As such, we create an imaginary suite based on the project configuration.
+		cfg.Suites = []config.Suite{newDefaultSuite(cfg)}
+	}
+
+	exitCode := 0
+	for _, suite := range cfg.Suites {
+		exitCode, err = runSuite(cfg, suite, cli)
+		if err != nil {
+			return 1, err
+		}
+	}
+
+	return exitCode, nil
+}
+
+func runSuite(p config.Project, s config.Suite, cli *command.SauceCtlCli) (int, error) {
+	tr, err := newRunner(p, s, cli)
 	if err != nil {
 		return 1, err
 	}
@@ -101,10 +120,10 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 		Int("ExitCode", exitCode).
 		Msg("Command Finished")
 
-	return exitCode, nil
+	return exitCode, err
 }
 
-func newRunner(p config.Project, cli *command.SauceCtlCli) (runner.Testrunner, error) {
+func newRunner(p config.Project, s config.Suite, cli *command.SauceCtlCli) (runner.Testrunner, error) {
 	// return test runner for testing
 	if p.Image.Base == "test" {
 		return mocks.NewTestRunner(p, cli)
@@ -112,11 +131,23 @@ func newRunner(p config.Project, cli *command.SauceCtlCli) (runner.Testrunner, e
 
 	if ci.IsAvailable() {
 		log.Info().Msg("Starting CI runner")
-		return ci.NewRunner(p, cli)
+		return ci.NewRunner(p, s, cli)
 	}
 
 	log.Info().Msg("Starting local runner")
-	return docker.NewRunner(p, cli)
+	return docker.NewRunner(p, s, cli)
+}
+
+// newDefaultSuite creates a rudimentary test suite from a project configuration.
+// Its main use is for when no suites are defined in the config.
+func newDefaultSuite(p config.Project) config.Suite {
+	// TODO remove this method once saucectl fully transitions to the new config
+	s := config.Suite{Name: "default", Files: p.Files}
+	if len(p.Capabilities) > 0 {
+		s.Capabilities = p.Capabilities[0]
+	}
+
+	return s
 }
 
 // mergeArgs merges settings from CLI arguments with the loaded job configuration.

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -82,15 +82,14 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 		cfg.Suites = []config.Suite{newDefaultSuite(cfg)}
 	}
 
-	exitCode := 0
 	for _, suite := range cfg.Suites {
-		exitCode, err = runSuite(cfg, suite, cli)
-		if err != nil {
-			return 1, err
+		exitCode, err := runSuite(cfg, suite, cli)
+		if err != nil  || exitCode != 0 {
+			return exitCode, err
 		}
 	}
 
-	return exitCode, nil
+	return 0, nil
 }
 
 func runSuite(p config.Project, s config.Suite, cli *command.SauceCtlCli) (int, error) {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -64,7 +64,7 @@ type Project struct {
 type Suite struct {
 	Name         string       `yaml:"name"`
 	Capabilities Capabilities `yaml:"capabilities"`
-	Root         string       `yaml:"root"`
+	Files        []string     `yaml:"files"`
 	Match        []string     `yaml:"match"`
 }
 

--- a/cli/runner/runner.go
+++ b/cli/runner/runner.go
@@ -37,6 +37,7 @@ type Testrunner interface {
 // BaseRunner contains common properties across all runners
 type BaseRunner struct {
 	Project      config.Project
+	Suite        config.Suite
 	RunnerConfig config.RunnerConfiguration
 	Ctx          context.Context
 	Cli          *command.SauceCtlCli

--- a/internal/ci/runner.go
+++ b/internal/ci/runner.go
@@ -59,7 +59,7 @@ func (r *Runner) Setup() error {
 
 	// copy files from repository into target dir
 	log.Info().Msg("Copy files into assigned directories")
-	for _, pattern := range r.Suite.Files {
+	for _, pattern := range r.Project.Files {
 		matches, err := filepath.Glob(pattern)
 		if err != nil {
 			continue

--- a/internal/ci/runner.go
+++ b/internal/ci/runner.go
@@ -26,7 +26,7 @@ type Runner struct {
 }
 
 // NewRunner creates a new Runner instance.
-func NewRunner(c config.Project, cli *command.SauceCtlCli) (*Runner, error) {
+func NewRunner(c config.Project, s config.Suite, cli *command.SauceCtlCli) (*Runner, error) {
 	r := Runner{}
 
 	// read runner config file
@@ -38,6 +38,7 @@ func NewRunner(c config.Project, cli *command.SauceCtlCli) (*Runner, error) {
 	r.Cli = cli
 	r.Ctx = context.Background()
 	r.Project = c
+	r.Suite = s
 	r.RunnerConfig = rc
 	return &r, nil
 }
@@ -58,7 +59,7 @@ func (r *Runner) Setup() error {
 
 	// copy files from repository into target dir
 	log.Info().Msg("Copy files into assigned directories")
-	for _, pattern := range r.Project.Files {
+	for _, pattern := range r.Suite.Files {
 		matches, err := filepath.Glob(pattern)
 		if err != nil {
 			continue
@@ -76,11 +77,6 @@ func (r *Runner) Setup() error {
 
 // Run runs the tests defined in the config.Project.
 func (r *Runner) Run() (int, error) {
-	browserName := ""
-	if len(r.Project.Capabilities) > 0 {
-		browserName = r.Project.Capabilities[0].BrowserName
-	}
-
 	cmd := exec.Command(r.RunnerConfig.ExecCommand[0], r.RunnerConfig.ExecCommand[1])
 	cmd.Env = append(
 		os.Environ(),
@@ -88,7 +84,7 @@ func (r *Runner) Run() (int, error) {
 		fmt.Sprintf("SAUCE_TAGS=%s", strings.Join(r.Project.Metadata.Tags, ",")),
 		fmt.Sprintf("SAUCE_REGION=%s", r.Project.Sauce.Region),
 		fmt.Sprintf("TEST_TIMEOUT=%d", r.Project.Timeout),
-		fmt.Sprintf("BROWSER_NAME=%s", browserName),
+		fmt.Sprintf("BROWSER_NAME=%s", r.Suite.Capabilities.BrowserName),
 	)
 
 	// Add any defined env variables from the job config / CLI args.

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -198,7 +198,7 @@ func (handler *Handler) PullBaseImage(ctx context.Context, c config.Project) err
 }
 
 // StartContainer starts the Docker testrunner container
-func (handler *Handler) StartContainer(ctx context.Context, c config.Project) (*container.ContainerCreateCreatedBody, error) {
+func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s config.Suite) (*container.ContainerCreateCreatedBody, error) {
 	var (
 		ports        map[nat.Port]struct{}
 		portBindings map[nat.Port][]nat.PortBinding
@@ -218,11 +218,6 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project) (*
 		return nil, err
 	}
 
-	browserName := ""
-	if len(c.Capabilities) > 0 {
-		browserName = c.Capabilities[0].BrowserName
-	}
-
 	hostConfig := &container.HostConfig{
 		PortBindings: portBindings,
 	}
@@ -238,7 +233,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project) (*
 			fmt.Sprintf("SAUCE_DEVTOOLS_PORT=%d", port),
 			fmt.Sprintf("SAUCE_REGION=%s", c.Sauce.Region),
 			fmt.Sprintf("TEST_TIMEOUT=%d", c.Timeout),
-			fmt.Sprintf("BROWSER_NAME=%s", browserName),
+			fmt.Sprintf("BROWSER_NAME=%s", s.Capabilities.BrowserName),
 		},
 	}
 

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -25,14 +25,15 @@ type PassFailCase struct {
 	Name           string
 	Client         CommonAPIClient
 	JobConfig      *config.Project
+	Suite		   *config.Suite
 	ExpectedError  error
 	ExpectedResult interface{}
 }
 
 func TestValidateDependency(t *testing.T) {
 	cases := []PassFailCase{
-		{"Docker is not installed", &mocks.FakeClient{}, nil, errors.New("ContainerListFailure"), nil},
-		{"Docker is intalled", &mocks.FakeClient{ContainerListSuccess: true}, nil, nil, nil},
+		{"Docker is not installed", &mocks.FakeClient{}, nil, nil, errors.New("ContainerListFailure"), nil},
+		{"Docker is intalled", &mocks.FakeClient{ContainerListSuccess: true}, nil, nil,nil, nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -45,8 +46,8 @@ func TestValidateDependency(t *testing.T) {
 
 func TestHasBaseImage(t *testing.T) {
 	cases := []PassFailCase{
-		{"failing command", &mocks.FakeClient{}, nil, errors.New("ImageListFailure"), false},
-		{"passing command", &mocks.FakeClient{ImageListSuccess: true}, nil, nil, true},
+		{"failing command", &mocks.FakeClient{}, nil, nil,errors.New("ImageListFailure"), false},
+		{"passing command", &mocks.FakeClient{ImageListSuccess: true}, nil, nil, nil, true},
 	}
 
 	for _, tc := range cases {
@@ -68,7 +69,7 @@ func TestGetImagePullOptionsUsesRegistryAuth(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"correct options", &mocks.FakeClient{}, &jobConfig, errors.New("GetImagePullOptionsFailure"), nil},
+		{"correct options", &mocks.FakeClient{}, &jobConfig, nil,errors.New("GetImagePullOptionsFailure"), nil},
 	}
 
 	for _, tc := range cases {
@@ -87,7 +88,7 @@ func TestGetImagePullOptionsDefault(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"default options", &mocks.FakeClient{}, &jobConfig, errors.New("GetImagePullOptionsFailure"), nil},
+		{"default options", &mocks.FakeClient{}, &jobConfig, nil, errors.New("GetImagePullOptionsFailure"), nil},
 	}
 
 	for _, tc := range cases {
@@ -104,7 +105,7 @@ func TestPullBaseImage(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"failing command", &mocks.FakeClient{}, &jobConfig, errors.New("ImagePullFailure"), nil},
+		{"failing command", &mocks.FakeClient{}, &jobConfig, nil,errors.New("ImagePullFailure"), nil},
 		// {"passing command", &mocks.FakeClient{ImagePullSuccess: true}, nil, nil},
 	}
 
@@ -124,7 +125,7 @@ func TestGetImageFlavorDefault(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"get image flavor", &mocks.FakeClient{}, &jobConfig, errors.New("Wrong flavor name"), false},
+		{"get image flavor", &mocks.FakeClient{}, &jobConfig, nil,errors.New("Wrong flavor name"), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -142,7 +143,7 @@ func TestGetImageFlavorVersioned(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar", Version: "barfoo"},
 	}
 	cases := []PassFailCase{
-		{"get image flavor", &mocks.FakeClient{}, &jobConfig, errors.New("Wrong flavor name"), false},
+		{"get image flavor", &mocks.FakeClient{}, &jobConfig, nil, errors.New("Wrong flavor name"), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -163,28 +164,29 @@ func TestStartContainer(t *testing.T) {
 			{BrowserName: "chrome"},
 		},
 	}
+	suite := config.Suite{Capabilities: jobConfig.Capabilities[0]}
 	jobConfigWithoutCaps := config.Project{
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"failing to create container", &mocks.FakeClient{}, &jobConfig, errors.New("ContainerCreateFailure"), failureResult},
+		{"failing to create container", &mocks.FakeClient{}, &jobConfig, &suite,errors.New("ContainerCreateFailure"), failureResult},
 		{"failing to start container", &mocks.FakeClient{
 			ContainerCreateSuccess: true,
-		}, &jobConfig, errors.New("ContainerStartFailure"), failureResult},
+		}, &jobConfig, &suite,errors.New("ContainerStartFailure"), failureResult},
 		{"failing to inspect container", &mocks.FakeClient{
 			ContainerCreateSuccess: true,
 			ContainerStartSuccess:  true,
-		}, &jobConfig, errors.New("ContainerInspectFailure"), failureResult},
+		}, &jobConfig, &suite,errors.New("ContainerInspectFailure"), failureResult},
 		{"successful execution", &mocks.FakeClient{
 			ContainerCreateSuccess:  true,
 			ContainerStartSuccess:   true,
 			ContainerInspectSuccess: true,
-		}, &jobConfig, nil, failureResult},
+		}, &jobConfig, &suite, nil, failureResult},
 		{"successful execution without caps", &mocks.FakeClient{
 			ContainerCreateSuccess:  true,
 			ContainerStartSuccess:   true,
 			ContainerInspectSuccess: true,
-		}, &jobConfigWithoutCaps, nil, failureResult},
+		}, &jobConfigWithoutCaps, &suite, nil,failureResult},
 	}
 
 	for _, tc := range cases {
@@ -192,7 +194,7 @@ func TestStartContainer(t *testing.T) {
 			handler := Handler{
 				client: tc.Client,
 			}
-			_, err := handler.StartContainer(ctx, *tc.JobConfig)
+			_, err := handler.StartContainer(ctx, *tc.JobConfig, *tc.Suite)
 			assert.Equal(t, err, tc.ExpectedError)
 		})
 	}
@@ -211,15 +213,15 @@ func TestCopyFromContainer(t *testing.T) {
 	targetFile := dir.Path() + "/some.other.foo.js"
 
 	cases := []PassFailCaseWithArgument{
-		{PassFailCase{"not existing target dir", &mocks.FakeClient{}, nil, errors.New("invalid output path: directory /foo does not exist"), nil}, "/foo/bar"},
-		{PassFailCase{"failure when getting stat info", &mocks.FakeClient{}, nil, errors.New("ContainerStatPathFailure"), nil}, targetFile},
+		{PassFailCase{"not existing target dir", &mocks.FakeClient{}, nil, nil,errors.New("invalid output path: directory /foo does not exist"), nil}, "/foo/bar"},
+		{PassFailCase{"failure when getting stat info", &mocks.FakeClient{}, nil, nil,errors.New("ContainerStatPathFailure"), nil}, targetFile},
 		{PassFailCase{"failure when copying from container", &mocks.FakeClient{
 			ContainerStatPathSuccess: true,
-		}, nil, errors.New("CopyFromContainerFailure"), nil}, targetFile},
+		}, nil, nil, errors.New("CopyFromContainerFailure"), nil}, targetFile},
 		{PassFailCase{"successful attempt", &mocks.FakeClient{
 			ContainerStatPathSuccess: true,
 			CopyFromContainerSuccess: true,
-		}, nil, nil, nil}, targetFile},
+		}, nil, nil, nil,nil}, targetFile},
 	}
 
 	for _, tc := range cases {
@@ -235,14 +237,14 @@ func TestCopyFromContainer(t *testing.T) {
 
 func TestExecute(t *testing.T) {
 	cases := []PassFailCase{
-		{"failing to create exec", &mocks.FakeClient{}, nil, errors.New("ContainerExecCreateFailure"), nil},
+		{"failing to create exec", &mocks.FakeClient{}, nil, nil, errors.New("ContainerExecCreateFailure"), nil},
 		{"failing to create attach", &mocks.FakeClient{
 			ContainerExecCreateSuccess: true,
-		}, nil, errors.New("ContainerExecAttachFailure"), nil},
+		}, nil, nil,errors.New("ContainerExecAttachFailure"), nil},
 		{"successful call", &mocks.FakeClient{
 			ContainerExecCreateSuccess: true,
 			ContainerExecAttachSuccess: true,
-		}, nil, nil, nil},
+		}, nil, nil, nil,nil},
 	}
 
 	for _, tc := range cases {
@@ -258,10 +260,10 @@ func TestExecute(t *testing.T) {
 
 func TestExecuteExecuteInspect(t *testing.T) {
 	cases := []PassFailCase{
-		{"failing to inspect", &mocks.FakeClient{}, nil, errors.New("ContainerExecInspectFailure"), 1},
+		{"failing to inspect", &mocks.FakeClient{}, nil, nil, errors.New("ContainerExecInspectFailure"), 1},
 		{"successful call", &mocks.FakeClient{
 			ContainerExecInspectSuccess: true,
-		}, nil, nil, 0},
+		}, nil, nil, nil,0},
 	}
 
 	for _, tc := range cases {
@@ -278,10 +280,10 @@ func TestExecuteExecuteInspect(t *testing.T) {
 
 func TestContainerStop(t *testing.T) {
 	cases := []PassFailCase{
-		{"failing to inspect", &mocks.FakeClient{}, nil, errors.New("ContainerStopFailure"), nil},
+		{"failing to inspect", &mocks.FakeClient{}, nil, nil,errors.New("ContainerStopFailure"), nil},
 		{"successful call", &mocks.FakeClient{
 			ContainerStopSuccess: true,
-		}, nil, nil, 0},
+		}, nil, nil, nil,0},
 	}
 
 	for _, tc := range cases {
@@ -297,10 +299,10 @@ func TestContainerStop(t *testing.T) {
 
 func TestContainerRemove(t *testing.T) {
 	cases := []PassFailCase{
-		{"failing to inspect", &mocks.FakeClient{}, nil, errors.New("ContainerRemoveFailure"), nil},
+		{"failing to inspect", &mocks.FakeClient{}, nil, nil,errors.New("ContainerRemoveFailure"), nil},
 		{"successful call", &mocks.FakeClient{
 			ContainerRemoveSuccess: true,
-		}, nil, nil, 0},
+		}, nil, nil,nil, 0},
 	}
 
 	for _, tc := range cases {

--- a/internal/docker/runner.go
+++ b/internal/docker/runner.go
@@ -25,7 +25,7 @@ type Runner struct {
 }
 
 // NewRunner creates a new Runner instance.
-func NewRunner(c config.Project, cli *command.SauceCtlCli) (*Runner, error) {
+func NewRunner(c config.Project, s config.Suite, cli *command.SauceCtlCli) (*Runner, error) {
 	progress.Show("Starting test runner for docker")
 	defer progress.Stop()
 
@@ -33,6 +33,7 @@ func NewRunner(c config.Project, cli *command.SauceCtlCli) (*Runner, error) {
 	r.Cli = cli
 	r.Ctx = context.Background()
 	r.Project = c
+	r.Suite = s
 
 	var err error
 	r.docker, err = Create()
@@ -74,7 +75,7 @@ func (r *Runner) Setup() error {
 	}
 
 	progress.Show("Starting container %s", baseImage)
-	container, err := r.docker.StartContainer(r.Ctx, r.Project)
+	container, err := r.docker.StartContainer(r.Ctx, r.Project, r.Suite)
 	if err != nil {
 		return err
 	}
@@ -98,7 +99,7 @@ func (r *Runner) Setup() error {
 	}
 
 	progress.Show("Copying test files to container")
-	if err := r.docker.CopyTestFilesToContainer(r.Ctx, r.containerID, r.Project.Files, r.RunnerConfig.TargetDir); err != nil {
+	if err := r.docker.CopyTestFilesToContainer(r.Ctx, r.containerID, r.Suite.Files, r.RunnerConfig.TargetDir); err != nil {
 		return err
 	}
 

--- a/internal/docker/runner.go
+++ b/internal/docker/runner.go
@@ -99,7 +99,7 @@ func (r *Runner) Setup() error {
 	}
 
 	progress.Show("Copying test files to container")
-	if err := r.docker.CopyTestFilesToContainer(r.Ctx, r.containerID, r.Suite.Files, r.RunnerConfig.TargetDir); err != nil {
+	if err := r.docker.CopyTestFilesToContainer(r.Ctx, r.containerID, r.Project.Files, r.RunnerConfig.TargetDir); err != nil {
 		return err
 	}
 

--- a/tests/e2e/cypress/example.test.js
+++ b/tests/e2e/cypress/example.test.js
@@ -1,0 +1,10 @@
+context('Actions', () => {
+		beforeEach(() => {
+			cy.visit('https://example.cypress.io/commands/actions')
+		})
+		it('.type() - type into a DOM element', () => {
+			// https://on.cypress.io/type
+			cy.get('.action-email')
+				.type('fake@email.com').should('have.value', 'fake@email.com')
+		})
+	})

--- a/tests/e2e/playwright/example.test.js
+++ b/tests/e2e/playwright/example.test.js
@@ -1,0 +1,7 @@
+describe('saucectl demo test', () => {
+	test('should verify title of the page', async () => {
+		const page = (await browser.pages())[0]
+		await page.goto('https://www.saucedemo.com/');
+		expect(await page.title()).toBe('Swag Labs');
+	});
+});

--- a/tests/e2e/playwright/example.test.js
+++ b/tests/e2e/playwright/example.test.js
@@ -1,6 +1,5 @@
 describe('saucectl demo test', () => {
 	test('should verify title of the page', async () => {
-		const page = (await browser.pages())[0]
 		await page.goto('https://www.saucedemo.com/');
 		expect(await page.title()).toBe('Swag Labs');
 	});

--- a/tests/e2e/puppeteer/example.test.js
+++ b/tests/e2e/puppeteer/example.test.js
@@ -1,0 +1,7 @@
+describe('saucectl demo test', () => {
+	test('should verify title of the page', async () => {
+		const page = (await browser.pages())[0]
+		await page.goto('https://www.saucedemo.com/');
+		expect(await page.title()).toBe('Swag Labs');
+	});
+});

--- a/tests/e2e/testcafe/example.test.js
+++ b/tests/e2e/testcafe/example.test.js
@@ -1,0 +1,12 @@
+import { Selector } from 'testcafe';
+fixture `Getting Started`
+	.page `http://devexpress.github.io/testcafe/example`
+
+const testName = 'testcafe test'
+test(testName, async t => {
+	await t
+		.typeText('#developer-name', 'devx')
+		.click('#submit-button')
+		.expect(Selector('#article-header').innerText).eql('Thank you, devx!');
+});
+	


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Introduces rudimentary support for test suites, with backwards compatibility.
If the config has suites specified, they will be used and the capabilities and files on the project level (the root of the config) will be ignored. If no suites are specified, saucectl will continue to work as before.

The test runner will run once per test suite, but stop on the first test suite failure.

The `match` field is currently ignored.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

Example config:
```
apiVersion: v1
metadata:
  name: Feature XYZ
  tags:
    - e2e
    - release team
    - other tag
  build: Release $CI_COMMIT_SHORT_SHA
suites:
  - name: "my shiny suite"
    capabilities:
      browserName: "chromium"
    files:
      - ./tests/example.test.js
  - name: "my fiery suite"
    capabilities:
      browserName: "firefox"
    files:
      - ./tests/example.test.js
image:
  base: saucelabs/stt-puppeteer-jest-node
  version: v0.1.2
sauce:
  region: us-west-1
```