### PR TITLE
feat: Add SKIP_CI parameter to saucectl

### DIFF
--- a/internal/ci/ci.go
+++ b/internal/ci/ci.go
@@ -5,12 +5,10 @@ import (
 	"runtime"
 )
 
-// IsAvailable detects whether this code is executed inside a CI environment that isn't Windows or MacOS
+// IsAvailable detects whether this code is executed inside a CI environment
 func IsAvailable() bool {
 	// Most CI providers have this.
 	isCi := os.Getenv("CI") != "" || os.Getenv("BUILD_NUMBER") != ""
-	isWin := runtime.GOOS == "windows"
-	isMacOS := runtime.GOOS == "darwin"
 	shouldSkipCi := os.Getenv("SKIP_CI") != ""
-	return isCi && !isWin && !isMacOS && !shouldSkipCi
+	return isCi && !shouldSkipCi
 }

--- a/internal/ci/ci.go
+++ b/internal/ci/ci.go
@@ -6,6 +6,6 @@ import "os"
 func IsAvailable() bool {
 	// Most CI providers have this.
 	isCi := os.Getenv("CI") != "" || os.Getenv("BUILD_NUMBER") != ""
-	shouldSkipCi := os.Getenv("SKIP_CI") != ""
-	return isCi && !shouldSkipCi
+	skip := os.Getenv("SKIP_CI") != ""
+	return isCi && !skip
 }

--- a/internal/ci/ci.go
+++ b/internal/ci/ci.go
@@ -1,9 +1,16 @@
 package ci
 
-import "os"
+import (
+	"os"
+	"runtime"
+)
 
-// IsAvailable detects whether this code is executed inside a CI environment.
+// IsAvailable detects whether this code is executed inside a CI environment that isn't Windows or MacOS
 func IsAvailable() bool {
 	// Most CI providers have this.
-	return os.Getenv("CI") != "" || os.Getenv("BUILD_NUMBER") != ""
+	isCi := os.Getenv("CI") != "" || os.Getenv("BUILD_NUMBER") != ""
+	isWin := runtime.GOOS == "windows"
+	isMacOS := runtime.GOOS == "darwin"
+	shouldSkipCi := os.Getenv("SKIP_CI") != ""
+	return isCi && !isWin && !isMacOS && !shouldSkipCi
 }

--- a/internal/ci/ci.go
+++ b/internal/ci/ci.go
@@ -1,9 +1,6 @@
 package ci
 
-import (
-	"os"
-	"runtime"
-)
+import "os"
 
 // IsAvailable detects whether this code is executed inside a CI environment
 func IsAvailable() bool {


### PR DESCRIPTION
## Proposed changes

We may not always want saucectl to think it's inside a container whenver saucectl is run from a CI environment. This pull-request makes an exception for if the platforms is windows or macos; and it makes an exception if an environment variable `SKIP_CI` was passed to it.

This also makes it so we can test our containers using saucectl in CI.

## Types of changes

What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...