### PR TITLE
Cypress native config: Fix saucectl new command

### DIFF
--- a/cli/command/new/cmd.go
+++ b/cli/command/new/cmd.go
@@ -132,7 +132,7 @@ func updateRegion(cfgFile string, region string) error {
 		return err
 	}
 
-	if d.Kind == "cypress" && d.APIVersion == "v1alpha" {
+	if d.Kind == config.KindCypress && d.APIVersion == config.VersionV1Alpha {
 		c, err := cypress.FromFile(cfgFile)
 		if err != nil {
 			return err

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -107,7 +107,7 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 		return 1, err
 	}
 
-	if d.Kind == "cypress" && d.APIVersion == "v1alpha" {
+	if d.Kind == config.KindCypress && d.APIVersion == config.VersionV1Alpha {
 		return runCypress(cli)
 	}
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -121,6 +121,16 @@ type Npm struct {
 	Packages map[string]string `yaml:"packages,omitempty" json:"packages"`
 }
 
+// Version* contains referenced config version
+const (
+	VersionV1Alpha = "v1alpha"
+)
+
+// Kind* contains referenced config kinds
+const (
+	KindCypress = "cypress"
+)
+
 func readYaml(cfgFilePath string) ([]byte, error) {
 	if cfgFilePath == "" {
 		return nil, errors.New("no config file was provided")

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -48,8 +48,7 @@ type ImageDefinition struct {
 
 // Project represents the project configuration.
 type Project struct {
-	APIVersion   string            `yaml:"apiVersion,omitempty"`
-	Kind         string            `yaml:"kind,omitempty"`
+	TypeDef                        `yaml:",inline"`
 	Metadata     Metadata          `yaml:"metadata,omitempty"`
 	Suites       []Suite           `yaml:"suites,omitempty"`
 	Files        []string          `yaml:"files,omitempty"`

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -10,6 +10,8 @@ import (
 
 // Project represents the cypress project configuration.
 type Project struct {
+	APIVersion string             `yaml:"apiVersion,omitempty"`
+	Kind       string             `yaml:"kind,omitempty"`
 	Sauce      config.SauceConfig `yaml:"sauce,omitempty" json:"sauce"`
 	Cypress    Cypress            `yaml:"cypress,omitempty" json:"cypress"`
 	Suites     []Suite            `yaml:"suites,omitempty" json:"suites"`

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -10,8 +10,7 @@ import (
 
 // Project represents the cypress project configuration.
 type Project struct {
-	APIVersion string             `yaml:"apiVersion,omitempty"`
-	Kind       string             `yaml:"kind,omitempty"`
+	config.TypeDef                `yaml:",inline"`
 	Sauce      config.SauceConfig `yaml:"sauce,omitempty" json:"sauce"`
 	Cypress    Cypress            `yaml:"cypress,omitempty" json:"cypress"`
 	Suites     []Suite            `yaml:"suites,omitempty" json:"suites"`


### PR DESCRIPTION
## Proposed changes

`saucectl new` command open the configuration file and save it while updating the region.
As the config format has changed for cypress, this command has been broken.

This PR fixes this unexpected behaviour.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
