### PR TITLE
enhancement: check whether files in sauce config are existed before test

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -92,6 +92,9 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 	}
 
 	mergeArgs(cmd, &p)
+	if err := validateFiles(p.Files); err != nil {
+		return 1, err
+	}
 	if cmd.Flags().Lookup("suite").Changed {
 		if err := filterSuite(&p); err != nil {
 			return 1, err
@@ -123,10 +126,10 @@ func newRunner(p config.Project, cli *command.SauceCtlCli) (runner.Testrunner, e
 		if err != nil {
 			return nil, err
 		}
-		if (os.Getenv("SAUCE_TARGET_DIR") != "") {
+		if os.Getenv("SAUCE_TARGET_DIR") != "" {
 			rc.TargetDir = os.Getenv("SAUCE_TARGET_DIR")
 		}
-		if (os.Getenv("SAUCE_ROOT_DIR") != "") {
+		if os.Getenv("SAUCE_ROOT_DIR") != "" {
 			rc.RootDir = os.Getenv("SAUCE_ROOT_DIR")
 		}
 		cip := createCIProvider()
@@ -244,4 +247,13 @@ func filterSuite(c *config.Project) error {
 		}
 	}
 	return errors.New("suite name is invalid")
+}
+
+func validateFiles(files []string) error {
+	for _, f := range files {
+		if _, err := os.Stat(f); os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Proposed changes
Validate file path before binding to docker when parsing files path from sauce config.
When there is any non-existing file, the output should be
```
1:19AM INF Reading config file config=./.sauce/cypress.yml
1:19AM ERR failed to execute run command error="stat test/e2e/cypress/: no such file or directory"
```
The original issue https://github.com/saucelabs/saucectl/issues/98

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
