### PR TITLE
Check for framework availability before trying to start tests

### DIFF
--- a/internal/cypress/sauce/runner.go
+++ b/internal/cypress/sauce/runner.go
@@ -42,6 +42,12 @@ func (r *Runner) RunProject() (int, error) {
 	log.Error().Msg("Caution: Not yet implemented.") // TODO remove debug
 	exitCode := 1
 
+	err := r.JobStarter.CheckFrameworkAvailability(context.Background(), r.Project.Kind)
+	if err != nil {
+		err = fmt.Errorf("job pre-check failed; %s", err)
+		return exitCode, err
+	}
+
 	// Archive the project files.
 	tempDir, err := ioutil.TempDir(os.TempDir(), "saucectl-app-payload")
 	if err != nil {

--- a/internal/job/starter.go
+++ b/internal/job/starter.go
@@ -27,4 +27,5 @@ type TunnelOptions struct {
 // Starter is the interface for starting jobs.
 type Starter interface {
 	StartJob(ctx context.Context, opts StartOptions) (jobID string, err error)
+	CheckFrameworkAvailability(ctx context.Context, frameworkName string) error
 }

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -13,7 +13,8 @@ import (
 	"net/http"
 )
 
-const ForbiddenPreviewError = "Forbidden: not part of preview"
+// forbiddenPreviewError contains the message send by test-composer when access is restricted
+const forbiddenPreviewError = "Forbidden: not part of preview"
 
 // Client service
 type Client struct {
@@ -75,7 +76,7 @@ func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID str
 	}
 
 	// Check if error is related to preview
-	if resp.StatusCode == http.StatusForbidden && string(body) == ForbiddenPreviewError {
+	if resp.StatusCode == http.StatusForbidden && string(body) == forbiddenPreviewError {
 		log.Error().Msg("Looks like you are not part of the preview. To join the preview, please sign up here: https://info.saucelabs.com/scale-cypress-testing.html")
 		err = fmt.Errorf("job start failed; not part of preview")
 		return "", err

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -80,7 +80,7 @@ func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID str
 	}
 
 	// Check if error is related to preview
-	err = c.checkFrameworkRestrictions(*resp, string(body))
+	err = c.checkFrameworkRestrictions(opts.Framework, *resp, string(body))
 	if err != nil {
 		err = fmt.Errorf("job start failed; %s", err)
 		return "", err
@@ -190,7 +190,7 @@ func (c *Client) CheckFrameworkAvailability(ctx context.Context, frameworkName s
 	}
 
 	bodyStr := strings.TrimSpace(string(body))
-	err = c.checkFrameworkRestrictions(*resp, bodyStr)
+	err = c.checkFrameworkRestrictions(frameworkName, *resp, bodyStr)
 	if err != nil {
 		return err
 	}
@@ -202,13 +202,13 @@ func (c *Client) CheckFrameworkAvailability(ctx context.Context, frameworkName s
 }
 
 // checkFrameworkRestrictions checks specific cases related to framework availability
-func (c *Client) checkFrameworkRestrictions(resp http.Response, body string) error {
+func (c *Client) checkFrameworkRestrictions(framework string, resp http.Response, body string) error {
 	if resp.StatusCode == http.StatusForbidden && body == forbiddenPreviewError {
 		log.Error().Msg("Looks like you are not part of the preview. To join the preview, please sign up here: https://info.saucelabs.com/scale-cypress-testing.html")
 		return errors.New("not part of preview")
 	}
 	if resp.StatusCode == http.StatusBadRequest && body == unsupportedFrameworkError {
-		log.Error().Msg("The framework you've selected is invalid")
+		log.Error().Msg("The framework " + framework + " is not supported.")
 		return errors.New("framework not supported")
 	}
 	return nil

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/job"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 // forbiddenPreviewError contains the message send by test-composer when access is restricted
@@ -188,13 +189,14 @@ func (c *Client) CheckFrameworkAvailability(ctx context.Context, frameworkName s
 		return err
 	}
 
-	err = c.checkFrameworkRestrictions(*resp, string(body))
+	bodyStr := strings.TrimSpace(string(body))
+	err = c.checkFrameworkRestrictions(*resp, bodyStr)
 	if err != nil {
 		return err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected response code:'%d', msg:'%s'", resp.StatusCode, string(body))
+		return fmt.Errorf("unexpected response code:'%d', msg:'%s'", resp.StatusCode, bodyStr)
 	}
 	return nil
 }

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -80,7 +80,7 @@ func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID str
 	}
 
 	// Check if error is related to preview
-	err = c.checkFrameworkRestrictions(opts.Framework, *resp, string(body))
+	err = c.checkFrameworkRestrictions(*resp, string(body), opts.Framework, opts.User)
 	if err != nil {
 		err = fmt.Errorf("job start failed; %s", err)
 		return "", err
@@ -190,7 +190,7 @@ func (c *Client) CheckFrameworkAvailability(ctx context.Context, frameworkName s
 	}
 
 	bodyStr := strings.TrimSpace(string(body))
-	err = c.checkFrameworkRestrictions(frameworkName, *resp, bodyStr)
+	err = c.checkFrameworkRestrictions(*resp, bodyStr, frameworkName, c.Credentials.Username)
 	if err != nil {
 		return err
 	}
@@ -202,9 +202,9 @@ func (c *Client) CheckFrameworkAvailability(ctx context.Context, frameworkName s
 }
 
 // checkFrameworkRestrictions checks specific cases related to framework availability
-func (c *Client) checkFrameworkRestrictions(framework string, resp http.Response, body string) error {
+func (c *Client) checkFrameworkRestrictions(resp http.Response, body string, framework, username string) error {
 	if resp.StatusCode == http.StatusForbidden && body == forbiddenPreviewError {
-		log.Error().Msg("Looks like you are not part of the preview. To join the preview, please sign up here: https://info.saucelabs.com/scale-cypress-testing.html")
+		log.Error().Msg("User \"" + username + "\" is not registered for the " + framework + " preview. To join the preview, please sign up here: https://info.saucelabs.com/scale-cypress-testing.html")
 		return errors.New("not part of preview")
 	}
 	if resp.StatusCode == http.StatusBadRequest && body == unsupportedFrameworkError {

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -76,7 +76,7 @@ func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID str
 
 	// Check if error is related to preview
 	if resp.StatusCode == http.StatusForbidden && string(body) == ForbiddenPreviewError {
-		log.Error().Msg("Looks like you are not part of the preview. To join the preview, please sign up here: (link)")
+		log.Error().Msg("Looks like you are not part of the preview. To join the preview, please sign up here: https://info.saucelabs.com/scale-cypress-testing.html")
 		err = fmt.Errorf("job start failed; not part of preview")
 		return "", err
 	}

--- a/internal/testcomposer/testcomposer_test.go
+++ b/internal/testcomposer/testcomposer_test.go
@@ -114,6 +114,39 @@ func TestTestComposer_StartJob(t *testing.T) {
 				w.WriteHeader(300)
 			},
 		},
+		{
+			name: "Non preview error",
+			fields: fields{
+				HTTPClient: mockTestComposerServer.Client(),
+				URL:        mockTestComposerServer.URL,
+			},
+			args: args{
+				ctx:               context.TODO(),
+				jobStarterPayload: job.StartOptions{},
+			},
+			want:    "",
+			wantErr: fmt.Errorf("job start failed; not part of preview"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(403)
+				w.Write([]byte(ForbiddenPreviewError))
+			},
+		},
+		{
+			name: "Other forbidden error",
+			fields: fields{
+				HTTPClient: mockTestComposerServer.Client(),
+				URL:        mockTestComposerServer.URL,
+			},
+			args: args{
+				ctx:               context.TODO(),
+				jobStarterPayload: job.StartOptions{},
+			},
+			want:    "",
+			wantErr: fmt.Errorf("job start failed; unexpected response code:'403', msg:''"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(403)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/testcomposer/testcomposer_test.go
+++ b/internal/testcomposer/testcomposer_test.go
@@ -128,7 +128,7 @@ func TestTestComposer_StartJob(t *testing.T) {
 			wantErr: fmt.Errorf("job start failed; not part of preview"),
 			serverFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(403)
-				w.Write([]byte(ForbiddenPreviewError))
+				w.Write([]byte(forbiddenPreviewError))
 			},
 		},
 		{

--- a/internal/testcomposer/testcomposer_test.go
+++ b/internal/testcomposer/testcomposer_test.go
@@ -3,6 +3,7 @@ package testcomposer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/cli/credentials"
@@ -132,7 +133,7 @@ func TestTestComposer_StartJob(t *testing.T) {
 			},
 		},
 		{
-			name: "Other forbidden error",
+			name: "Non supported framework error",
 			fields: fields{
 				HTTPClient: mockTestComposerServer.Client(),
 				URL:        mockTestComposerServer.URL,
@@ -142,9 +143,27 @@ func TestTestComposer_StartJob(t *testing.T) {
 				jobStarterPayload: job.StartOptions{},
 			},
 			want:    "",
-			wantErr: fmt.Errorf("job start failed; unexpected response code:'403', msg:''"),
+			wantErr: fmt.Errorf("job start failed; framework not supported"),
 			serverFunc: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(403)
+				w.WriteHeader(400)
+				w.Write([]byte(unsupportedFrameworkError))
+			},
+		},
+		{
+			name: "Unknown error",
+			fields: fields{
+				HTTPClient: mockTestComposerServer.Client(),
+				URL:        mockTestComposerServer.URL,
+			},
+			args: args{
+				ctx:               context.TODO(),
+				jobStarterPayload: job.StartOptions{},
+			},
+			want:    "",
+			wantErr: fmt.Errorf("job start failed; unexpected response code:'500', msg:'Internal server error'"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(500)
+				w.Write([]byte("Internal server error"))
 			},
 		},
 	}
@@ -296,6 +315,109 @@ func TestClient_NextAssignment(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("NextAssignment() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTestComposer_CheckFrameworkAvailability(t *testing.T) {
+	respo := Responder{
+		Test: t,
+	}
+	mockTestComposerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		respo.Play(w, r)
+	}))
+	type args struct {
+		ctx       context.Context
+		framework string
+	}
+	type fields struct {
+		HTTPClient *http.Client
+		URL        string
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		want       error
+		serverFunc func(w http.ResponseWriter, r *http.Request) // what shall the mock server respond with
+	}{
+		{
+			name: "Access OK",
+			fields: fields{
+				HTTPClient: mockTestComposerServer.Client(),
+				URL:        mockTestComposerServer.URL,
+			},
+			args: args{
+				ctx: context.TODO(),
+				framework: "fake-framework",
+			},
+			want: nil,
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+			},
+		},
+		{
+			name: "Not part of preview",
+			fields: fields{
+				HTTPClient: mockTestComposerServer.Client(),
+				URL:        mockTestComposerServer.URL,
+			},
+			args: args{
+				ctx: context.TODO(),
+				framework: "fake-framework",
+			},
+			want: errors.New("not part of preview"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(403)
+				w.Write([]byte(forbiddenPreviewError))
+			},
+		},
+		{
+			name: "Unexpected error",
+			fields: fields{
+				HTTPClient: mockTestComposerServer.Client(),
+				URL:        mockTestComposerServer.URL,
+			},
+			args: args{
+				ctx: context.TODO(),
+				framework: "fake-framework",
+			},
+			want: errors.New("unexpected response code:'500', msg:''"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(500)
+			},
+		},
+		{
+			name: "Unsupported backend",
+			fields: fields{
+				HTTPClient: mockTestComposerServer.Client(),
+				URL:        mockTestComposerServer.URL,
+			},
+			args: args{
+				ctx: context.TODO(),
+				framework: "fake-framework",
+			},
+			want: errors.New("framework not supported"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(400)
+				w.Write([]byte(unsupportedFrameworkError))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				HTTPClient: tt.fields.HTTPClient,
+				URL:        tt.fields.URL,
+			}
+
+			respo.Record(tt.serverFunc)
+
+			err := c.CheckFrameworkAvailability(tt.args.ctx, tt.args.framework)
+			if !reflect.DeepEqual(err, tt.want) {
+				t.Errorf("CheckFrameworkAvailability() got = %v, want %v", err, tt.want)
+				return
 			}
 		})
 	}


### PR DESCRIPTION
## Proposed changes

To ensure we don't have saucectl trying to access backend in case of restricted framework, this PR implements a check before uploading and trying to run the test package.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Should be merge after backend availability