### PR TITLE
Poll for job end

### DIFF
--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -1,5 +1,18 @@
 package job
 
+// The different states that a job can be in.
+const (
+	StateNew        = "new"
+	StateQueued     = "queued"
+	StateInProgress = "in progress"
+	StateComplete   = "complete"
+	StateError      = "error"
+)
+
+// DoneStates represents states that a job doesn't transition out of, i.e. once the job is in one of these states,
+// it's done.
+var DoneStates = []string{StateComplete, StateError}
+
 // Job represents test details and metadata of a test run (aka Job), that is usually associated with a particular test
 // execution instance (e.g. VM).
 type Job struct {
@@ -7,4 +20,15 @@ type Job struct {
 	Passed bool   `json:"passed"`
 	Status string `json:"status"`
 	Error  string `json:"error"`
+}
+
+// Done returns true if the job status is one of DoneStates. False otherwise.
+func Done(status string) bool {
+	for _, s := range DoneStates {
+		if s == status {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -1,0 +1,10 @@
+package job
+
+// Job represents test details and metadata of a test run (aka Job), that is usually associated with a particular test
+// execution instance (e.g. VM).
+type Job struct {
+	ID     string `json:"id"`
+	Passed bool   `json:"passed"`
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}

--- a/internal/job/reader.go
+++ b/internal/job/reader.go
@@ -7,6 +7,9 @@ import (
 
 // Reader is the interface for retrieving jobs.
 type Reader interface {
+	// ReadJob returns the job details.
 	ReadJob(ctx context.Context, id string) (Job, error)
+
+	// PollJob polls job details at an interval, until the job has ended, whether successfully or due to an error.
 	PollJob(ctx context.Context, id string, interval time.Duration) (Job, error)
 }

--- a/internal/job/reader.go
+++ b/internal/job/reader.go
@@ -1,0 +1,12 @@
+package job
+
+import (
+	"context"
+	"time"
+)
+
+// Reader is the interface for retrieving jobs.
+type Reader interface {
+	ReadJob(ctx context.Context, id string) (Job, error)
+	PollJob(ctx context.Context, id string, interval time.Duration) (Job, error)
+}

--- a/internal/resto/client.go
+++ b/internal/resto/client.go
@@ -1,9 +1,12 @@
 package resto
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/job"
+	"io/ioutil"
 	"net/http"
 	"time"
 )
@@ -11,13 +14,13 @@ import (
 const (
 	completeJobStatus string = "complete"
 	errorJobStatus    string = "error"
-
-	commonErrorMessage = "http status code is not 200 but %d"
 )
 
-var jobStatuses = map[string]struct{}{
-	completeJobStatus: struct{}{},
-	errorJobStatus:    struct{}{},
+// finalJobStates represents states that a job doesn't transition out of, i.e. once the job is in one of these states,
+// it's done.
+var finalJobStates = map[string]struct{}{
+	completeJobStatus: {},
+	errorJobStatus:    {},
 }
 
 var (
@@ -45,22 +48,22 @@ func New(url, username, accessKey string, timeout time.Duration) Client {
 	}
 }
 
-// GetJobDetails returns the job details.
-func (c *Client) GetJobDetails(id string) (Details, error) {
-	request, err := createRequest(c.URL, c.Username, c.AccessKey, id)
+// ReadJob returns the job details.
+func (c *Client) ReadJob(ctx context.Context, id string) (job.Job, error) {
+	request, err := createRequest(ctx, c.URL, c.Username, c.AccessKey, id)
 	if err != nil {
-		return Details{}, err
+		return job.Job{}, err
 	}
 
 	return doRequest(c.HTTPClient, request)
 }
 
-// PollJobEnd polls a server till the end of the job.
+// PollJob polls a server till the end of the job.
 // Stops polling the job when the status will be complete or error.
-func (c *Client) PollJobEnd(id string, interval time.Duration) (Details, error) {
-	request, err := createRequest(c.URL, c.Username, c.AccessKey, id)
+func (c *Client) PollJob(ctx context.Context, id string, interval time.Duration) (job.Job, error) {
+	request, err := createRequest(ctx, c.URL, c.Username, c.AccessKey, id)
 	if err != nil {
-		return Details{}, err
+		return job.Job{}, err
 	}
 
 	ticker := time.NewTicker(interval)
@@ -69,47 +72,49 @@ func (c *Client) PollJobEnd(id string, interval time.Duration) (Details, error) 
 	for range ticker.C {
 		jobDetails, err := doRequest(c.HTTPClient, request)
 		if err != nil {
-			return Details{}, err
+			return job.Job{}, err
 		}
 
-		if _, ok := jobStatuses[jobDetails.Status]; ok {
+		if _, ok := finalJobStates[jobDetails.Status]; ok {
 			return jobDetails, nil
 		}
 	}
 
-	return Details{}, nil
+	return job.Job{}, nil
 }
 
-func doRequest(httpClient *http.Client, request *http.Request) (Details, error) {
-	response, err := httpClient.Do(request)
+func doRequest(httpClient *http.Client, request *http.Request) (job.Job, error) {
+	resp, err := httpClient.Do(request)
 	if err != nil {
-		return Details{}, err
+		return job.Job{}, err
 	}
-	defer response.Body.Close()
+	defer resp.Body.Close()
 
-	if response.StatusCode >= http.StatusInternalServerError {
-		return Details{}, ErrServerInaccessible
-	}
-
-	if response.StatusCode == http.StatusNotFound {
-		return Details{}, ErrJobNotFound
+	if resp.StatusCode >= http.StatusInternalServerError {
+		return job.Job{}, ErrServerInaccessible
 	}
 
-	if response.StatusCode != http.StatusOK {
-		return Details{}, fmt.Errorf(commonErrorMessage, response.StatusCode)
+	if resp.StatusCode == http.StatusNotFound {
+		return job.Job{}, ErrJobNotFound
 	}
 
-	jobDetails := Details{}
-	if err := json.NewDecoder(response.Body).Decode(&jobDetails); err != nil {
-		return Details{}, err
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		err := fmt.Errorf("status request failed; unexpected response code:'%d', msg:'%v'", resp.StatusCode, string(body))
+		return job.Job{}, err
+	}
+
+	jobDetails := job.Job{}
+	if err := json.NewDecoder(resp.Body).Decode(&jobDetails); err != nil {
+		return job.Job{}, err
 	}
 
 	return jobDetails, nil
 }
 
-func createRequest(host, username, accessKey, jobID string) (*http.Request, error) {
-	request, err := http.NewRequest(http.MethodGet,
-		fmt.Sprintf("%s/rest/v1/%s/jobs/%s", host, username, jobID), nil)
+func createRequest(ctx context.Context, url, username, accessKey, jobID string) (*http.Request, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		fmt.Sprintf("%s/rest/v1/%s/jobs/%s", url, username, jobID), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resto/client_test.go
+++ b/internal/resto/client_test.go
@@ -77,14 +77,14 @@ func TestClient_GetJobDetails(t *testing.T) {
 			client:       New(ts.URL, "test", "123", timeout),
 			jobID:        "4",
 			expectedResp: job.Job{},
-			expectedErr:  errors.New("status request failed; unexpected response code:'401', msg:''"),
+			expectedErr:  errors.New("job status request failed; unexpected response code:'401', msg:''"),
 		},
 		{
 			name:         "internal server error from external API",
 			client:       New(ts.URL, "test", "123", timeout),
 			jobID:        "333",
 			expectedResp: job.Job{},
-			expectedErr:  ErrServerInaccessible,
+			expectedErr:  ErrServerError,
 		},
 	}
 
@@ -178,14 +178,14 @@ func TestClient_GetJobStatus(t *testing.T) {
 			client:       New(ts.URL, "test", "123", timeout),
 			jobID:        "4",
 			expectedResp: job.Job{},
-			expectedErr:  errors.New("status request failed; unexpected response code:'401', msg:''"),
+			expectedErr:  errors.New("job status request failed; unexpected response code:'401', msg:''"),
 		},
 		{
 			name:         "unexpected status code from external API",
 			client:       New(ts.URL, "test", "123", timeout),
 			jobID:        "333",
 			expectedResp: job.Job{},
-			expectedErr:  ErrServerInaccessible,
+			expectedErr:  ErrServerError,
 		},
 	}
 

--- a/internal/resto/response.go
+++ b/internal/resto/response.go
@@ -1,9 +1,0 @@
-package resto
-
-// Details represent API response regarding job.
-type Details struct {
-	ID     string `json:"id"`
-	Passed bool   `json:"passed"`
-	Status string `json:"status"`
-	Error  string `json:"error"`
-}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Add a job poll after launching a sauce test in the sauce cloud.

The expected result is akin to:
```
./saucectl run -c .sauce/cypress.yml --test-env sauce
11:59AM INF Running version unknown-version
11:59AM INF Reading config file config=.sauce/cypress.yml
11:59AM INF Running Cypress in Sauce Labs
11:59AM ERR Caution: Not yet implemented.
11:59AM INF Project uploaded. fileID=69993be1-c514-4202-aace-32fc9677b0a5
11:59AM INF Starting job. suite="saucy test"
11:59AM INF Job started. jobID=7992eb0f2e4a4863a48401b13f2f1ae6
11:59AM INF Suite passed. suite="saucy test"
```
(disclaimer: since a full e2e is not available, I had re-purposed an already existing job for this)

Worth noting:
No concurrency in place yet (suites are run sequentially) and will be handled in a future PR.
No distinction between job failure (crash, fail to start) vs test failure within the job. This may be worth adding (either this PR or separate).

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
