### PR TITLE
Archive export for windows as zip

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,6 +38,9 @@ archives:
       windows: win
       amd64: 64-bit
       386: 32-bit
+    format_overrides:
+      - goos: windows
+        format: zip
     files:
       - LICENSE
 checksum:


### PR DESCRIPTION
## Proposed changes

`tar` is not a standard command on Windows hosts, `zip` is much more common.
To avoid requiring installation of a new software to access the binary, archive windows binaries is adviced.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Demo release: https://github.com/FriggaHel/saucectl/releases/tag/v0.13.0-windows-zip
It is assertable that windows binaries are now in `zip` format.