### PR TITLE
Replace capabilities with settings in config files

### DIFF
--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -11,8 +11,10 @@ files:
 suites:
   - name: "saucy test"
     match: ".*.(spec|test).js$"
+    capabilities:
+      browserName: "chrome"
     settings:
-      browserName: "firefox"
+      browserName: "chrome"
 image:
   base: saucelabs/stt-cypress-mocha-node
   version: latest

--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -11,8 +11,8 @@ files:
 suites:
   - name: "saucy test"
     match: ".*.(spec|test).js$"
-    capabilities:
-      browserName: "chrome"
+    settings:
+      browserName: "firefox"
 image:
   base: saucelabs/stt-cypress-mocha-node
   version: latest

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -9,6 +9,8 @@ files:
 suites:
   - name: "saucy test"
     match: ".*.(spec|test).js$"
+    capabilities:
+      browserName: "firefox"
     settings:
       browserName: "firefox"
 image:

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -9,7 +9,7 @@ files:
 suites:
   - name: "saucy test"
     match: ".*.(spec|test).js$"
-    capabilities:
+    settings:
       browserName: "firefox"
 image:
   base: saucelabs/stt-playwright-jest-node

--- a/.sauce/puppeteer.yml
+++ b/.sauce/puppeteer.yml
@@ -11,6 +11,8 @@ files:
 suites:
   - name: "chrome"
     match: ".*.(spec|test).js$"
+    capabilities:
+      browserName: "chrome"
     settings:
       browserName: "chrome"
 image:

--- a/.sauce/puppeteer.yml
+++ b/.sauce/puppeteer.yml
@@ -11,7 +11,7 @@ files:
 suites:
   - name: "chrome"
     match: ".*.(spec|test).js$"
-    capabilities:
+    settings:
       browserName: "chrome"
 image:
   base: saucelabs/stt-puppeteer-jest-node

--- a/.sauce/puppeteer_parallel.yml
+++ b/.sauce/puppeteer_parallel.yml
@@ -11,8 +11,10 @@ files:
 suites:
   - name: "chrome"
     match: ".*.(spec|test).js$"
+    capabilities:
+      browserName: "chrome"
     settings:
-      browsername: "chrome"
+      browserName: "chrome"
 image:
   base: saucelabs/stt-puppeteer-jest-node
   version: latest

--- a/.sauce/puppeteer_parallel.yml
+++ b/.sauce/puppeteer_parallel.yml
@@ -11,8 +11,8 @@ files:
 suites:
   - name: "chrome"
     match: ".*.(spec|test).js$"
-    capabilities:
-      browserName: "chrome"
+    settings:
+      browsername: "chrome"
 image:
   base: saucelabs/stt-puppeteer-jest-node
   version: latest

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -186,9 +186,6 @@ func apiBaseURL(r region.Region) string {
 func newDefaultSuite(p config.Project) config.Suite {
 	// TODO remove this method once saucectl fully transitions to the new config
 	s := config.Suite{Name: "default"}
-	if len(p.Settings) > 0 {
-		s.Settings = p.Settings[0]
-	}
 
 	return s
 }

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -1,6 +1,11 @@
 package run
 
 import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/cli/config"
@@ -16,10 +21,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/saucelabs/saucectl/internal/testcomposer"
 	"github.com/spf13/cobra"
-	"net/http"
-	"os"
-	"path/filepath"
-	"time"
 )
 
 var (
@@ -185,8 +186,8 @@ func apiBaseURL(r region.Region) string {
 func newDefaultSuite(p config.Project) config.Suite {
 	// TODO remove this method once saucectl fully transitions to the new config
 	s := config.Suite{Name: "default"}
-	if len(p.Capabilities) > 0 {
-		s.Capabilities = p.Capabilities[0]
+	if len(p.Settings) > 0 {
+		s.Settings = p.Settings[0]
 	}
 
 	return s

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -24,18 +24,17 @@ type Timeouts struct {
 	Implicit int `yaml:"implicit"`
 }
 
-// Capabilities describes job capabilies
-type Capabilities struct {
-	BrowserName               string                 `yaml:"browserName"`
-	BrowserVersion            string                 `yaml:"browserVersion"`
-	PlatformName              string                 `yaml:"platformName"`
-	AcceptInsecureCerts       bool                   `yaml:"acceptInsecureCerts"`
-	PageLoadStrategy          bool                   `yaml:"pageLoadStrategy"`
-	Proxy                     map[string]interface{} `yaml:"proxy"`
-	SetWindowRect             bool                   `yaml:"setWindowRect"`
-	Timeouts                  Timeouts               `yaml:"timeouts"`
-	StrictFileInteractability bool                   `yaml:"strictFileInteractability"`
-	UnhandledPromptBehavior   string                 `yaml:"unhandledPromptBehavior"`
+// Settings describes job settings
+type Settings struct {
+	BrowserName               string   `yaml:"browserName"`
+	BrowserVersion            string   `yaml:"browserVersion"`
+	PlatformName              string   `yaml:"platformName"`
+	AcceptInsecureCerts       bool     `yaml:"acceptInsecureCerts"`
+	PageLoadStrategy          bool     `yaml:"pageLoadStrategy"`
+	SetWindowRect             bool     `yaml:"setWindowRect"`
+	Timeouts                  Timeouts `yaml:"timeouts"`
+	StrictFileInteractability bool     `yaml:"strictFileInteractability"`
+	UnhandledPromptBehavior   string   `yaml:"unhandledPromptBehavior"`
 }
 
 // ImageDefinition describe configuration to the testrunner image
@@ -48,25 +47,25 @@ type ImageDefinition struct {
 
 // Project represents the project configuration.
 type Project struct {
-	APIVersion   string            `yaml:"apiVersion"`
-	Kind         string            `yaml:"kind"`
-	Metadata     Metadata          `yaml:"metadata"`
-	Capabilities []Capabilities    `yaml:"capabilities"`
-	Suites       []Suite           `yaml:"suites"`
-	Files        []string          `yaml:"files"`
-	Image        ImageDefinition   `yaml:"image"`
-	BeforeExec   []string          `yaml:"beforeExec"`
-	Timeout      int               `yaml:"timeout"`
-	Sauce        SauceConfig       `yaml:"sauce"`
-	Env          map[string]string `yaml:"env"`
-	Parallel     bool              `yaml:"parallel"`
+	APIVersion string            `yaml:"apiVersion"`
+	Kind       string            `yaml:"kind"`
+	Metadata   Metadata          `yaml:"metadata"`
+	Settings   []Settings        `yaml:"settings"`
+	Suites     []Suite           `yaml:"suites"`
+	Files      []string          `yaml:"files"`
+	Image      ImageDefinition   `yaml:"image"`
+	BeforeExec []string          `yaml:"beforeExec"`
+	Timeout    int               `yaml:"timeout"`
+	Sauce      SauceConfig       `yaml:"sauce"`
+	Env        map[string]string `yaml:"env"`
+	Parallel   bool              `yaml:"parallel"`
 }
 
 // Suite represents the test suite configuration.
 type Suite struct {
-	Name         string       `yaml:"name"`
-	Capabilities Capabilities `yaml:"capabilities"`
-	Match        string       `yaml:"match"`
+	Name     string   `yaml:"name"`
+	Settings Settings `yaml:"settings"`
+	Match    string   `yaml:"match"`
 }
 
 // SauceConfig represents sauce labs related settings.

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,7 @@ github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/internal/ci/runner_test.go
+++ b/internal/ci/runner_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/cli/config"
 	"github.com/saucelabs/saucectl/cli/runner"
-
 	"github.com/saucelabs/saucectl/internal/fleet"
 
 	"github.com/stretchr/testify/assert"

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -5,8 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/docker/docker/api/types/mount"
-	"github.com/rs/zerolog/log"
 	"io"
 	"io/ioutil"
 	"os"
@@ -14,21 +12,22 @@ import (
 	"strings"
 	"time"
 
+	"github.com/saucelabs/saucectl/cli/config"
+	"github.com/saucelabs/saucectl/cli/streams"
+	"github.com/saucelabs/saucectl/cli/utils"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/go-connections/nat"
-
 	"github.com/phayes/freeport"
-
-	"github.com/saucelabs/saucectl/cli/config"
-	"github.com/saucelabs/saucectl/cli/streams"
-	"github.com/saucelabs/saucectl/cli/utils"
+	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -251,7 +250,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s 
 			fmt.Sprintf("SAUCE_DEVTOOLS_PORT=%d", port),
 			fmt.Sprintf("SAUCE_REGION=%s", c.Sauce.Region),
 			fmt.Sprintf("TEST_TIMEOUT=%d", c.Timeout),
-			fmt.Sprintf("BROWSER_NAME=%s", s.Capabilities.BrowserName),
+			fmt.Sprintf("BROWSER_NAME=%s", s.Settings.BrowserName),
 		},
 	}
 

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -161,11 +161,8 @@ func TestStartContainer(t *testing.T) {
 	failureResult := container.ContainerCreateCreatedBody{}
 	jobConfig := config.Project{
 		Image: config.ImageDefinition{Base: "foobar"},
-		Settings: []config.Settings{
-			{BrowserName: "chrome"},
-		},
 	}
-	suite := config.Suite{Settings: jobConfig.Settings[0]}
+	suite := config.Suite{Settings: config.Settings{BrowserName: "chrome"}}
 	jobConfigWithoutCaps := config.Project{
 		Image: config.ImageDefinition{Base: "foobar"},
 	}

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/docker/docker/api/types"
 	"io"
 	"log"
 	"os"
@@ -13,6 +12,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/saucelabs/saucectl/cli/config"
 	"github.com/saucelabs/saucectl/cli/mocks"
@@ -34,7 +34,7 @@ type PassFailCase struct {
 func TestValidateDependency(t *testing.T) {
 	cases := []PassFailCase{
 		{"Docker is not installed", &mocks.FakeClient{}, nil, nil, errors.New("ContainerListFailure"), nil},
-		{"Docker is intalled", &mocks.FakeClient{ContainerListSuccess: true}, nil, nil,nil, nil},
+		{"Docker is intalled", &mocks.FakeClient{ContainerListSuccess: true}, nil, nil, nil, nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestValidateDependency(t *testing.T) {
 
 func TestHasBaseImage(t *testing.T) {
 	cases := []PassFailCase{
-		{"failing command", &mocks.FakeClient{}, nil, nil,errors.New("ImageListFailure"), false},
+		{"failing command", &mocks.FakeClient{}, nil, nil, errors.New("ImageListFailure"), false},
 		{"passing command", &mocks.FakeClient{ImageListSuccess: true}, nil, nil, nil, true},
 	}
 
@@ -70,7 +70,7 @@ func TestGetImagePullOptionsUsesRegistryAuth(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"correct options", &mocks.FakeClient{}, &jobConfig, nil,errors.New("GetImagePullOptionsFailure"), nil},
+		{"correct options", &mocks.FakeClient{}, &jobConfig, nil, errors.New("GetImagePullOptionsFailure"), nil},
 	}
 
 	for _, tc := range cases {
@@ -106,7 +106,7 @@ func TestPullBaseImage(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"failing command", &mocks.FakeClient{}, &jobConfig, nil,errors.New("ImagePullFailure"), nil},
+		{"failing command", &mocks.FakeClient{}, &jobConfig, nil, errors.New("ImagePullFailure"), nil},
 		// {"passing command", &mocks.FakeClient{ImagePullSuccess: true}, nil, nil},
 	}
 
@@ -126,7 +126,7 @@ func TestGetImageFlavorDefault(t *testing.T) {
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"get image flavor", &mocks.FakeClient{}, &jobConfig, nil,errors.New("Wrong flavor name"), false},
+		{"get image flavor", &mocks.FakeClient{}, &jobConfig, nil, errors.New("Wrong flavor name"), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -161,23 +161,23 @@ func TestStartContainer(t *testing.T) {
 	failureResult := container.ContainerCreateCreatedBody{}
 	jobConfig := config.Project{
 		Image: config.ImageDefinition{Base: "foobar"},
-		Capabilities: []config.Capabilities{
+		Settings: []config.Settings{
 			{BrowserName: "chrome"},
 		},
 	}
-	suite := config.Suite{Capabilities: jobConfig.Capabilities[0]}
+	suite := config.Suite{Settings: jobConfig.Settings[0]}
 	jobConfigWithoutCaps := config.Project{
 		Image: config.ImageDefinition{Base: "foobar"},
 	}
 	cases := []PassFailCase{
-		{"failing to create container", &mocks.FakeClient{}, &jobConfig, &suite,errors.New("ContainerCreateFailure"), failureResult},
+		{"failing to create container", &mocks.FakeClient{}, &jobConfig, &suite, errors.New("ContainerCreateFailure"), failureResult},
 		{"failing to start container", &mocks.FakeClient{
 			ContainerCreateSuccess: true,
-		}, &jobConfig, &suite,errors.New("ContainerStartFailure"), failureResult},
+		}, &jobConfig, &suite, errors.New("ContainerStartFailure"), failureResult},
 		{"failing to inspect container", &mocks.FakeClient{
 			ContainerCreateSuccess: true,
 			ContainerStartSuccess:  true,
-		}, &jobConfig, &suite,errors.New("ContainerInspectFailure"), failureResult},
+		}, &jobConfig, &suite, errors.New("ContainerInspectFailure"), failureResult},
 		{"successful execution", &mocks.FakeClient{
 			ContainerCreateSuccess:  true,
 			ContainerStartSuccess:   true,
@@ -187,7 +187,7 @@ func TestStartContainer(t *testing.T) {
 			ContainerCreateSuccess:  true,
 			ContainerStartSuccess:   true,
 			ContainerInspectSuccess: true,
-		}, &jobConfigWithoutCaps, &suite, nil,failureResult},
+		}, &jobConfigWithoutCaps, &suite, nil, failureResult},
 	}
 
 	for _, tc := range cases {
@@ -214,15 +214,15 @@ func TestCopyFromContainer(t *testing.T) {
 	targetFile := dir.Path() + "/some.other.foo.js"
 
 	cases := []PassFailCaseWithArgument{
-		{PassFailCase{"not existing target dir", &mocks.FakeClient{}, nil, nil,errors.New("invalid output path: directory /foo does not exist"), nil}, "/foo/bar"},
-		{PassFailCase{"failure when getting stat info", &mocks.FakeClient{}, nil, nil,errors.New("ContainerStatPathFailure"), nil}, targetFile},
+		{PassFailCase{"not existing target dir", &mocks.FakeClient{}, nil, nil, errors.New("invalid output path: directory /foo does not exist"), nil}, "/foo/bar"},
+		{PassFailCase{"failure when getting stat info", &mocks.FakeClient{}, nil, nil, errors.New("ContainerStatPathFailure"), nil}, targetFile},
 		{PassFailCase{"failure when copying from container", &mocks.FakeClient{
 			ContainerStatPathSuccess: true,
 		}, nil, nil, errors.New("CopyFromContainerFailure"), nil}, targetFile},
 		{PassFailCase{"successful attempt", &mocks.FakeClient{
 			ContainerStatPathSuccess: true,
 			CopyFromContainerSuccess: true,
-		}, nil, nil, nil,nil}, targetFile},
+		}, nil, nil, nil, nil}, targetFile},
 	}
 
 	for _, tc := range cases {
@@ -241,11 +241,11 @@ func TestExecute(t *testing.T) {
 		{"failing to create exec", &mocks.FakeClient{}, nil, nil, errors.New("ContainerExecCreateFailure"), nil},
 		{"failing to create attach", &mocks.FakeClient{
 			ContainerExecCreateSuccess: true,
-		}, nil, nil,errors.New("ContainerExecAttachFailure"), nil},
+		}, nil, nil, errors.New("ContainerExecAttachFailure"), nil},
 		{"successful call", &mocks.FakeClient{
 			ContainerExecCreateSuccess: true,
 			ContainerExecAttachSuccess: true,
-		}, nil, nil, nil,nil},
+		}, nil, nil, nil, nil},
 	}
 
 	for _, tc := range cases {
@@ -264,7 +264,7 @@ func TestExecuteExecuteInspect(t *testing.T) {
 		{"failing to inspect", &mocks.FakeClient{}, nil, nil, errors.New("ContainerExecInspectFailure"), 1},
 		{"successful call", &mocks.FakeClient{
 			ContainerExecInspectSuccess: true,
-		}, nil, nil, nil,0},
+		}, nil, nil, nil, 0},
 	}
 
 	for _, tc := range cases {
@@ -281,10 +281,10 @@ func TestExecuteExecuteInspect(t *testing.T) {
 
 func TestContainerStop(t *testing.T) {
 	cases := []PassFailCase{
-		{"failing to inspect", &mocks.FakeClient{}, nil, nil,errors.New("ContainerStopFailure"), nil},
+		{"failing to inspect", &mocks.FakeClient{}, nil, nil, errors.New("ContainerStopFailure"), nil},
 		{"successful call", &mocks.FakeClient{
 			ContainerStopSuccess: true,
-		}, nil, nil, nil,0},
+		}, nil, nil, nil, 0},
 	}
 
 	for _, tc := range cases {
@@ -300,10 +300,10 @@ func TestContainerStop(t *testing.T) {
 
 func TestContainerRemove(t *testing.T) {
 	cases := []PassFailCase{
-		{"failing to inspect", &mocks.FakeClient{}, nil, nil,errors.New("ContainerRemoveFailure"), nil},
+		{"failing to inspect", &mocks.FakeClient{}, nil, nil, errors.New("ContainerRemoveFailure"), nil},
 		{"successful call", &mocks.FakeClient{
 			ContainerRemoveSuccess: true,
-		}, nil, nil,nil, 0},
+		}, nil, nil, nil, 0},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Proposed changes
Replace `capabilities` with `settings` in config files for project. But it's still remain backwards compatibility for `suites`.
It would behave like follows:
1. It should use `settings` when only `settings` exists.
2. It should use `capabilities` when only `capabilities` exists.
3. It should use `settings` when `capabilities` and `settings` both exist.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->