### PR TITLE
DEVX-311 add args to run by specified suite name

### DIFF
--- a/cli/command/new/templates.go
+++ b/cli/command/new/templates.go
@@ -5,16 +5,17 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
-	"github.com/google/go-github/v32/github"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
-	"github.com/tj/survey"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/google/go-github/v32/github"
+	"github.com/rs/zerolog/log"
+	"github.com/tj/survey"
 )
 
 var (
@@ -22,7 +23,7 @@ var (
 )
 
 func getReleaseArtifact(org string, repo string) (io.ReadCloser, error) {
-	ctx, _ := context.WithTimeout(context.Background(), 10 * time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 	ghClient := github.NewClient(nil)
 	release, _, err := ghClient.Repositories.GetLatestRelease(ctx, org, repo)
 	if err != nil {
@@ -97,7 +98,7 @@ func FetchAndExtractTemplate(org string, repo string) error {
 		return err
 	}
 	if artifactStream == nil {
-		return errors.Errorf("invalid download stream for tarball")
+		return errors.New("invalid download stream for tarball")
 	}
 
 	body, err := ioutil.ReadAll(artifactStream)

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -41,6 +42,7 @@ var (
 	parallel    bool
 	ciBuildID   string
 	sauceAPI    string
+	suiteName   string
 )
 
 // Command creates the `run` command
@@ -69,6 +71,7 @@ func Command(cli *command.SauceCtlCli) *cobra.Command {
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tests in parallel across multiple machines.")
 	cmd.Flags().StringVar(&ciBuildID, "ci-build-id", "", "Overrides the CI dependent build ID.")
 	cmd.Flags().StringVar(&sauceAPI, "sauce-api", "", "Overrides the region specific sauce API URL. (e.g. https://api.us-west-1.saucelabs.com)")
+	cmd.Flags().StringVar(&suiteName, "suite", "", "Run specified test suite.")
 
 	return cmd
 }
@@ -88,6 +91,11 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 	}
 
 	mergeArgs(cmd, &p)
+	if cmd.Flags().Lookup("suite").Changed {
+		if err := filterSuite(&p); err != nil {
+			return 1, err
+		}
+	}
 	p.Metadata.ExpandEnv()
 
 	if len(p.Suites) == 0 {
@@ -221,4 +229,19 @@ func enableCIProviders() {
 	github.Enable()
 	gitlab.Enable()
 	jenkins.Enable()
+}
+
+func filterSuite(c *config.Project) error {
+	found := false
+	for _, s := range c.Suites {
+		if s.Name == suiteName {
+			found = true
+			c.Suites = []config.Suite{s}
+			break
+		}
+	}
+	if !found {
+		return errors.New("suite name is invalid")
+	}
+	return nil
 }

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -232,16 +232,11 @@ func enableCIProviders() {
 }
 
 func filterSuite(c *config.Project) error {
-	found := false
 	for _, s := range c.Suites {
 		if s.Name == suiteName {
-			found = true
 			c.Suites = []config.Suite{s}
-			break
+			return nil
 		}
 	}
-	if !found {
-		return errors.New("suite name is invalid")
-	}
-	return nil
+	return errors.New("suite name is invalid")
 }

--- a/cli/command/run/cmd_test.go
+++ b/cli/command/run/cmd_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/saucelabs/saucectl/cli/command"
+	"github.com/saucelabs/saucectl/cli/runner"
 	"github.com/saucelabs/saucectl/internal/region"
+
 	"github.com/stretchr/testify/assert"
 	"gotest.tools/v3/fs"
 )
@@ -35,8 +37,8 @@ func TestNewRunCommand(t *testing.T) {
 		{
 			name:           "it doesn't filter suite when not required",
 			configFileName: `config.yaml`,
-			configFile:     "apiVersion: 1.2\nsuites:\n  - name: filtersuite\n  - name: suite2",
-			expResult:      0,
+			configFile:     "apiVersion: 1.2\nimage:\n  base: test",
+			expResult:      123,
 		},
 		{
 			name:           "it can filterout suite name",
@@ -62,6 +64,7 @@ func TestNewRunCommand(t *testing.T) {
 			cli := command.SauceCtlCli{}
 			cmd := Command(&cli)
 			assert.Equal(t, cmd.Use, runUse)
+			runner.ConfigPath = filepath.Join(dir.Path(), tc.configFileName)
 			if err := cmd.Flags().Set("config", filepath.Join(dir.Path(), tc.configFileName)); err != nil {
 				t.Fatal(err)
 			}
@@ -77,8 +80,9 @@ func TestNewRunCommand(t *testing.T) {
 				assert.False(t, tc.expErr)
 				assert.Equal(t, tc.expResult, code)
 			}
-			suiteName = ""
 			t.Cleanup(func() {
+				suiteName = ""
+				runner.ConfigPath = "/home/seluser/config.yaml"
 			})
 		})
 	}

--- a/cli/command/run/cmd_test.go
+++ b/cli/command/run/cmd_test.go
@@ -1,30 +1,87 @@
 package run
 
 import (
-	"github.com/saucelabs/saucectl/internal/region"
+	"path/filepath"
 	"testing"
 
 	"github.com/saucelabs/saucectl/cli/command"
+	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/stretchr/testify/assert"
 	"gotest.tools/v3/fs"
 )
 
 func TestNewRunCommand(t *testing.T) {
-	dir := fs.NewDir(t, "fixtures",
-		fs.WithFile("config.yaml", "apiVersion: 1.2\nimage:\n  base: test", fs.WithMode(0755)))
-	cli := command.SauceCtlCli{}
-	cmd := Command(&cli)
-	assert.Equal(t, cmd.Use, runUse)
-
-	if err := cmd.Flags().Set("config", dir.Path()+"/config.yaml"); err != nil {
-		t.Fatal(err)
+	testCases := []struct {
+		name           string
+		filter         string
+		configFileName string
+		configFile     string
+		expErr         bool
+		expResult      int
+	}{
+		{
+			name:           "it can run successfully",
+			configFileName: `config.yaml`,
+			configFile:     "apiVersion: 1.2\nimage:\n  base: test",
+			expResult:      123,
+		},
+		{
+			name:           "it failed to parse config",
+			configFileName: `config.yaml`,
+			configFile:     "===",
+			expErr:         true,
+			expResult:      1,
+		},
+		{
+			name:           "it doesn't filter suite when not required",
+			configFileName: `config.yaml`,
+			configFile:     "apiVersion: 1.2\nsuites:\n  - name: filtersuite\n  - name: suite2",
+			expResult:      0,
+		},
+		{
+			name:           "it can filterout suite name",
+			filter:         "filtersuite",
+			configFileName: `config.yaml`,
+			configFile:     "apiVersion: 1.2\nsuites:\n  - name: filtersuite\n  - name: suite2",
+			expResult:      0,
+		},
+		{
+			name:           "it failed with non-existed suite name",
+			filter:         "non_existed_name",
+			configFileName: `config.yaml`,
+			configFile:     "apiVersion: 1.2\nsuites:\n  - name: filtersuite\n  - name: suite2",
+			expErr:         true,
+			expResult:      1,
+		},
 	}
 
-	var args []string
-	exitCode, err := Run(cmd, &cli, args)
-
-	assert.Equal(t, err, nil)
-	assert.Equal(t, exitCode, 123)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := fs.NewDir(t, "fixtures",
+				fs.WithFile(tc.configFileName, tc.configFile, fs.WithMode(0755)))
+			cli := command.SauceCtlCli{}
+			cmd := Command(&cli)
+			assert.Equal(t, cmd.Use, runUse)
+			if err := cmd.Flags().Set("config", filepath.Join(dir.Path(), tc.configFileName)); err != nil {
+				t.Fatal(err)
+			}
+			suiteName = tc.filter
+			if tc.filter != "" {
+				cmd.Flags().Lookup("suite").Changed = true
+			}
+			var args []string
+			code, err := Run(cmd, &cli, args)
+			if err != nil {
+				assert.True(t, tc.expErr)
+			} else {
+				assert.False(t, tc.expErr)
+				assert.Equal(t, tc.expResult, code)
+			}
+			suiteName = ""
+			t.Cleanup(func() {
+			})
+		})
+	}
 }
 
 func Test_apiBaseURL(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
-	github.com/pkg/errors v0.8.1
 	github.com/rs/zerolog v1.18.0
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
+	github.com/pkg/errors v0.8.1
 	github.com/rs/zerolog v1.18.0
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.4.0


### PR DESCRIPTION
## Proposed changes
Add args to run by specified suite name. Given suite name, it will directly replace `Project.Suites` with the suite.

Run firefox suite
```
saucectl run --suite firefox
```
Run all suites
```
saucectl run
```
Run non-existed suite
```
saucectl run --suite 233
5:16PM ERR failed to execute run command error="suite name is invalid"
```
Run without args
```
saucectl run --suite
panic: flag needs an argument: --suite
```
## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments