### PR TITLE
feat: store SauceLabs authentication token

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ saucectl run
 ```
 This command will run the test based on the `./.sauce/config.yml` file.
 
+## The `configure` Command
+```sh
+saucectl configure
+```
+
+This command ask you to type-in your SauceLabs username and access key.
+
+You can also use the following command to do it in batch mode:
+
+```sh
+saucectl configure -u <MyUser> -a <MyAccessKey>
+```
+
+The credentials are store in `$HOME/.sauce/credentials.yml`
+
 ### Flags
 
 #### `config`

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/saucelabs/saucectl/cli/command"
+	"github.com/saucelabs/saucectl/cli/command/configure"
 	"github.com/saucelabs/saucectl/cli/command/new"
 	"github.com/saucelabs/saucectl/cli/command/run"
 	"github.com/spf13/cobra"
@@ -12,5 +13,6 @@ func AddCommands(cmd *cobra.Command, cli *command.SauceCtlCli) {
 	cmd.AddCommand(
 		new.Command(cli),
 		run.Command(cli),
+		configure.Command(cli),
 	)
 }

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -87,14 +87,15 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 
 	fileCreds := credentials.GetCredentialsFromFile()
 	envCreds := credentials.GetCredentialsFromEnv()
+	var creds credentials.Credentials
 
 	defaultUsername := fileCreds.Username
 	if defaultUsername == "" {
 		defaultUsername = envCreds.Username
 	}
 	usernameQuestion := &survey.Input{
-		Message: fmt.Sprintf("SauceLabs username [%s]:", defaultUsername),
-		Default: "",
+		Message: "SauceLabs username",
+		Default: defaultUsername,
 	}
 
 	defaultAccessKey := fileCreds.AccessKey
@@ -102,11 +103,20 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 		defaultAccessKey = envCreds.AccessKey
 	}
 	accessKeyQuestion := &survey.Input{
-		Message: fmt.Sprintf("SauceLabs access key [%s]:", defaultAccessKey),
-		Default: "",
+		Message: "SauceLabs access key",
+		Default: defaultAccessKey,
 	}
-	askNotEmpty(usernameQuestion, &fileCreds.Username)
-	askNotEmpty(accessKeyQuestion, &fileCreds.AccessKey)
+	askNotEmpty(usernameQuestion, &creds.Username)
+	askNotEmpty(accessKeyQuestion, &creds.AccessKey)
 
-	return fileCreds.Store()
+	if !creds.IsValid() {
+		fmt.Println("\nCredentials provided looks invalid. They won't be saved.")
+		return fmt.Errorf("invalid credentials")
+	}
+
+	if err := fileCreds.Store(); err != nil {
+		return fmt.Errorf("unable to save credentials")
+	}
+	fmt.Println("\n\nYou're all set ! ")
+	return nil
 }

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -62,11 +62,11 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 			Validate: func(val interface{}) error {
 				str, ok := val.(string)
 				if !ok {
-					return errors.New("invalid username. Get it here: https://app.saucelabs.com/user-settings")
+					return errors.New("invalid username. Check it here: https://app.saucelabs.com/user-settings")
 				}
 				str = strings.TrimSpace(str)
 				if len(str) < 1 {
-					return errors.New("you need to type a username. Get it here: https://app.saucelabs.com/user-settings")
+					return errors.New("you need to type a username. Get yours here: https://app.saucelabs.com/user-settings")
 
 				}
 				return nil
@@ -85,7 +85,7 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 				}
 				str = strings.TrimSpace(str)
 				if len(str) < 1 {
-					return errors.New("you need to type an access key. Check it here: https://app.saucelabs.com/user-settings")
+					return errors.New("you need to type an access key. Get yours here: https://app.saucelabs.com/user-settings")
 
 				}
 				return nil

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -65,7 +65,7 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 					return errors.New("invalid username. Check it here: https://app.saucelabs.com/user-settings")
 				}
 				str = strings.TrimSpace(str)
-				if len(str) < 1 {
+				if str == "" {
 					return errors.New("you need to type a username. Get yours here: https://app.saucelabs.com/user-settings")
 
 				}
@@ -84,7 +84,7 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 					return errors.New("invalid access key. Check it here: https://app.saucelabs.com/user-settings")
 				}
 				str = strings.TrimSpace(str)
-				if len(str) < 1 {
+				if str == "" {
 					return errors.New("you need to type an access key. Get yours here: https://app.saucelabs.com/user-settings")
 
 				}

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -85,6 +85,6 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 		Default: "",
 	}
 	askNotEmpty(accessKeyQuestion, &creds.AccessKey)
-	return credentials.StoreCredentials(creds)
+	return creds.Store()
 
 }

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -62,11 +62,11 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 			Validate: func(val interface{}) error {
 				str, ok := val.(string)
 				if !ok {
-					return errors.New("invalid username. Check it here: https://app.saucelabs.com/user-settings")
+					return errors.New("invalid username. Get it here: https://app.saucelabs.com/user-settings")
 				}
 				str = strings.TrimSpace(str)
 				if len(str) < 1 {
-					return errors.New("you need to type a username")
+					return errors.New("you need to type a username. Get it here: https://app.saucelabs.com/user-settings")
 
 				}
 				return nil
@@ -85,7 +85,7 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 				}
 				str = strings.TrimSpace(str)
 				if len(str) < 1 {
-					return errors.New("you need to type an access key")
+					return errors.New("you need to type an access key. Check it here: https://app.saucelabs.com/user-settings")
 
 				}
 				return nil

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -62,7 +62,7 @@ func askNotEmpty(prompt survey.Prompt, dest *string) error {
 // explainHowToObtainCredentials explains how to get credentials
 func explainHowToObtainCredentials() {
 	fmt.Println("\nDon't have an account ? Signup here https://saucelabs.com/sign-up !")
-	fmt.Println("Already have an account ? Get your username and access key here: https://app.saucelabs.com/user-settings\n\n")
+	fmt.Printf("Already have an account ? Get your username and access key here: https://app.saucelabs.com/user-settings\n\n\n")
 }
 
 // interactiveConfiguration expect user to manually type-in its credentials
@@ -81,7 +81,7 @@ func interactiveConfiguration() credentials.Credentials {
 	askNotEmpty(usernameQuestion, &creds.Username)
 	askNotEmpty(accessKeyQuestion, &creds.AccessKey)
 
-	fmt.Println("\n")
+	fmt.Printf("\n\n")
 	return creds
 }
 

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tj/survey"
 	"os"
-	"regexp"
+	"strings"
 )
 
 var (
@@ -62,11 +62,12 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 			Validate: func(val interface{}) error {
 				str, ok := val.(string)
 				if !ok {
-					return errors.New("invalid input")
-				}
-				re := regexp.MustCompile(`^[a-zA-Z0-9_\-\.\+]{2,70}$`)
-				if !re.MatchString(str) {
 					return errors.New("invalid username. Check it here: https://app.saucelabs.com/user-settings")
+				}
+				str = strings.TrimSpace(str)
+				if len(str) < 1 {
+					return errors.New("you need to type a username")
+
 				}
 				return nil
 			},
@@ -80,11 +81,12 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 			Validate: func(val interface{}) error {
 				str, ok := val.(string)
 				if !ok {
-					return errors.New("invalid input")
-				}
-				re := regexp.MustCompile(`^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$`)
-				if !re.MatchString(str) {
 					return errors.New("invalid access key. Check it here: https://app.saucelabs.com/user-settings")
+				}
+				str = strings.TrimSpace(str)
+				if len(str) < 1 {
+					return errors.New("you need to type an access key")
+
 				}
 				return nil
 			},

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -123,7 +123,7 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 		return nil
 	}
 	if err := creds.Store(); err != nil {
-		return fmt.Errorf("unable to save credentials")
+		return fmt.Errorf("unable to save credentials: %s", err)
 	}
 	fmt.Println("You're all set ! ")
 	return nil

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -99,7 +99,7 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 	return creds, nil
 }
 
-// Run starts the new command
+// Run starts the configure command
 func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 	var creds *credentials.Credentials
 	var err error = nil

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -71,20 +71,42 @@ func askNotEmpty(prompt survey.Prompt, dest *string) error {
 	return nil
 }
 
+// Explain why do this
+func explainHowToObtainCredentials() {
+	fmt.Printf(`
+Don't have an account ? Signup here https://saucelabs.com/sign-up !
+Already have an account ? Get your username and access key here: https://app.saucelabs.com/user-settings
+
+
+`)
+}
+
 // Run starts the new command
 func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
-	creds := credentials.GetCredentialsFromConfig()
+	explainHowToObtainCredentials()
+
+	fileCreds := credentials.GetCredentialsFromFile()
+	envCreds := credentials.GetCredentialsFromEnv()
+
+	defaultUsername := fileCreds.Username
+	if defaultUsername == "" {
+		defaultUsername = envCreds.Username
+	}
 	usernameQuestion := &survey.Input{
-		Message: fmt.Sprintf("SauceLabs username [%s]:", creds.Username),
+		Message: fmt.Sprintf("SauceLabs username [%s]:", defaultUsername),
 		Default: "",
 	}
-	askNotEmpty(usernameQuestion, &creds.Username)
 
+	defaultAccessKey := fileCreds.AccessKey
+	if defaultAccessKey == "" {
+		defaultAccessKey = envCreds.AccessKey
+	}
 	accessKeyQuestion := &survey.Input{
-		Message: fmt.Sprintf("SauceLabs access key [%s]:", creds.AccessKey),
+		Message: fmt.Sprintf("SauceLabs access key [%s]:", defaultAccessKey),
 		Default: "",
 	}
-	askNotEmpty(accessKeyQuestion, &creds.AccessKey)
-	return creds.Store()
+	askNotEmpty(usernameQuestion, &fileCreds.Username)
+	askNotEmpty(accessKeyQuestion, &fileCreds.AccessKey)
 
+	return fileCreds.Store()
 }

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -21,7 +21,7 @@ var (
 	cliAccessKey     = ""
 )
 
-// Command creates the `new` command
+// Command creates the `configure` command
 func Command(cli *command.SauceCtlCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     configureUse,
@@ -66,7 +66,7 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 				}
 				re := regexp.MustCompile(`^[a-zA-Z0-9_\-\.\+]{2,70}$`)
 				if !re.MatchString(str) {
-					return errors.New("invalid username format")
+					return errors.New("invalid username. Check it here: https://app.saucelabs.com/user-settings")
 				}
 				return nil
 			},
@@ -84,7 +84,7 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 				}
 				re := regexp.MustCompile(`^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$`)
 				if !re.MatchString(str) {
-					return errors.New("invalid access key format")
+					return errors.New("invalid access key. Check it here: https://app.saucelabs.com/user-settings")
 				}
 				return nil
 			},

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -39,6 +39,7 @@ func Command(cli *command.SauceCtlCli) *cobra.Command {
 	return cmd
 }
 
+// askNotEmpty asks the user to type in a value.
 func askNotEmpty(prompt survey.Prompt, dest *string) error {
 	prev := *dest
 	for {
@@ -58,16 +59,13 @@ func askNotEmpty(prompt survey.Prompt, dest *string) error {
 	return nil
 }
 
-// Explain why do this
+// explainHowToObtainCredentials explains how to get credentials
 func explainHowToObtainCredentials() {
-	fmt.Printf(`
-Don't have an account ? Signup here https://saucelabs.com/sign-up !
-Already have an account ? Get your username and access key here: https://app.saucelabs.com/user-settings
-
-
-`)
+	fmt.Println("\nDon't have an account ? Signup here https://saucelabs.com/sign-up !")
+	fmt.Println("Already have an account ? Get your username and access key here: https://app.saucelabs.com/user-settings\n\n")
 }
 
+// interactiveConfiguration expect user to manually type-in its credentials
 func interactiveConfiguration() credentials.Credentials {
 	explainHowToObtainCredentials()
 	creds := getDefaultCredentials()
@@ -86,6 +84,7 @@ func interactiveConfiguration() credentials.Credentials {
 	fmt.Println("\n")
 	return creds
 }
+
 // Run starts the new command
 func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 	var creds credentials.Credentials
@@ -100,8 +99,8 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 	}
 
 	if !creds.IsValid() {
-		fmt.Println("Credentials provided looks invalid. They won't be saved.")
-		return fmt.Errorf("invalid credentials")
+		fmt.Println("Credentials provided looks invalid and won't be saved.")
+		return nil
 	}
 	if err := creds.Store(); err != nil {
 		return fmt.Errorf("unable to save credentials")

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -36,7 +36,7 @@ func Command(cli *command.SauceCtlCli) *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVarP(&cliUsername, "username", "u", "", "username,, available on your saucelabs account")
+	cmd.Flags().StringVarP(&cliUsername, "username", "u", "", "username, available on your saucelabs account")
 	cmd.Flags().StringVarP(&cliAccessKey, "accessKey", "a", "", "accessKey, available on your saucelabs account")
 	return cmd
 }

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -131,12 +131,12 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 
 // getDefaultCredentials returns first the file credentials, then the one founded in the env.
 func getDefaultCredentials() *credentials.Credentials {
-	fileCreds := credentials.GetCredentialsFromFile()
+	fileCreds := credentials.FromFile()
 	if fileCreds != nil {
 		return fileCreds
 	}
 
-	envCreds := credentials.GetCredentialsFromEnv()
+	envCreds := credentials.FromEnv()
 	if envCreds != nil {
 		return envCreds
 	}

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -1,0 +1,90 @@
+package configure
+
+import (
+	"fmt"
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/cli/command"
+	"github.com/saucelabs/saucectl/cli/credentials"
+	"github.com/spf13/cobra"
+	"github.com/tj/survey"
+	"os"
+)
+
+var (
+	configureUse     = "configure"
+	configureShort   = "Configure your Sauce Labs credentials"
+	configureLong    = `Persist locally your Sauce Labs credentials`
+	configureExample = "saucectl configure"
+
+	qs = []*survey.Question{
+		{
+			Name: "username",
+			Prompt: &survey.Input{
+				Message: "SauceLabs username:",
+				Default: "",
+			},
+		},
+		{
+			Name: "accessKey",
+			Prompt: &survey.Input{
+				Message: "SauceLabs access key:",
+				Default: "",
+			},
+		},
+	}
+)
+
+// Command creates the `new` command
+func Command(cli *command.SauceCtlCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     configureUse,
+		Short:   configureShort,
+		Long:    configureLong,
+		Example: configureExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Info().Msg("Start Configure Command")
+			if err := Run(cmd, cli, args); err != nil {
+				log.Err(err).Msg("failed to execute configure command")
+				os.Exit(1)
+			}
+		},
+	}
+	return cmd
+}
+
+func askNotEmpty(prompt survey.Prompt, dest *string) error {
+	prev := *dest
+	for {
+		// Add validator for format
+		err := survey.AskOne(prompt, dest, nil)
+		if err != nil {
+			return err
+		}
+		// Keep old input
+		if *dest == "" {
+			*dest = prev
+		}
+		if *dest != "" {
+			break
+		}
+	}
+	return nil
+}
+
+// Run starts the new command
+func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
+	creds := credentials.GetCredentials()
+	usernameQuestion := &survey.Input{
+		Message: fmt.Sprintf("SauceLabs username [%s]:", creds.Username),
+		Default: "",
+	}
+	askNotEmpty(usernameQuestion, &creds.Username)
+
+	accessKeyQuestion := &survey.Input{
+		Message: fmt.Sprintf("SauceLabs access key [%s]:", creds.AccessKey),
+		Default: "",
+	}
+	askNotEmpty(accessKeyQuestion, &creds.AccessKey)
+	return credentials.StoreCredentials(creds)
+
+}

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -87,21 +87,24 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 
 	fileCreds := credentials.GetCredentialsFromFile()
 	envCreds := credentials.GetCredentialsFromEnv()
-	var creds credentials.Credentials
 
 	defaultUsername := fileCreds.Username
 	if defaultUsername == "" {
 		defaultUsername = envCreds.Username
+	}
+	defaultAccessKey := fileCreds.AccessKey
+	if defaultAccessKey == "" {
+		defaultAccessKey = envCreds.AccessKey
+	}
+	creds := credentials.Credentials{
+		AccessKey: defaultAccessKey,
+		Username: defaultUsername,
 	}
 	usernameQuestion := &survey.Input{
 		Message: "SauceLabs username",
 		Default: defaultUsername,
 	}
 
-	defaultAccessKey := fileCreds.AccessKey
-	if defaultAccessKey == "" {
-		defaultAccessKey = envCreds.AccessKey
-	}
 	accessKeyQuestion := &survey.Input{
 		Message: "SauceLabs access key",
 		Default: defaultAccessKey,

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -73,7 +73,7 @@ func askNotEmpty(prompt survey.Prompt, dest *string) error {
 
 // Run starts the new command
 func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
-	creds := credentials.GetCredentials()
+	creds := credentials.GetCredentialsFromConfig()
 	usernameQuestion := &survey.Input{
 		Message: fmt.Sprintf("SauceLabs username [%s]:", creds.Username),
 		Default: "",

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -64,7 +64,7 @@ func interactiveConfiguration() (*credentials.Credentials, error) {
 				if !ok {
 					return errors.New("invalid input")
 				}
-				re := regexp.MustCompile(`^([a-zA-Z0-9-.]{3,})$`)
+				re := regexp.MustCompile(`^[a-zA-Z0-9_\-\.\+]{2,70}$`)
 				if !re.MatchString(str) {
 					return errors.New("invalid username format")
 				}

--- a/cli/command/new/cmd.go
+++ b/cli/command/new/cmd.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/cli/config"
+	"github.com/saucelabs/saucectl/cli/credentials"
 	"github.com/saucelabs/saucectl/internal/yaml"
 	"github.com/spf13/cobra"
 	"github.com/tj/survey"
@@ -112,6 +113,11 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 	}
 
 	fmt.Println("\nNew project bootstrapped successfully! You can now run:\n$ saucectl run")
+
+	creds := credentials.GetCredentials()
+	if !creds.LooksValid() {
+		fmt.Println("\nIt looks you have not configured your SauceLab account !\nTo enjoy SauceLabs capabilities, configure your account by running:\n$ saucectl configure")
+	}
 	return nil
 }
 

--- a/cli/command/new/cmd.go
+++ b/cli/command/new/cmd.go
@@ -114,8 +114,8 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 
 	fmt.Println("\nNew project bootstrapped successfully! You can now run:\n$ saucectl run")
 
-	creds := credentials.GetCredentials()
-	if creds.IsEmpty() {
+	creds := credentials.Get()
+	if creds == nil {
 		fmt.Println("\nIt looks you have not configured your SauceLab account !\nTo enjoy SauceLabs capabilities, configure your account by running:\n$ saucectl configure")
 	}
 	return nil

--- a/cli/command/new/cmd.go
+++ b/cli/command/new/cmd.go
@@ -115,7 +115,7 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 	fmt.Println("\nNew project bootstrapped successfully! You can now run:\n$ saucectl run")
 
 	creds := credentials.GetCredentials()
-	if !creds.LooksValid() {
+	if creds.IsEmpty() {
 		fmt.Println("\nIt looks you have not configured your SauceLab account !\nTo enjoy SauceLabs capabilities, configure your account by running:\n$ saucectl configure")
 	}
 	return nil

--- a/cli/command/new/templates_test.go
+++ b/cli/command/new/templates_test.go
@@ -90,7 +90,7 @@ func TestGetReleaseArtifact(t *testing.T) {
 		},
 	}
 
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/fake-org/fake-repo/releases/latest",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-repo/releases/latest",
 		func(req *http.Request) (*http.Response, error) {
 			resp, err := httpmock.NewJsonResponse(200, validRelease)
 			if err != nil {
@@ -100,19 +100,19 @@ func TestGetReleaseArtifact(t *testing.T) {
 		},
 	)
 
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/fake-org/fake-repo/releases/assets/1",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-repo/releases/assets/1",
 		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewBytesResponse(200, createTemplateTar().Bytes()), nil
 		},
 	)
 
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/fake-org/fake-repo/releases/assets/2",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-repo/releases/assets/2",
 		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewBytesResponse(200, createTemplateTar().Bytes()), nil
 		},
 	)
 
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/fake-org/fake-buggy-repo/releases/latest",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-buggy-repo/releases/latest",
 		func(req *http.Request) (*http.Response, error) {
 			resp, err := httpmock.NewJsonResponse(200, invalidRelease)
 			if err != nil {
@@ -164,7 +164,7 @@ func TestFetchAndExtractTemplate(t *testing.T) {
 			},
 		},
 	}
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/fake-org/fake-repo/releases/latest",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-repo/releases/latest",
 		func(req *http.Request) (*http.Response, error) {
 			resp, err := httpmock.NewJsonResponse(200, validRelease)
 			if err != nil {
@@ -174,7 +174,7 @@ func TestFetchAndExtractTemplate(t *testing.T) {
 		},
 	)
 
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/fake-org/fake-repo/releases/assets/1",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-repo/releases/assets/1",
 		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewBytesResponse(200, createTemplateTar().Bytes()), nil
 		},
@@ -204,7 +204,7 @@ func TestFetchAndExtractTemplateTimeoutingConnection(t *testing.T) {
 			},
 		},
 	}
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/fake-org/fake-repo/releases/latest",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-repo/releases/latest",
 		func(req *http.Request) (*http.Response, error) {
 			resp, err := httpmock.NewJsonResponse(200, validRelease)
 			if err != nil {
@@ -214,7 +214,7 @@ func TestFetchAndExtractTemplateTimeoutingConnection(t *testing.T) {
 		},
 	)
 
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/fake-org/fake-repo/releases/assets/1",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-repo/releases/assets/1",
 		func(req *http.Request) (*http.Response, error) {
 			time.Sleep(15 * time.Second)
 			return httpmock.NewBytesResponse(200, createTemplateTar().Bytes()), nil

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -153,7 +153,7 @@ func createCISequencer(p config.Project, cip ci.Provider) fleet.Sequencer {
 			"https://github.com/saucelabs/saucectl on how to configure parallelization across machines.")
 		return &memseq.Sequencer{}
 	}
-	creds := credentials.GetCredentials()
+	creds := credentials.Get()
 	if creds == nil {
 		log.Info().Msg("No valid credentials provided. Running tests sequentially.")
 		return &memseq.Sequencer{}

--- a/cli/credentials/credentials.go
+++ b/cli/credentials/credentials.go
@@ -1,0 +1,72 @@
+package credentials
+
+import (
+	"fmt"
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/yaml"
+	yamlbase "gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// Credentials contains a set of Username + AccessKey for SauceLabs.
+type Credentials struct {
+	Username  string `yaml:"username"`
+	AccessKey string `yaml:"accessKey"`
+}
+
+// GetCredentials returns the currently configured credentials (env is prioritary vs. file).
+func GetCredentials() Credentials {
+	if os.Getenv("SAUCE_USERNAME") != "" && os.Getenv("SAUCE_ACCESS_KEY") != "" {
+		return Credentials{
+			Username:  os.Getenv("SAUCE_USERNAME"),
+			AccessKey: os.Getenv("SAUCE_ACCESS_KEY"),
+		}
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Warn().Msgf("Unable to locate configuration folder")
+		return Credentials{}
+	}
+
+	err = os.MkdirAll(filepath.Join(homeDir, ".sauce"), 0700)
+	if err != nil {
+		log.Warn().Msgf("Unable to create configuration folder")
+		return Credentials{}
+	}
+
+	return credentialsFromFile(filepath.Join(homeDir, ".sauce", "config.yml"))
+}
+
+// StoreCredentials stores the provided credentials into the user config.
+func StoreCredentials(credentials Credentials) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("unable to locate home folder")
+	}
+
+	err = os.MkdirAll(filepath.Join(homeDir, ".sauce"), 0700)
+	if err != nil {
+		return fmt.Errorf("unable to create configuration folder")
+	}
+	fmt.Printf("%s / %s\n", credentials.Username, credentials.AccessKey)
+	return yaml.WriteFile(filepath.Join(homeDir, ".sauce", "config.yml"), credentials)
+}
+
+func credentialsFromFile(credentialsFilePath string) Credentials {
+	var c Credentials
+
+	yamlFile, err := ioutil.ReadFile(credentialsFilePath)
+	if err != nil {
+		log.Info().Msgf("failed to locate credentials: %v", err)
+		return Credentials{}
+	}
+
+	if err = yamlbase.Unmarshal(yamlFile, &c); err != nil {
+		log.Info().Msgf("failed to parse credentials: %v", err)
+		return Credentials{}
+	}
+	return c
+}

--- a/cli/credentials/credentials.go
+++ b/cli/credentials/credentials.go
@@ -121,7 +121,7 @@ func (credentials *Credentials) IsValid() bool {
 	}
 	httpClient := http.Client{}
 	ctx, _ := context.WithTimeout(context.Background(), 5 * time.Second)
-	req, err := http.NewRequestWithContext(ctx, "GET", "https://saucelabs.com/rest/v1/users/" + credentials.Username, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://saucelabs.com/rest/v1/users/" + credentials.Username, nil)
 	if err != nil {
 		log.Error().Msgf("unable to check credentials")
 		return false

--- a/cli/credentials/credentials.go
+++ b/cli/credentials/credentials.go
@@ -18,11 +18,9 @@ type Credentials struct {
 
 // GetCredentials returns the currently configured credentials (env is prioritary vs. file).
 func GetCredentials() Credentials {
-	if os.Getenv("SAUCE_USERNAME") != "" && os.Getenv("SAUCE_ACCESS_KEY") != "" {
-		return Credentials{
-			Username:  os.Getenv("SAUCE_USERNAME"),
-			AccessKey: os.Getenv("SAUCE_ACCESS_KEY"),
-		}
+	envCredentials := GetCredentialsFromEnv()
+	if envCredentials.LooksValid() {
+		return envCredentials
 	}
 
 	configDir := getCredentialsFolderPath()
@@ -31,11 +29,20 @@ func GetCredentials() Credentials {
 		log.Warn().Msgf("Unable to create configuration folder")
 		return Credentials{}
 	}
-	return GetCredentialsFromConfig()
+	return GetCredentialsFromFile()
 }
 
-// GetCredentialsFromConfig reads the credentials from the user config.
-func GetCredentialsFromConfig() Credentials {
+
+// GetCredentialsFromFile reads the credentials from the user credentials file.
+func GetCredentialsFromEnv() Credentials {
+	return Credentials{
+		Username:  os.Getenv("SAUCE_USERNAME"),
+		AccessKey: os.Getenv("SAUCE_ACCESS_KEY"),
+	}
+}
+
+// GetCredentialsFromFile reads the credentials from the user credentials file.
+func GetCredentialsFromFile() Credentials {
 	var c Credentials
 
 	yamlFile, err := ioutil.ReadFile(getCredentialsFilePath())

--- a/cli/credentials/credentials.go
+++ b/cli/credentials/credentials.go
@@ -25,7 +25,7 @@ func GetCredentials() Credentials {
 		}
 	}
 
-	configDir := getConfigFolderPath()
+	configDir := getCredentialsFolderPath()
 	err := os.MkdirAll(configDir, 0700)
 	if err != nil {
 		log.Warn().Msgf("Unable to create configuration folder")
@@ -36,19 +36,19 @@ func GetCredentials() Credentials {
 
 // StoreCredentials stores the provided credentials into the user config.
 func StoreCredentials(credentials Credentials) error {
-	err := os.MkdirAll(getConfigFolderPath(), 0700)
+	err := os.MkdirAll(getCredentialsFolderPath(), 0700)
 	if err != nil {
 		return fmt.Errorf("unable to create configuration folder")
 	}
 	fmt.Printf("%s / %s\n", credentials.Username, credentials.AccessKey)
-	return yaml.WriteFile(getConfigFilePath(), credentials)
+	return yaml.WriteFile(getCredentialsFilePath(), credentials)
 }
 
 // GetCredentialsFromConfig reads the credentials from the user config.
 func GetCredentialsFromConfig() Credentials {
 	var c Credentials
 
-	yamlFile, err := ioutil.ReadFile(getConfigFilePath())
+	yamlFile, err := ioutil.ReadFile(getCredentialsFilePath())
 	if err != nil {
 		log.Info().Msgf("failed to locate credentials: %v", err)
 		return Credentials{}
@@ -61,7 +61,7 @@ func GetCredentialsFromConfig() Credentials {
 	return c
 }
 
-func getConfigFolderPath() string {
+func getCredentialsFolderPath() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		homeDir = "/"
@@ -70,7 +70,7 @@ func getConfigFolderPath() string {
 	return homeDir
 }
 
-func getConfigFilePath() string {
-	homeDir := getConfigFolderPath()
-	return filepath.Join(homeDir, ".sauce", "config.yml")
+func getCredentialsFilePath() string {
+	homeDir := getCredentialsFolderPath()
+	return filepath.Join(homeDir, ".sauce", "credentials.yml")
 }

--- a/cli/credentials/credentials.go
+++ b/cli/credentials/credentials.go
@@ -36,7 +36,7 @@ func GetCredentials() Credentials {
 }
 
 
-// GetCredentialsFromFile reads the credentials from the user credentials file.
+// GetCredentialsFromEnv reads the credentials from the user environment.
 func GetCredentialsFromEnv() Credentials {
 	return Credentials{
 		Username:  os.Getenv("SAUCE_USERNAME"),

--- a/cli/credentials/credentials.go
+++ b/cli/credentials/credentials.go
@@ -34,16 +34,6 @@ func GetCredentials() Credentials {
 	return GetCredentialsFromConfig()
 }
 
-// StoreCredentials stores the provided credentials into the user config.
-func StoreCredentials(credentials Credentials) error {
-	err := os.MkdirAll(getCredentialsFolderPath(), 0700)
-	if err != nil {
-		return fmt.Errorf("unable to create configuration folder")
-	}
-	fmt.Printf("%s / %s\n", credentials.Username, credentials.AccessKey)
-	return yaml.WriteFile(getCredentialsFilePath(), credentials)
-}
-
 // GetCredentialsFromConfig reads the credentials from the user config.
 func GetCredentialsFromConfig() Credentials {
 	var c Credentials
@@ -73,4 +63,18 @@ func getCredentialsFolderPath() string {
 func getCredentialsFilePath() string {
 	homeDir := getCredentialsFolderPath()
 	return filepath.Join(homeDir, ".sauce", "credentials.yml")
+}
+
+// Store stores the provided credentials into the user config.
+func (credentials *Credentials) Store() error {
+	err := os.MkdirAll(getCredentialsFolderPath(), 0700)
+	if err != nil {
+		return fmt.Errorf("unable to create configuration folder")
+	}
+	return yaml.WriteFile(getCredentialsFilePath(), credentials)
+}
+
+// LooksValid validates that the credentials looks valid.
+func (credentials *Credentials) LooksValid() bool {
+	return credentials.AccessKey != "" && credentials.Username != ""
 }

--- a/cli/credentials/credentials.go
+++ b/cli/credentials/credentials.go
@@ -72,7 +72,8 @@ func getCredentialsFolderPath() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		if "windows" == runtime.GOOS {
-			homeDir = filepath.VolumeName(".")+"\\"
+			systemDir := os.Getenv("SystemRoot")
+			homeDir = filepath.VolumeName(systemDir)+"\\"
 		} else {
 			homeDir = "/"
 		}

--- a/cli/credentials/credentials.go
+++ b/cli/credentials/credentials.go
@@ -73,12 +73,12 @@ func getCredentialsFolderPath() string {
 		homeDir = "/"
 		log.Warn().Msgf("unable to locate home folder")
 	}
-	return homeDir
+	return filepath.Join(homeDir, ".sauce")
 }
 
 func getCredentialsFilePath() string {
-	homeDir := getCredentialsFolderPath()
-	return filepath.Join(homeDir, ".sauce", "credentials.yml")
+	credentialsDir := getCredentialsFolderPath()
+	return filepath.Join(credentialsDir, "credentials.yml")
 }
 
 // Store stores the provided credentials into the user config.

--- a/cli/credentials/credentials.go
+++ b/cli/credentials/credentials.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 )
 
@@ -70,7 +71,11 @@ func GetCredentialsFromFile() *Credentials {
 func getCredentialsFolderPath() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		homeDir = "/"
+		if "windows" == runtime.GOOS {
+			homeDir = filepath.VolumeName(".")+"\\"
+		} else {
+			homeDir = "/"
+		}
 		log.Warn().Msgf("unable to locate home folder")
 	}
 	return filepath.Join(homeDir, ".sauce")

--- a/cli/credentials/credentials.go
+++ b/cli/credentials/credentials.go
@@ -81,7 +81,7 @@ func (credentials *Credentials) Store() error {
 	if err != nil {
 		return fmt.Errorf("unable to create configuration folder")
 	}
-	return yaml.WriteFile(getCredentialsFilePath(), credentials)
+	return yaml.WriteFileWithFileMode(getCredentialsFilePath(), credentials, 0600)
 }
 
 // IsEmpty ensure credentials are not set

--- a/cli/credentials/credentials_test.go
+++ b/cli/credentials/credentials_test.go
@@ -1,0 +1,130 @@
+package credentials
+
+import (
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestEnvPrioritary(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	defer func() {
+		os.Remove(getCredentialsFilePath())
+	}()
+
+	// Prepare to restore home var
+	userprofile := os.Getenv("USERPROFILE")
+	home := os.Getenv("HOME")
+	defer func() {
+		os.Setenv("USERPROFILE", userprofile)
+		os.Setenv("HOME", home)
+	}()
+
+	// Override Home
+	os.Setenv("USERPROFILE", "C:\\non-existent")
+	os.Setenv("HOME", "/tmp/non-existent")
+
+	os.Unsetenv("SAUCE_USERNAME")
+	os.Unsetenv("SAUCE_ACCESS_KEY")
+
+	// To avoid conflict with real file
+	httpmock.RegisterResponder("GET", "https://saucelabs.com/rest/v1/users/envUsername", httpmock.NewStringResponder(200, ""))
+	httpmock.RegisterResponder("GET", "https://saucelabs.com/rest/v1/users/fileUsername", httpmock.NewStringResponder(200, ""))
+
+	// Test No file No env
+	envCreds := GetCredentialsFromEnv()
+	fileCreds := GetCredentialsFromFile()
+	overallCreds := GetCredentials()
+	assert.Nil(t, envCreds)
+	assert.Nil(t, fileCreds)
+	assert.Nil(t, overallCreds)
+
+	// Test Only env
+	os.Setenv("SAUCE_USERNAME", "envUsername")
+	os.Setenv("SAUCE_ACCESS_KEY", "envAccessKey")
+	envCreds = GetCredentialsFromEnv()
+	fileCreds = GetCredentialsFromFile()
+	overallCreds = GetCredentials()
+	assert.Nil(t, fileCreds)
+	assert.NotNil(t, envCreds)
+	assert.NotNil(t, overallCreds)
+	assert.Equal(t, envCreds.Username, "envUsername")
+	assert.Equal(t, envCreds.AccessKey, "envAccessKey")
+	assert.Equal(t, overallCreds.Username, "envUsername")
+	assert.Equal(t, overallCreds.AccessKey, "envAccessKey")
+
+
+	wd, _ := os.Getwd()
+	os.Setenv("USERPROFILE", wd)
+	os.Setenv("HOME", wd)
+	toSaveCreds := Credentials{
+		Username: "fileUsername",
+		AccessKey: "fileAccessKey",
+	}
+	err := toSaveCreds.Store()
+	assert.Nil(t, err)
+
+	// Test File & Env
+	envCreds = GetCredentialsFromEnv()
+	fileCreds = GetCredentialsFromFile()
+	overallCreds = GetCredentials()
+	assert.NotNil(t, fileCreds)
+	assert.NotNil(t, envCreds)
+	assert.NotNil(t, overallCreds)
+
+	assert.Equal(t, envCreds.Username, "envUsername")
+	assert.Equal(t, envCreds.AccessKey, "envAccessKey")
+	assert.Equal(t, fileCreds.Username, "fileUsername")
+	assert.Equal(t, fileCreds.AccessKey, "fileAccessKey")
+	assert.Equal(t, overallCreds.Username, "envUsername")
+	assert.Equal(t, overallCreds.AccessKey, "envAccessKey")
+
+	// Test Only file
+	os.Unsetenv("SAUCE_USERNAME")
+	os.Unsetenv("SAUCE_ACCESS_KEY")
+	envCreds = GetCredentialsFromEnv()
+	fileCreds = GetCredentialsFromFile()
+	overallCreds = GetCredentials()
+	assert.NotNil(t, fileCreds)
+	assert.Nil(t, envCreds)
+	assert.NotNil(t, overallCreds)
+
+	assert.Equal(t, fileCreds.Username, "fileUsername")
+	assert.Equal(t, fileCreds.AccessKey, "fileAccessKey")
+	assert.Equal(t, overallCreds.Username, "fileUsername")
+	assert.Equal(t, overallCreds.AccessKey, "fileAccessKey")
+}
+
+func TestCredentials_IsValid(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	defer func() {
+		os.Unsetenv("SAUCE_USERNAME")
+		os.Unsetenv("SAUCE_ACCESS_KEY")
+	}()
+
+	// Prepare to restore home var
+	userprofile := os.Getenv("USERPROFILE")
+	home := os.Getenv("HOME")
+	defer func() {
+		os.Setenv("USERPROFILE", userprofile)
+		os.Setenv("HOME", home)
+	}()
+	os.Setenv("USERPROFILE", "C:\\non-existent")
+	os.Setenv("HOME", "/tmp/non-existent")
+
+	httpmock.RegisterResponder("GET", "https://saucelabs.com/rest/v1/users/validUser", httpmock.NewStringResponder(200, ""))
+	httpmock.RegisterResponder("GET", "https://saucelabs.com/rest/v1/users/invalidUser", httpmock.NewStringResponder(401, ""))
+
+	os.Setenv("SAUCE_USERNAME", "validUser")
+	os.Setenv("SAUCE_ACCESS_KEY", "validAccessKey")
+	envCreds := GetCredentials()
+	assert.NotNil(t, envCreds)
+
+	os.Setenv("SAUCE_USERNAME", "invalidUser")
+	os.Setenv("SAUCE_ACCESS_KEY", "invalidAccessKey")
+	envCreds = GetCredentials()
+	assert.Nil(t, envCreds)
+}

--- a/cli/credentials/credentials_test.go
+++ b/cli/credentials/credentials_test.go
@@ -3,6 +3,7 @@ package credentials
 import (
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"net/http"
 	"os"
 	"testing"
 )
@@ -31,8 +32,8 @@ func TestEnvPrioritary(t *testing.T) {
 	os.Unsetenv("SAUCE_ACCESS_KEY")
 
 	// To avoid conflict with real file
-	httpmock.RegisterResponder("GET", "https://saucelabs.com/rest/v1/users/envUsername", httpmock.NewStringResponder(200, ""))
-	httpmock.RegisterResponder("GET", "https://saucelabs.com/rest/v1/users/fileUsername", httpmock.NewStringResponder(200, ""))
+	httpmock.RegisterResponder(http.MethodGet, "https://saucelabs.com/rest/v1/users/envUsername", httpmock.NewStringResponder(200, ""))
+	httpmock.RegisterResponder(http.MethodGet, "https://saucelabs.com/rest/v1/users/fileUsername", httpmock.NewStringResponder(200, ""))
 
 	// Test No file No env
 	envCreds := FromEnv()
@@ -102,14 +103,14 @@ func TestCredentials_IsValid(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder("GET", "https://saucelabs.com/rest/v1/users/validUser", httpmock.NewStringResponder(200, ""))
+	httpmock.RegisterResponder(http.MethodGet, "https://saucelabs.com/rest/v1/users/validUser", httpmock.NewStringResponder(200, ""))
 	validCreds := Credentials{
 		Username: "validUser",
 		AccessKey: "validAccessKey",
 	}
 	assert.True(t, validCreds.IsValid())
 
-	httpmock.RegisterResponder("GET", "https://saucelabs.com/rest/v1/users/invalidUser", httpmock.NewStringResponder(401, ""))
+	httpmock.RegisterResponder(http.MethodGet, "https://saucelabs.com/rest/v1/users/invalidUser", httpmock.NewStringResponder(401, ""))
 	invalidCreds := Credentials{
 		Username: "invalidUser",
 		AccessKey: "invalidAccessKey",

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
-	github.com/pkg/errors v0.8.1
 	github.com/rs/zerolog v1.18.0
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.4.0
 	github.com/tj/survey v2.0.6+incompatible
+	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	gopkg.in/yaml.v2 v2.2.8
 	gotest.tools v2.2.0+incompatible
 	gotest.tools/v3 v3.0.2

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
+	github.com/pkg/errors v0.8.1
 	github.com/rs/zerolog v1.18.0
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.4.0

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -237,7 +237,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s 
 
 	username := ""
 	accessKey := ""
-	if creds := credentials.GetCredentials(); creds != nil {
+	if creds := credentials.Get(); creds != nil {
 		username = creds.Username
 		accessKey = creds.AccessKey
 		log.Info().Msgf("Using credentials from %s", creds.Source)

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/saucelabs/saucectl/cli/credentials"
 	"io"
 	"io/ioutil"
 	"os"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	"github.com/saucelabs/saucectl/cli/config"
+	"github.com/saucelabs/saucectl/cli/credentials"
 	"github.com/saucelabs/saucectl/cli/streams"
 	"github.com/saucelabs/saucectl/cli/utils"
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/saucelabs/saucectl/cli/credentials"
 	"io"
 	"io/ioutil"
 	"os"
@@ -234,6 +235,14 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s 
 		return nil, err
 	}
 
+	username := ""
+	accessKey := ""
+	if creds := credentials.GetCredentials(); creds != nil {
+		username = creds.Username
+		accessKey = creds.AccessKey
+		log.Info().Msgf("Using credentials from %s", creds.Source)
+	}
+
 	hostConfig := &container.HostConfig{
 		PortBindings: portBindings,
 		Mounts:       m,
@@ -243,8 +252,8 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s 
 		Image:        handler.GetImageFlavor(c),
 		ExposedPorts: ports,
 		Env: []string{
-			fmt.Sprintf("SAUCE_USERNAME=%s", os.Getenv("SAUCE_USERNAME")),
-			fmt.Sprintf("SAUCE_ACCESS_KEY=%s", os.Getenv("SAUCE_ACCESS_KEY")),
+			fmt.Sprintf("SAUCE_USERNAME=%s", username),
+			fmt.Sprintf("SAUCE_ACCESS_KEY=%s", accessKey),
 			fmt.Sprintf("SAUCE_BUILD_NAME=%s", c.Metadata.Build),
 			fmt.Sprintf("SAUCE_TAGS=%s", strings.Join(c.Metadata.Tags, ",")),
 			fmt.Sprintf("SAUCE_DEVTOOLS_PORT=%d", port),

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/saucelabs/saucectl/cli/credentials"
 	"github.com/saucelabs/saucectl/internal/fleet"
 	"io/ioutil"
 	"net/http"
@@ -12,10 +13,9 @@ import (
 
 // Client service
 type Client struct {
-	HTTPClient *http.Client
-	URL        string // e.g.) https://api.<region>.saucelabs.net
-	Username   string
-	AccessKey  string
+	HTTPClient  *http.Client
+	URL         string // e.g.) https://api.<region>.saucelabs.net
+	Credentials credentials.Credentials
 }
 
 // Job represents the sauce labs test job.
@@ -141,7 +141,7 @@ func (c *Client) newJSONRequest(ctx context.Context, url, method string, payload
 	if err != nil {
 		return nil, err
 	}
-	req.SetBasicAuth(c.Username, c.AccessKey)
+	req.SetBasicAuth(c.Credentials.Username, c.Credentials.AccessKey)
 	req.Header.Set("Content-Type", "application/json")
 
 	return req, err

--- a/internal/testcomposer/testcomposer_test.go
+++ b/internal/testcomposer/testcomposer_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/cli/credentials"
 	"github.com/saucelabs/saucectl/internal/fleet"
 	"net/http"
 	"net/http/httptest"
@@ -145,10 +146,9 @@ func TestClient_CreateFleet(t *testing.T) {
 	defer server.Close()
 
 	type fields struct {
-		HTTPClient *http.Client
-		URL        string
-		Username   string
-		AccessKey  string
+		HTTPClient  *http.Client
+		URL         string
+		Credentials credentials.Credentials
 	}
 	type args struct {
 		ctx        context.Context
@@ -182,10 +182,9 @@ func TestClient_CreateFleet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := Client{
-				HTTPClient: tt.fields.HTTPClient,
-				URL:        tt.fields.URL,
-				Username:   tt.fields.Username,
-				AccessKey:  tt.fields.AccessKey,
+				HTTPClient:  tt.fields.HTTPClient,
+				URL:         tt.fields.URL,
+				Credentials: tt.fields.Credentials,
 			}
 
 			respo.Record(tt.serverFunc)
@@ -213,10 +212,9 @@ func TestClient_NextAssignment(t *testing.T) {
 	defer server.Close()
 
 	type fields struct {
-		HTTPClient *http.Client
-		URL        string
-		Username   string
-		AccessKey  string
+		HTTPClient  *http.Client
+		URL         string
+		Credentials credentials.Credentials
 	}
 	type args struct {
 		ctx       context.Context
@@ -250,10 +248,9 @@ func TestClient_NextAssignment(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Client{
-				HTTPClient: tt.fields.HTTPClient,
-				URL:        tt.fields.URL,
-				Username:   tt.fields.Username,
-				AccessKey:  tt.fields.AccessKey,
+				HTTPClient:  tt.fields.HTTPClient,
+				URL:         tt.fields.URL,
+				Credentials: tt.fields.Credentials,
 			}
 
 			respo.Record(tt.serverFunc)

--- a/internal/yaml/file.go
+++ b/internal/yaml/file.go
@@ -8,10 +8,15 @@ import (
 
 // WriteFile serializes v to a file with the given name.
 func WriteFile(name string, v interface{}) error {
+	return WriteFileWithFileMode(name, v, os.ModePerm)
+}
+
+// WriteFileWithFileMode serializes v to a file with the given name with specified FileMode.
+func WriteFileWithFileMode(name string, v interface{}, mode os.FileMode) error {
 	b, err := yaml.Marshal(v)
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(name, b, os.ModePerm)
+	return ioutil.WriteFile(name, b, mode)
 }


### PR DESCRIPTION
## Proposed changes

`saucectl` is able to upload artifacts and results to SauceLabs if there is an authentication token provided.
The only current way to provide it through a couple of environment variable (`SAUCE_USERNAME` / `SAUCE_ACCESS_KEY`).
While it's convenient for a CI environment, this is not optimum for running it locally.

This PR adds support for a local user configuration that will keep `username` and `accessKey` across the different terminals and shells.
It also come with an helper command that allow configure it easily without editing files (`saucectl configure`).

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
