### PR TITLE
Provide docker copy as an alternative to docker mount path (Cypress Native)

### DIFF
--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -10,7 +10,7 @@ sauce:
       - other tag
     build: Release $CI_COMMIT_SHORT_SHA
 docker:
-  fileMode: mount
+  fileTransfer: mount
   image:
     name: saucelabs/stt-cypress-mocha-node
     tag: v0.2.0

--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -10,6 +10,7 @@ sauce:
       - other tag
     build: Release $CI_COMMIT_SHORT_SHA
 docker:
+  fileMode: mount
   image:
     name: saucelabs/stt-cypress-mocha-node
     tag: v0.2.0

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -95,16 +95,19 @@ type TypeDef struct {
 	Kind       string `yaml:"kind,omitempty"`
 }
 
-// Docker* represent the file providing method
+// DockerFileMode represent the file providing method
+type DockerFileMode string
+
+// DockerFile* represent the different modes
 const (
-	DockerMount string = "mount"
-	DockerCopy         = "copy"
+	DockerFileMount DockerFileMode = "mount"
+	DockerFileCopy                 = "copy"
 )
 
 // Docker represents docker settings.
 type Docker struct {
-	FileMode string `yaml:"fileMode" json:"fileMode"`
-	Image    Image  `yaml:"image,omitempty" json:"image"`
+	FileMode DockerFileMode `yaml:"fileMode" json:"fileMode"`
+	Image    Image          `yaml:"image,omitempty" json:"image"`
 }
 
 // Image represents the docker image.

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -95,10 +95,10 @@ type TypeDef struct {
 	Kind       string `yaml:"kind,omitempty"`
 }
 
-//
+// Docker* represent the file providing method
 const (
-	Mount string = "mount"
-	Copy = "copy"
+	DockerMount string = "mount"
+	DockerCopy         = "copy"
 )
 
 // Docker represents docker settings.

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -95,9 +95,16 @@ type TypeDef struct {
 	Kind       string `yaml:"kind,omitempty"`
 }
 
+//
+const (
+	Mount string = "mount"
+	Copy = "copy"
+)
+
 // Docker represents docker settings.
 type Docker struct {
-	Image Image `yaml:"image,omitempty" json:"image"`
+	FileMode string `yaml:"fileMode" json:"fileMode"`
+	Image    Image  `yaml:"image,omitempty" json:"image"`
 }
 
 // Image represents the docker image.

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -176,6 +176,11 @@ func NewJobConfiguration(cfgFilePath string) (Project, error) {
 
 	c.SyncCapabilities()
 
+	// Default mode to Mount
+	if c.FileTransfer == "" {
+		c.FileTransfer = DockerFileMount
+	}
+
 	return c, nil
 }
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -48,18 +48,19 @@ type ImageDefinition struct {
 
 // Project represents the project configuration.
 type Project struct {
-	APIVersion string            `yaml:"apiVersion,omitempty"`
-	Kind       string            `yaml:"kind,omitempty"`
-	Metadata   Metadata          `yaml:"metadata,omitempty"`
-	Suites     []Suite           `yaml:"suites,omitempty"`
-	Files      []string          `yaml:"files,omitempty"`
-	Image      ImageDefinition   `yaml:"image,omitempty"`
-	BeforeExec []string          `yaml:"beforeExec,omitempty"`
-	Timeout    int               `yaml:"timeout,omitempty"`
-	Sauce      SauceConfig       `yaml:"sauce,omitempty"`
-	Env        map[string]string `yaml:"env,omitempty"`
-	Parallel   bool              `yaml:"parallel,omitempty"`
-	Npm        Npm               `yaml:"npm,omitempty"`
+	APIVersion   string            `yaml:"apiVersion,omitempty"`
+	Kind         string            `yaml:"kind,omitempty"`
+	Metadata     Metadata          `yaml:"metadata,omitempty"`
+	Suites       []Suite           `yaml:"suites,omitempty"`
+	Files        []string          `yaml:"files,omitempty"`
+	FileTransfer DockerFileMode    `yaml:"fileTransfer,omitempty"`
+	Image        ImageDefinition   `yaml:"image,omitempty"`
+	BeforeExec   []string          `yaml:"beforeExec,omitempty"`
+	Timeout      int               `yaml:"timeout,omitempty"`
+	Sauce        SauceConfig       `yaml:"sauce,omitempty"`
+	Env          map[string]string `yaml:"env,omitempty"`
+	Parallel     bool              `yaml:"parallel,omitempty"`
+	Npm          Npm               `yaml:"npm,omitempty"`
 }
 
 // Suite represents the test suite configuration.

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -106,8 +106,8 @@ const (
 
 // Docker represents docker settings.
 type Docker struct {
-	FileMode DockerFileMode `yaml:"fileMode" json:"fileMode"`
-	Image    Image          `yaml:"image,omitempty" json:"image"`
+	FileTransfer DockerFileMode `yaml:"fileTransfer,omitempty" json:"fileTransfer"`
+	Image        Image          `yaml:"image,omitempty" json:"image"`
 }
 
 // Image represents the docker image.

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -77,5 +77,10 @@ func FromFile(cfgPath string) (Project, error) {
 		p.Cypress.EnvFile = envFile
 	}
 
+	// Default mode to Mount
+	if p.Docker.FileTransfer == "" {
+		p.Docker.FileTransfer = config.DockerFileMount
+	}
+
 	return p, nil
 }

--- a/internal/cypress/docker/docker.go
+++ b/internal/cypress/docker/docker.go
@@ -206,7 +206,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c cypress.Project) (
 		return nil, err
 	}
 
-	m = []mount.Mount{}
+	var m []mount.Mount
 	if c.Docker.FileTransfer == config.DockerFileMount || c.Docker.FileTransfer == "" {
 		m, err = createMounts(files, pDir)
 		if err != nil {

--- a/internal/cypress/docker/docker.go
+++ b/internal/cypress/docker/docker.go
@@ -207,7 +207,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c cypress.Project) (
 	}
 
 	var m []mount.Mount
-	if c.Docker.FileMode == config.DockerFileMount {
+	if c.Docker.FileTransfer == config.DockerFileMount {
 		m, err = createMounts(files, pDir)
 		if err != nil {
 			return nil, err
@@ -248,7 +248,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c cypress.Project) (
 		return nil, err
 	}
 
-	if c.Docker.FileMode == config.DockerFileCopy {
+	if c.Docker.FileTransfer == config.DockerFileCopy {
 		if err := copyTestFiles(ctx, handler, container.ID, files, pDir); err != nil {
 			return nil, err
 		}

--- a/internal/cypress/docker/docker.go
+++ b/internal/cypress/docker/docker.go
@@ -206,14 +206,12 @@ func (handler *Handler) StartContainer(ctx context.Context, c cypress.Project) (
 		return nil, err
 	}
 
-	var m []mount.Mount
+	m = []mount.Mount{}
 	if c.Docker.FileTransfer == config.DockerFileMount || c.Docker.FileTransfer == "" {
 		m, err = createMounts(files, pDir)
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		m = []mount.Mount{}
 	}
 
 	username := ""

--- a/internal/cypress/docker/docker.go
+++ b/internal/cypress/docker/docker.go
@@ -207,7 +207,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c cypress.Project) (
 	}
 
 	var m []mount.Mount
-	if c.Docker.FileTransfer == config.DockerFileMount || c.Docker.FileTransfer == "" {
+	if c.Docker.FileTransfer == config.DockerFileMount {
 		m, err = createMounts(files, pDir)
 		if err != nil {
 			return nil, err

--- a/internal/cypress/docker/docker.go
+++ b/internal/cypress/docker/docker.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/saucelabs/saucectl/cli/credentials"
@@ -208,7 +207,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c cypress.Project) (
 	}
 
 	var m []mount.Mount
-	if strings.ToLower(c.Docker.FileMode) == config.Mount {
+	if c.Docker.FileMode == config.DockerMount {
 		m, err = createMounts(files, pDir)
 		if err != nil {
 			return nil, err
@@ -249,7 +248,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c cypress.Project) (
 		return nil, err
 	}
 
-	if strings.ToLower(c.Docker.FileMode) == config.Copy {
+	if c.Docker.FileMode == config.DockerCopy {
 		if err := copyTestFiles(ctx, handler, container.ID, files, pDir); err != nil {
 			return nil, err
 		}
@@ -266,10 +265,11 @@ func (handler *Handler) StartContainer(ctx context.Context, c cypress.Project) (
 	return &container, nil
 }
 
-func copyTestFiles(ctx context.Context, handler *Handler, containerId string, files []string, pDir string) error {
+// copyTestFiles copies the files within the container.
+func copyTestFiles(ctx context.Context, handler *Handler, containerID string, files []string, pDir string) error {
 	for _, file := range files {
 		log.Info().Str("from", file).Str("to", pDir).Msg("File copied")
-		if err := handler.CopyToContainer(ctx, containerId, file, pDir); err != nil {
+		if err := handler.CopyToContainer(ctx, containerID, file, pDir); err != nil {
 			return err
 		}
 	}

--- a/internal/cypress/docker/docker.go
+++ b/internal/cypress/docker/docker.go
@@ -207,7 +207,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c cypress.Project) (
 	}
 
 	var m []mount.Mount
-	if c.Docker.FileMode == config.DockerMount {
+	if c.Docker.FileMode == config.DockerFileMount {
 		m, err = createMounts(files, pDir)
 		if err != nil {
 			return nil, err
@@ -248,7 +248,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c cypress.Project) (
 		return nil, err
 	}
 
-	if c.Docker.FileMode == config.DockerCopy {
+	if c.Docker.FileMode == config.DockerFileCopy {
 		if err := copyTestFiles(ctx, handler, container.ID, files, pDir); err != nil {
 			return nil, err
 		}

--- a/internal/cypress/docker/docker.go
+++ b/internal/cypress/docker/docker.go
@@ -207,7 +207,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c cypress.Project) (
 	}
 
 	var m []mount.Mount
-	if c.Docker.FileTransfer == config.DockerFileMount {
+	if c.Docker.FileTransfer == config.DockerFileMount || c.Docker.FileTransfer == "" {
 		m, err = createMounts(files, pDir)
 		if err != nil {
 			return nil, err

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -192,7 +192,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s 
 	}
 
 	var m []mount.Mount
-	if c.FileTransfer == config.DockerFileMount || c.FileTransfer == "" {
+	if c.FileTransfer == config.DockerFileMount {
 		m, err = createMounts(c.Files, DefaultProjectPath)
 		if err != nil {
 			return nil, err

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -191,9 +191,14 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s 
 		return nil, err
 	}
 
-	m, err := createMounts(c.Files, DefaultProjectPath)
-	if err != nil {
-		return nil, err
+	var m []mount.Mount
+	if c.FileTransfer == config.DockerFileMount {
+		m, err = createMounts(c.Files, DefaultProjectPath)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		m = []mount.Mount{}
 	}
 
 	username := ""
@@ -238,6 +243,12 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s 
 		return nil, err
 	}
 
+	if c.FileTransfer == config.DockerFileCopy {
+		if err := copyTestFiles(ctx, handler, container.ID, c.Files, DefaultProjectPath); err != nil {
+			return nil, err
+		}
+	}
+
 	// We need to check the tty _before_ we do the ContainerExecCreate, because
 	// otherwise if we error out we will leak execIDs on the server (and
 	// there's no easy way to clean those up). But also in order to make "not
@@ -247,6 +258,17 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s 
 	}
 
 	return &container, nil
+}
+
+// copyTestFiles copies the files within the container.
+func copyTestFiles(ctx context.Context, handler *Handler, containerID string, files []string, pDir string) error {
+	for _, file := range files {
+		log.Info().Str("from", file).Str("to", pDir).Msg("File copied")
+		if err := handler.CopyToContainer(ctx, containerID, file, pDir); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // createMounts returns a list of mount bindings, binding files to target, such that {source}:{target}/{source}.

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -197,8 +197,6 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s 
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		m = []mount.Mount{}
 	}
 
 	username := ""

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -192,7 +192,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c config.Project, s 
 	}
 
 	var m []mount.Mount
-	if c.FileTransfer == config.DockerFileMount {
+	if c.FileTransfer == config.DockerFileMount || c.FileTransfer == "" {
 		m, err = createMounts(c.Files, DefaultProjectPath)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Proposed changes

In some cases, the docker server is not hosted on the same machine, so using mount points does not permit to share files.
As an alternative solution, this PR implement in `saucectl` the ability to copy files into the container.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

