### PR TITLE
Start cypress job with test-composer

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -201,9 +201,17 @@ func runCypressInSauce(p cypress.Project) (int, error) {
 	// TODO decide on a good timeout and perhaps make it configurable. Slow clients may take time to upload. Can't be higher than API gateway timeout though!
 	s := appstore.New(re.APIBaseURL(), c.Username, c.AccessKey, 30*time.Second)
 
+	// TODO decide on a good timeout and perhaps make it configurable. Slow clients may take time to upload. Can't be higher than API gateway timeout though!
+	tc := testcomposer.Client{
+		HTTPClient:  &http.Client{Timeout: 30 * time.Second},
+		URL:         re.APIBaseURL(),
+		Credentials: credentials.Credentials{},
+	}
+
 	r := sauce.Runner{
 		Project:         p,
 		ProjectUploader: s,
+		JobStarter:      &tc,
 	}
 	return r.RunProject()
 }

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -23,6 +23,7 @@ type Suite struct {
 	Name           string      `yaml:"name,omitempty" json:"name"`
 	Browser        string      `yaml:"browser,omitempty" json:"browser"`
 	BrowserVersion string      `yaml:"browserVersion,omitempty" json:"browserVersion"`
+	PlatformName   string      `yaml:"platformName,omitempty" json:"platformName"`
 	Config         SuiteConfig `yaml:"config,omitempty" json:"config"`
 }
 

--- a/internal/cypress/sauce/runner.go
+++ b/internal/cypress/sauce/runner.go
@@ -25,6 +25,8 @@ type Runner struct {
 
 // RunProject runs the tests defined in cypress.Project.
 func (r *Runner) RunProject() (int, error) {
+	log.Error().Msg("Caution: Not yet implemented.") // TODO remove debug
+
 	// Archive the project files.
 	tempDir, err := ioutil.TempDir(os.TempDir(), "saucectl-app-payload")
 	if err != nil {
@@ -48,7 +50,6 @@ func (r *Runner) RunProject() (int, error) {
 		}
 	}
 
-	log.Error().Msg("Not yet implemented.") // TODO remove debug
 	return 1, nil
 }
 

--- a/internal/cypress/sauce/runner.go
+++ b/internal/cypress/sauce/runner.go
@@ -1,10 +1,14 @@
 package sauce
 
 import (
+	"context"
+	"fmt"
 	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/cli/credentials"
 	"github.com/saucelabs/saucectl/cli/progress"
 	"github.com/saucelabs/saucectl/internal/archive/zip"
 	"github.com/saucelabs/saucectl/internal/cypress"
+	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/jsonio"
 	"github.com/saucelabs/saucectl/internal/storage"
 	"io/ioutil"
@@ -16,6 +20,7 @@ import (
 type Runner struct {
 	Project         cypress.Project
 	ProjectUploader storage.ProjectUploader
+	JobStarter      job.Starter
 }
 
 // RunProject runs the tests defined in cypress.Project.
@@ -32,9 +37,45 @@ func (r *Runner) RunProject() (int, error) {
 		return 1, err
 	}
 
-	r.uploadProject(zipName)
+	fileID, err := r.uploadProject(zipName)
+	if err != nil {
+		return 1, err
+	}
+
+	for _, s := range r.Project.Suites {
+		if err := r.runSuite(s, fileID); err != nil {
+			return 1, err
+		}
+	}
+
 	log.Error().Msg("Not yet implemented.") // TODO remove debug
 	return 1, nil
+}
+
+func (r *Runner) runSuite(s cypress.Suite, fileID string) error {
+	log.Info().Str("suite", s.Name).Msg("Starting job.")
+
+	opts := job.StartOptions{
+		User:           credentials.Get().Username,
+		AccessKey:      credentials.Get().AccessKey,
+		App:            fmt.Sprintf("storage:%s", fileID),
+		Suite:          s.Name,
+		Framework:      "cypress",
+		BrowserName:    s.Browser,
+		BrowserVersion: s.BrowserVersion,
+		PlatformName:   s.PlatformName,
+		Name:           r.Project.Sauce.Metadata.Name + " - " + s.Name,
+		Build:          r.Project.Sauce.Metadata.Build,
+		Tags:           r.Project.Sauce.Metadata.Tags,
+	}
+
+	id, err := r.JobStarter.StartJob(context.Background(), opts)
+	if err != nil {
+		return err
+	}
+
+	log.Info().Str("jobID", id).Msg("Job started.")
+	return nil
 }
 
 func (r *Runner) archiveProject(tempDir string) (string, error) {

--- a/internal/job/starter.go
+++ b/internal/job/starter.go
@@ -1,0 +1,23 @@
+package job
+
+import "context"
+
+// StartOptions represents the options for starting a job.
+type StartOptions struct {
+	User           string   `json:"username"`
+	AccessKey      string   `json:"accessKey"`
+	App            string   `json:"app,omitempty"`
+	Suite          string   `json:"suite,omitempty"`
+	Framework      string   `json:"framework,omitempty"`
+	BrowserName    string   `json:"browserName,omitempty"`
+	BrowserVersion string   `json:"browserVersion,omitempty"`
+	PlatformName   string   `json:"platformName,omitempty"`
+	Name           string   `json:"name,omitempty"`
+	Build          string   `json:"build,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+}
+
+// Starter is the interface for starting jobs.
+type Starter interface {
+	StartJob(ctx context.Context, opts StartOptions) (jobID string, err error)
+}

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/saucelabs/saucectl/cli/credentials"
 	"github.com/saucelabs/saucectl/internal/fleet"
+	"github.com/saucelabs/saucectl/internal/job"
 	"io/ioutil"
 	"net/http"
 )
@@ -24,17 +25,6 @@ type Job struct {
 	Owner string `json:"owner"`
 }
 
-// JobStarterPayload is a JSON object of parameters used to start a session
-// from saucectl
-type JobStarterPayload struct {
-	User        string   `json:"username"`
-	AccessKey   string   `json:"accessKey"`
-	BrowserName string   `json:"browserName,omitempty"`
-	TestName    string   `json:"testName,omitempty"`
-	Framework   string   `json:"framework,omitempty"`
-	BuildName   string   `json:"buildName,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
-}
 
 // CreatorRequest represents the request body for creating a fleet.
 type CreatorRequest struct {
@@ -58,18 +48,19 @@ type AssignerResponse struct {
 }
 
 // StartJob creates a new job in Sauce Labs.
-func (c *Client) StartJob(ctx context.Context, jobStarterPayload JobStarterPayload) (jobID string, err error) {
-	url := fmt.Sprintf("%s/v1/testcomposer/jobs/", c.URL)
-	b := new(bytes.Buffer)
-	err = json.NewEncoder(b).Encode(jobStarterPayload)
+func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID string, err error) {
+	url := fmt.Sprintf("%s/v1/testcomposer/jobs", c.URL)
+
+	var b bytes.Buffer
+	err = json.NewEncoder(&b).Encode(opts)
 	if err != nil {
 		return
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, b)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &b)
 	if err != nil {
 		return
 	}
-	req.SetBasicAuth(jobStarterPayload.User, jobStarterPayload.AccessKey)
+	req.SetBasicAuth(opts.User, opts.AccessKey)
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return
@@ -80,16 +71,17 @@ func (c *Client) StartJob(ctx context.Context, jobStarterPayload JobStarterPaylo
 		return
 	}
 	if resp.StatusCode >= 300 {
-		err = fmt.Errorf("Failed to start job. statusCode='%d'", resp.StatusCode)
+		err = fmt.Errorf("job start failed; unexpected response code:'%d', msg:'%v'", resp.StatusCode, string(body))
 		return "", err
 	}
-	var job *Job
-	err = json.Unmarshal(body, &job)
+
+	var j Job
+	err = json.Unmarshal(body, &j)
 	if err != nil {
 		return
 	}
 
-	return job.ID, nil
+	return j.ID, nil
 }
 
 // Register registers a fleet with the given buildID and test suites.

--- a/internal/testcomposer/testcomposer_test.go
+++ b/internal/testcomposer/testcomposer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/cli/credentials"
 	"github.com/saucelabs/saucectl/internal/fleet"
+	"github.com/saucelabs/saucectl/internal/job"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -56,7 +57,7 @@ func TestTestComposer_StartJob(t *testing.T) {
 	}))
 	type args struct {
 		ctx               context.Context
-		jobStarterPayload JobStarterPayload
+		jobStarterPayload job.StartOptions
 	}
 	type fields struct {
 		HTTPClient *http.Client
@@ -78,13 +79,13 @@ func TestTestComposer_StartJob(t *testing.T) {
 			},
 			args: args{
 				ctx: context.TODO(),
-				jobStarterPayload: JobStarterPayload{
+				jobStarterPayload: job.StartOptions{
 					User:        "fake-user",
 					AccessKey:   "fake-access-key",
 					BrowserName: "fake-browser-name",
-					TestName:    "fake-test-name",
+					Name:        "fake-test-name",
 					Framework:   "fake-framework",
-					BuildName:   "fake-buildname",
+					Build:       "fake-buildname",
 					Tags:        nil,
 				},
 			},
@@ -105,10 +106,10 @@ func TestTestComposer_StartJob(t *testing.T) {
 			},
 			args: args{
 				ctx:               context.TODO(),
-				jobStarterPayload: JobStarterPayload{},
+				jobStarterPayload: job.StartOptions{},
 			},
 			want:    "",
-			wantErr: fmt.Errorf("Failed to start job. statusCode='300'"),
+			wantErr: fmt.Errorf("job start failed; unexpected response code:'300', msg:''"),
 			serverFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(300)
 			},


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Starts cypress inside Sauce Labs by calling test-composer with a fire-and-forget request.
Even if the request were to succeed (which it wouldn't right now, since the cloud is not ready), no further action is taken by saucectl.
Polling for job completion and status evaluation will be tackled in a future PR.

The expected output right now is:
```
./saucectl run -c .sauce/cypress.yml --test-env sauce
2:43PM INF Running version unknown-version
2:43PM INF Reading config file config=.sauce/cypress.yml
2:43PM INF Running Cypress in Sauce Labs
2:43PM ERR Caution: Not yet implemented.
2:43PM INF Project uploaded. fileID=bdfc4a1c-05b7-4ebb-a829-0d65f89aa1ac
2:43PM INF Starting job. suite="saucy test"
2:43PM ERR failed to execute run command error="job start failed; unexpected response code:'500', msg:'Internal Server Error\n'"
```


## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
