### PR TITLE
Log local time rather than UTC time

### DIFF
--- a/cmd/saucectl/saucectl.go
+++ b/cmd/saucectl/saucectl.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -51,7 +52,9 @@ func setupLogging(verbose bool) {
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
 
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	zerolog.TimestampFunc = func() time.Time {
+		return time.Now().In(time.Local)
+	}
 
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout})
 }


### PR DESCRIPTION
## Proposed changes
Log local time rather than UTC time. It makes more sense for a running-locally cmd.

Example:
```
3:10PM ERR failed to execute new command error=interrupt
```

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments