### PR TITLE
feat: use CWD when CI=true

### DIFF
--- a/cli/runner/runner.go
+++ b/cli/runner/runner.go
@@ -6,14 +6,22 @@ import (
 	"github.com/saucelabs/saucectl/cli/config"
 	"github.com/saucelabs/saucectl/cli/utils"
 	"github.com/saucelabs/saucectl/internal/fleet"
+	"os"
 )
 
 const logDir = "/var/log/cont"
 
 var homeDir, _ = utils.GetHomeDir()
 
+func getConfigYamlFile() string {
+	if (os.Getenv("SAUCE_VM") == "") {
+		return "config.yaml"
+	}
+	return "config-local.yaml"
+}
+
 // ConfigPath represents the path for the runner config.
-var ConfigPath = homeDir + "/" + utils.GetConfigFile()
+var ConfigPath = homeDir + "/" + getConfigYamlFile()
 
 // LogFiles contains the locations of log and resource files that are useful for reporting.
 var LogFiles = []string{

--- a/cli/runner/runner.go
+++ b/cli/runner/runner.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/cli/config"
+	"github.com/saucelabs/saucectl/cli/utils"
 	"github.com/saucelabs/saucectl/internal/fleet"
 )
 
 const logDir = "/var/log/cont"
 
+var homeDir, _ = utils.GetHomeDir()
+
 // ConfigPath represents the path for the runner config.
-var ConfigPath = "/home/seluser/config.yaml"
+var ConfigPath = homeDir + "/" + utils.GetConfigFile()
 
 // LogFiles contains the locations of log and resource files that are useful for reporting.
 var LogFiles = []string{
@@ -24,8 +27,8 @@ var LogFiles = []string{
 	logDir + "/wait-xvfb-stdout.log",
 	logDir + "/xvfb-tryouts-stderr.log",
 	logDir + "/xvfb-tryouts-stdout.log",
-	"/home/seluser/videos/video.mp4",
-	"/home/seluser/docker.log",
+	homeDir + "/videos/video.mp4",
+	homeDir + "/docker.log",
 }
 
 // Testrunner describes the test runner interface

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -43,3 +43,24 @@ func ValidateOutputPathFileMode(fileMode os.FileMode) error {
 	}
 	return nil
 }
+
+// GetHomeDir gets the home directory. If we're in CI, then it's the CWD, otherwise assume it's
+// /home/seluser
+func GetHomeDir() (string, error) {
+	if (os.Getenv("CI") == "") {
+		return "/home/seluser", nil
+	}
+	workingDir, err := os.Getwd()
+	if (err != nil) {
+		return "", err
+	}
+	return workingDir, nil
+}
+
+// GetConfigFile config yaml. If we're in CI, then it's config.yaml, otherwise it's config-local.yaml
+func GetConfigFile () string {
+	if (os.Getenv("CI") == "") {
+		return "config.yaml"
+	}
+	return "config-local.yaml"
+}

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -57,10 +57,3 @@ func GetHomeDir() (string, error) {
 	return workingDir, nil
 }
 
-// GetConfigFile config yaml. If we're in CI, then it's config.yaml, otherwise it's config-local.yaml
-func GetConfigFile () string {
-	if (os.Getenv("CI") == "") {
-		return "config.yaml"
-	}
-	return "config-local.yaml"
-}

--- a/internal/ci/ci_test.go
+++ b/internal/ci/ci_test.go
@@ -34,6 +34,13 @@ func TestAvailable(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "detect SKIP_CI",
+			envSetup: func() {
+				os.Setenv("SKIP_CI", "1")
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/ci/runner.go
+++ b/internal/ci/runner.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/saucelabs/saucectl/cli/utils"
 	"io"
 	"io/ioutil"
 	"os"
@@ -68,7 +69,8 @@ func (r *Runner) RunProject() (int, error) {
 func (r *Runner) setup(run config.Run) error {
 	log.Info().Msg("Run entry.sh")
 	var out bytes.Buffer
-	cmd := exec.Command("/home/seluser/entry.sh", "&")
+	var homeDir, _ = utils.GetHomeDir()
+	cmd := exec.Command(homeDir + "/entry.sh", "&")
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
 		return errors.New("couldn't start test: " + out.String())


### PR DESCRIPTION
## Proposed changes
We have `/home/seluser` hardcoded everywhere, which is fine if we're running inside a Docker container. If we're not running inside a docker container, that won't work (unless by coincidence we're in an environment where the users is `seluser`).

What this does is when the `CI` environment variable is set, we set the root directory as whatever the current working directory is. This is so that we can run `saucectl` in our Windows and macOS VM's (which don't have a root of `/home/seluser`)

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->