### PR TITLE
Copy over config file for consumption in container

### DIFF
--- a/cli/command/new/cmd.go
+++ b/cli/command/new/cmd.go
@@ -4,13 +4,14 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog/log"
-	"github.com/saucelabs/saucectl/internal/docker"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/docker"
 
 	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/spf13/cobra"
@@ -30,7 +31,7 @@ var (
 			Name: "framework",
 			Prompt: &survey.Select{
 				Message: "Choose a framework:",
-				Options: []string{"Puppeteer", "Playwright", "Testcafe", "Cypress"},
+				Options: []string{"Puppeteer", "Playwright", "Testcafe", "Cypress", "WebdriverIO"},
 				Default: "Puppeteer",
 			},
 		},
@@ -127,7 +128,7 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 	return nil
 }
 
-func getImageValues(framework string) (docker.Image, error){
+func getImageValues(framework string) (docker.Image, error) {
 	switch framework {
 	case "playwright":
 		return docker.DefaultPlaywright, nil
@@ -137,10 +138,11 @@ func getImageValues(framework string) (docker.Image, error){
 		return docker.DefaultTestcafe, nil
 	case "cypress":
 		return docker.DefaultCypress, nil
+	case "webdriverio":
+		return docker.DefaultWebdriverIO, nil
 	}
 	return docker.Image{}, errors.New("unknown framework")
 }
-
 
 func writeJobConfig(framework string, region string, w io.Writer) error {
 	configTpl, err := template.New("configTpl").Parse(configTpl)
@@ -152,9 +154,9 @@ func writeJobConfig(framework string, region string, w io.Writer) error {
 	image, err := getImageValues(framework)
 
 	v := struct {
-		Name    string
-		Version string
-		Region  string
+		Name        string
+		Version     string
+		Region      string
 		TestsFolder string
 	}{
 		Region: region,

--- a/cli/command/new/templates.go
+++ b/cli/command/new/templates.go
@@ -68,5 +68,21 @@ test(testName, async t => {
 			cy.get('.action-email')
 				.type('fake@email.com').should('have.value', 'fake@email.com')
 		})
-	})`},
+	})
+`},
+	"webdriverio": {
+		"example.test.js",
+		`describe('My Login application', () => {
+			it('should login with valid credentials', <%= _async %>() => {
+				browser.url('https://the-internet.herokuapp.com/login');
+				$('#username').setValue(username);
+				$('#password').setValue(password);
+				$('button[type="submit"]').click();
+
+				expect($('#flash')).toBeExisting();
+				expect($('#flash')).toHaveTextContaining(
+					'You logged into a secure area!');
+			});
+		});`,
+	},
 }

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -1,11 +1,12 @@
 package run
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/saucelabs/saucectl/cli/mocks"
 	"github.com/saucelabs/saucectl/internal/ci"
 	"github.com/saucelabs/saucectl/internal/docker"
-	"os"
-	"path/filepath"
 
 	"github.com/rs/zerolog/log"
 
@@ -84,7 +85,7 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 
 	for _, suite := range cfg.Suites {
 		exitCode, err := runSuite(cfg, suite, cli)
-		if err != nil  || exitCode != 0 {
+		if err != nil || exitCode != 0 {
 			return exitCode, err
 		}
 	}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -48,16 +48,17 @@ type ImageDefinition struct {
 
 // Project represents the project configuration.
 type Project struct {
-	APIVersion   string            `yaml:"apiVersion"`
-	Kind         string            `yaml:"kind"`
-	Metadata     Metadata          `yaml:"metadata"`
-	Capabilities []Capabilities    `yaml:"capabilities"`
-	Suites       []Suite           `yaml:"suites"`
-	Files        []string          `yaml:"files"`
-	Image        ImageDefinition   `yaml:"image"`
-	Timeout      int               `yaml:"timeout"`
-	Sauce        SauceConfig       `yaml:"sauce"`
-	Env          map[string]string `yaml:"env"`
+	ConfigFilePath string
+	APIVersion     string            `yaml:"apiVersion"`
+	Kind           string            `yaml:"kind"`
+	Metadata       Metadata          `yaml:"metadata"`
+	Capabilities   []Capabilities    `yaml:"capabilities"`
+	Suites         []Suite           `yaml:"suites"`
+	Files          []string          `yaml:"files"`
+	Image          ImageDefinition   `yaml:"image"`
+	Timeout        int               `yaml:"timeout"`
+	Sauce          SauceConfig       `yaml:"sauce"`
+	Env            map[string]string `yaml:"env"`
 }
 
 // Suite represents the test suite configuration.
@@ -132,6 +133,7 @@ func NewJobConfiguration(cfgFilePath string) (Project, error) {
 		c.Env = make(map[string]string)
 	}
 
+	c.ConfigFilePath = cfgFilePath
 	return c, nil
 }
 

--- a/internal/ci/runner.go
+++ b/internal/ci/runner.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/saucelabs/saucectl/cli/runner"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/cli/config"
+	"github.com/saucelabs/saucectl/cli/runner"
 )
 
 // Runner represents the CI implementation of a runner.Testrunner.
@@ -85,6 +85,7 @@ func (r *Runner) Run() (int, error) {
 		fmt.Sprintf("SAUCE_REGION=%s", r.Project.Sauce.Region),
 		fmt.Sprintf("TEST_TIMEOUT=%d", r.Project.Timeout),
 		fmt.Sprintf("BROWSER_NAME=%s", r.Suite.Capabilities.BrowserName),
+		fmt.Sprintf("CONFIG_FILE_PATH=%s", r.Project.ConfigFilePath),
 	)
 
 	// Add any defined env variables from the job config / CLI args.

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -281,8 +281,9 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s 
 // CopyFilesToContainer copies the given files into the container.
 func (handler *Handler) CopyFilesToContainer(ctx context.Context, srcContainerID string, filesToCopy []FilesToCopy) error {
 	for _, ftc := range filesToCopy {
-		for _, files := range ftc.files {
-			if err := handler.CopyToContainer(ctx, srcContainerID, files, ftc.targetDir); err != nil {
+		for _, file := range ftc.files {
+			log.Info().Msg("Copy " + file + " to " + ftc.targetDir)
+			if err := handler.CopyToContainer(ctx, srcContainerID, file, ftc.targetDir); err != nil {
 				return err
 			}
 		}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -76,6 +76,13 @@ var DefaultCypress = Image{
 	TestsFolder: "cypress/integration",
 }
 
+// DefaultWebdriverIO represents the default image for webdriverio.
+var DefaultWebdriverIO = Image{
+	Name:        "saucelabs/stt-webdriverio-node",
+	Version:     "v0.0.1",
+	TestsFolder: "tests",
+}
+
 // CommonAPIClient is the interface for interacting with containers.
 type CommonAPIClient interface {
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/docker/docker/api/types"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/docker/docker/api/types"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/saucelabs/saucectl/cli/config"
@@ -26,7 +27,7 @@ type PassFailCase struct {
 	Name           string
 	Client         CommonAPIClient
 	JobConfig      *config.Project
-	Suite		   *config.Suite
+	Suite          *config.Suite
 	ExpectedError  error
 	ExpectedResult interface{}
 }
@@ -34,7 +35,7 @@ type PassFailCase struct {
 func TestValidateDependency(t *testing.T) {
 	cases := []PassFailCase{
 		{"Docker is not installed", &mocks.FakeClient{}, nil, nil, errors.New("ContainerListFailure"), nil},
-		{"Docker is intalled", &mocks.FakeClient{ContainerListSuccess: true}, nil, nil,nil, nil},
+		{"Docker is intalled", &mocks.FakeClient{ContainerListSuccess: true}, nil, nil, nil, nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -47,7 +48,7 @@ func TestValidateDependency(t *testing.T) {
 
 func TestHasBaseImage(t *testing.T) {
 	cases := []PassFailCase{
-		{"failing command", &mocks.FakeClient{}, nil, nil,errors.New("ImageListFailure"), false},
+		{"failing command", &mocks.FakeClient{}, nil, nil, errors.New("ImageListFailure"), false},
 		{"passing command", &mocks.FakeClient{ImageListSuccess: true}, nil, nil, nil, true},
 	}
 
@@ -70,7 +71,7 @@ func TestGetImagePullOptionsUsesRegistryAuth(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"correct options", &mocks.FakeClient{}, &jobConfig, nil,errors.New("GetImagePullOptionsFailure"), nil},
+		{"correct options", &mocks.FakeClient{}, &jobConfig, nil, errors.New("GetImagePullOptionsFailure"), nil},
 	}
 
 	for _, tc := range cases {
@@ -106,7 +107,7 @@ func TestPullBaseImage(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"failing command", &mocks.FakeClient{}, &jobConfig, nil,errors.New("ImagePullFailure"), nil},
+		{"failing command", &mocks.FakeClient{}, &jobConfig, nil, errors.New("ImagePullFailure"), nil},
 		// {"passing command", &mocks.FakeClient{ImagePullSuccess: true}, nil, nil},
 	}
 
@@ -126,7 +127,7 @@ func TestGetImageFlavorDefault(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"get image flavor", &mocks.FakeClient{}, &jobConfig, nil,errors.New("Wrong flavor name"), false},
+		{"get image flavor", &mocks.FakeClient{}, &jobConfig, nil, errors.New("Wrong flavor name"), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -170,14 +171,14 @@ func TestStartContainer(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"failing to create container", &mocks.FakeClient{}, &jobConfig, &suite,errors.New("ContainerCreateFailure"), failureResult},
+		{"failing to create container", &mocks.FakeClient{}, &jobConfig, &suite, errors.New("ContainerCreateFailure"), failureResult},
 		{"failing to start container", &mocks.FakeClient{
 			ContainerCreateSuccess: true,
-		}, &jobConfig, &suite,errors.New("ContainerStartFailure"), failureResult},
+		}, &jobConfig, &suite, errors.New("ContainerStartFailure"), failureResult},
 		{"failing to inspect container", &mocks.FakeClient{
 			ContainerCreateSuccess: true,
 			ContainerStartSuccess:  true,
-		}, &jobConfig, &suite,errors.New("ContainerInspectFailure"), failureResult},
+		}, &jobConfig, &suite, errors.New("ContainerInspectFailure"), failureResult},
 		{"successful execution", &mocks.FakeClient{
 			ContainerCreateSuccess:  true,
 			ContainerStartSuccess:   true,
@@ -187,7 +188,7 @@ func TestStartContainer(t *testing.T) {
 			ContainerCreateSuccess:  true,
 			ContainerStartSuccess:   true,
 			ContainerInspectSuccess: true,
-		}, &jobConfigWithoutCaps, &suite, nil,failureResult},
+		}, &jobConfigWithoutCaps, &suite, nil, failureResult},
 	}
 
 	for _, tc := range cases {
@@ -195,7 +196,7 @@ func TestStartContainer(t *testing.T) {
 			handler := Handler{
 				client: tc.Client,
 			}
-			_, err := handler.StartContainer(ctx, *tc.JobConfig, *tc.Suite)
+			_, err := handler.StartContainer(ctx, *tc.JobConfig, *tc.Suite, "hostDstPath")
 			assert.Equal(t, err, tc.ExpectedError)
 		})
 	}
@@ -214,15 +215,15 @@ func TestCopyFromContainer(t *testing.T) {
 	targetFile := dir.Path() + "/some.other.foo.js"
 
 	cases := []PassFailCaseWithArgument{
-		{PassFailCase{"not existing target dir", &mocks.FakeClient{}, nil, nil,errors.New("invalid output path: directory /foo does not exist"), nil}, "/foo/bar"},
-		{PassFailCase{"failure when getting stat info", &mocks.FakeClient{}, nil, nil,errors.New("ContainerStatPathFailure"), nil}, targetFile},
+		{PassFailCase{"not existing target dir", &mocks.FakeClient{}, nil, nil, errors.New("invalid output path: directory /foo does not exist"), nil}, "/foo/bar"},
+		{PassFailCase{"failure when getting stat info", &mocks.FakeClient{}, nil, nil, errors.New("ContainerStatPathFailure"), nil}, targetFile},
 		{PassFailCase{"failure when copying from container", &mocks.FakeClient{
 			ContainerStatPathSuccess: true,
 		}, nil, nil, errors.New("CopyFromContainerFailure"), nil}, targetFile},
 		{PassFailCase{"successful attempt", &mocks.FakeClient{
 			ContainerStatPathSuccess: true,
 			CopyFromContainerSuccess: true,
-		}, nil, nil, nil,nil}, targetFile},
+		}, nil, nil, nil, nil}, targetFile},
 	}
 
 	for _, tc := range cases {
@@ -241,11 +242,11 @@ func TestExecute(t *testing.T) {
 		{"failing to create exec", &mocks.FakeClient{}, nil, nil, errors.New("ContainerExecCreateFailure"), nil},
 		{"failing to create attach", &mocks.FakeClient{
 			ContainerExecCreateSuccess: true,
-		}, nil, nil,errors.New("ContainerExecAttachFailure"), nil},
+		}, nil, nil, errors.New("ContainerExecAttachFailure"), nil},
 		{"successful call", &mocks.FakeClient{
 			ContainerExecCreateSuccess: true,
 			ContainerExecAttachSuccess: true,
-		}, nil, nil, nil,nil},
+		}, nil, nil, nil, nil},
 	}
 
 	for _, tc := range cases {
@@ -264,7 +265,7 @@ func TestExecuteExecuteInspect(t *testing.T) {
 		{"failing to inspect", &mocks.FakeClient{}, nil, nil, errors.New("ContainerExecInspectFailure"), 1},
 		{"successful call", &mocks.FakeClient{
 			ContainerExecInspectSuccess: true,
-		}, nil, nil, nil,0},
+		}, nil, nil, nil, 0},
 	}
 
 	for _, tc := range cases {
@@ -281,10 +282,10 @@ func TestExecuteExecuteInspect(t *testing.T) {
 
 func TestContainerStop(t *testing.T) {
 	cases := []PassFailCase{
-		{"failing to inspect", &mocks.FakeClient{}, nil, nil,errors.New("ContainerStopFailure"), nil},
+		{"failing to inspect", &mocks.FakeClient{}, nil, nil, errors.New("ContainerStopFailure"), nil},
 		{"successful call", &mocks.FakeClient{
 			ContainerStopSuccess: true,
-		}, nil, nil, nil,0},
+		}, nil, nil, nil, 0},
 	}
 
 	for _, tc := range cases {
@@ -300,10 +301,10 @@ func TestContainerStop(t *testing.T) {
 
 func TestContainerRemove(t *testing.T) {
 	cases := []PassFailCase{
-		{"failing to inspect", &mocks.FakeClient{}, nil, nil,errors.New("ContainerRemoveFailure"), nil},
+		{"failing to inspect", &mocks.FakeClient{}, nil, nil, errors.New("ContainerRemoveFailure"), nil},
 		{"successful call", &mocks.FakeClient{
 			ContainerRemoveSuccess: true,
-		}, nil, nil,nil, 0},
+		}, nil, nil, nil, 0},
 	}
 
 	for _, tc := range cases {

--- a/internal/docker/runner.go
+++ b/internal/docker/runner.go
@@ -114,7 +114,7 @@ func (r *Runner) Setup() error {
 			files:     fpath.Globs(r.Project.Files),
 		},
 		{
-			targetDir: hostDstPath,
+			targetDir: "/home/seluser",
 			files:     []string{r.Project.ConfigFilePath},
 		},
 	}


### PR DESCRIPTION
## Proposed changes

I feel like it can become handy to copy over the config file to the runner for consumption in order to not pollute the environment with data. I am currently working on a runner for [WebdriverIO](https://webdriver.io/) and it would be nice if user could modify the WDIO config file via the `sauce.yaml` config.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

work in progress