### PR TITLE
Add specific messaging when access is not granted

### DIFF
--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -13,7 +13,8 @@ import (
 	"net/http"
 )
 
-const ForbiddenPreviewError = "Forbidden: not part of preview"
+// forbiddenPreviewError contains the message send by test-composer when access is restricted
+const forbiddenPreviewError = "Forbidden: not part of preview"
 
 // Client service
 type Client struct {
@@ -75,7 +76,7 @@ func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID str
 	}
 
 	// Check if error is related to preview
-	if resp.StatusCode == http.StatusForbidden && string(body) == ForbiddenPreviewError {
+	if resp.StatusCode == http.StatusForbidden && string(body) == forbiddenPreviewError {
 		log.Error().Msg("Looks like you are not part of the preview. To join the preview, please sign up here: https://info.saucelabs.com/scale-cypress-testing.html")
 		err = fmt.Errorf("job start failed; not part of preview")
 		return "", err

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -76,7 +76,7 @@ func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID str
 
 	// Check if error is related to preview
 	if resp.StatusCode == http.StatusForbidden && string(body) == ForbiddenPreviewError {
-		log.Error().Msg("Looks like you are not part of the preview. To join the preview, please sign up here: (link)")
+		log.Error().Msg("Looks like you are not part of the preview. To join the preview, please sign up here: https://info.saucelabs.com/scale-cypress-testing.html")
 		err = fmt.Errorf("job start failed; not part of preview")
 		return "", err
 	}

--- a/internal/testcomposer/testcomposer_test.go
+++ b/internal/testcomposer/testcomposer_test.go
@@ -114,6 +114,39 @@ func TestTestComposer_StartJob(t *testing.T) {
 				w.WriteHeader(300)
 			},
 		},
+		{
+			name: "Non preview error",
+			fields: fields{
+				HTTPClient: mockTestComposerServer.Client(),
+				URL:        mockTestComposerServer.URL,
+			},
+			args: args{
+				ctx:               context.TODO(),
+				jobStarterPayload: job.StartOptions{},
+			},
+			want:    "",
+			wantErr: fmt.Errorf("job start failed; not part of preview"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(403)
+				w.Write([]byte(ForbiddenPreviewError))
+			},
+		},
+		{
+			name: "Other forbidden error",
+			fields: fields{
+				HTTPClient: mockTestComposerServer.Client(),
+				URL:        mockTestComposerServer.URL,
+			},
+			args: args{
+				ctx:               context.TODO(),
+				jobStarterPayload: job.StartOptions{},
+			},
+			want:    "",
+			wantErr: fmt.Errorf("job start failed; unexpected response code:'403', msg:''"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(403)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/testcomposer/testcomposer_test.go
+++ b/internal/testcomposer/testcomposer_test.go
@@ -128,7 +128,7 @@ func TestTestComposer_StartJob(t *testing.T) {
 			wantErr: fmt.Errorf("job start failed; not part of preview"),
 			serverFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(403)
-				w.Write([]byte(ForbiddenPreviewError))
+				w.Write([]byte(forbiddenPreviewError))
 			},
 		},
 		{


### PR DESCRIPTION
## Proposed changes

Implements specific messaging Instead of having a default error when trying to run closed-preview features.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)