### PR TITLE
Enhance messaging when a suite fails

### DIFF
--- a/internal/cypress/sauce/runner.go
+++ b/internal/cypress/sauce/runner.go
@@ -226,11 +226,11 @@ func (r *Runner) logSuite(res result) {
 		log.Error().Str("suite", res.suiteName).Msgf("%s", res.err)
 		return
 	}
-	resultStr := "pass"
+	resultStr := "Passed"
 	if !res.job.Passed {
-		resultStr = "failure"
+		resultStr = "Failed"
 	}
-	log.Info().Str("suite", res.suiteName).Msgf("Result %s", resultStr)
+	log.Info().Str("suite", res.suiteName).Msgf("%s: %s", res.suiteName, resultStr)
 
 	if !res.job.Passed {
 		r.logSuiteError(res)

--- a/internal/cypress/sauce/runner.go
+++ b/internal/cypress/sauce/runner.go
@@ -222,21 +222,20 @@ func (r *Runner) uploadProject(filename string) (string, error) {
 // logSuite display the result of a suite
 func (r *Runner) logSuite(res result) {
 	if res.job.ID == "" {
-		log.Error().Msgf("Suite \"%s\": failed to be started", res.suiteName)
-		log.Error().Msgf("Error: %s", res.err)
+		log.Error().Str("suite", res.suiteName).Msgf("failed to be started")
+		log.Error().Str("suite", res.suiteName).Msgf("%s", res.err)
 		return
 	}
 	resultStr := "pass"
 	if !res.job.Passed {
 		resultStr = "failure"
 	}
-	log.Info().Str("suiteName", res.suiteName).
-		Msgf("Suite \"%s\": %s", res.suiteName, resultStr)
+	log.Info().Str("suite", res.suiteName).Msgf("Result %s", resultStr)
 
 	if !res.job.Passed {
 		r.logSuiteError(res)
 	}
-	log.Info().Msgf("Open job details page: %s", r.URL+"/tests/"+res.job.ID)
+	log.Info().Str("suite", res.suiteName).Msgf("Open job details page: %s", r.URL+"/tests/"+res.job.ID)
 }
 
 // logSuiteError display the console output when tests from a suite are failing

--- a/internal/cypress/sauce/runner.go
+++ b/internal/cypress/sauce/runner.go
@@ -97,6 +97,7 @@ func (r *Runner) runSuites(fileID string) bool {
 	inProgress := total
 	passed := true
 
+	progress.Show("Suites completed: %d/%d", completed, total)
 	for i := 0; i < total; i++ {
 		res := <-results
 		// in case one of test suites not passed
@@ -106,13 +107,14 @@ func (r *Runner) runSuites(fileID string) bool {
 		completed++
 		inProgress--
 
-		log.Info().Msgf("Suites completed: %d/%d", completed, total)
+		progress.Show("Suites completed: %d/%d", completed, total)
 		r.logSuite(res)
 
-		if res.err != nil {
+		if res.job.ID != "" || res.err != nil {
 			errCount++
 		}
 	}
+	progress.Stop()
 	logSuitesResult(total, errCount)
 
 	return passed

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -87,7 +87,7 @@ func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID str
 	}
 
 	if resp.StatusCode >= 300 {
-		err = fmt.Errorf("job start failed; unexpected response code:'%d', msg:'%v'", resp.StatusCode, string(body))
+		err = fmt.Errorf("job start failed; unexpected response code:'%d', msg:'%v'", resp.StatusCode, strings.TrimSpace(string(body)))
 		return "", err
 	}
 


### PR DESCRIPTION
## Proposed changes

This PR enhances the messaging about errors in suites.

Before:
```
$> saucectl run -c .sauce/staging.yml --test-env sauce --region staging --ccy 2
11:09AM INF Running version unknown-version
11:09AM INF Reading config file config=.sauce/staging.yml
11:09AM INF Running Cypress in Sauce Labs
11:09AM ERR Caution: Not yet implemented.
11:09AM INF Project uploaded. fileID=xxxxxxxx-xxxx-xxxx-xxxx-c81d39fea402
11:09AM INF Launching workers. concurrency=2
11:09AM INF Starting job. suite="Firefox Tests"
11:09AM INF Suites completed: 0 in progress: 2
11:09AM INF Starting job. suite="Chrome Tests"
11:09AM INF Suites completed: 1 in progress: 1
11:09AM INF Suite name: Firefox Tests
11:09AM INF Browser: firefox
11:09AM INF Passed: false
11:09AM WRN Failed to get job asset. suite="Firefox Tests"
11:09AM INF Open job details page: https://api.staging.saucelabs.net/tests/
11:10AM INF Suites completed: 2 in progress: 0
11:10AM INF Suite name: Chrome Tests
11:10AM INF Browser: chrome
11:10AM INF Passed: false
11:10AM WRN Failed to get job asset. suite="Chrome Tests"
11:10AM INF Open job details page: https://api.staging.saucelabs.net/tests/
11:10AM INF Suites total: 2
11:10AM INF Suites passed: 0
11:10AM INF Suites failed: 2
```

After:
```
$> saucectl run -c .sauce/staging.yml --test-env sauce --region staging --ccy 2
11:05AM INF Running version unknown-version
11:05AM INF Reading config file config=.sauce/staging.yml
11:05AM INF Running Cypress in Sauce Labs
11:05AM ERR Caution: Not yet implemented.
11:05AM INF Project uploaded. fileID=xxxxxxxx-xxxx-xxxx-xxxx-705b4c0cc4e8
11:05AM INF Launching workers. concurrency=2
11:05AM INF Starting job. suite="Firefox Tests"
11:05AM INF Starting job. suite="Chrome Tests"
11:05AM ERR failed to be started suite="Chrome Tests"
11:05AM ERR job start failed; unexpected response code:'500', msg:'Internal Server Error' suite="Chrome Tests"
11:05AM ERR failed to be started suite="Firefox Tests"
11:05AM ERR job start failed; unexpected response code:'500', msg:'Internal Server Error' suite="Firefox Tests"
11:06AM INF Suites total: 2
11:06AM INF Suites passed: 0
11:06AM INF Suites failed: 2
$> 
```

It also adds the progress spinner to show there is still activity:
```
$> saucectl run -c .sauce/staging.yml --test-env sauce --region staging --ccy 2
11:05AM INF Running version unknown-version
11:05AM INF Reading config file config=.sauce/staging.yml
11:05AM INF Running Cypress in Sauce Labs
11:05AM ERR Caution: Not yet implemented.
11:05AM INF Project uploaded. fileID=xxxxxxxx-xxxx-xxxx-xxxx-5e1941ced0a8
11:05AM INF Launching workers. concurrency=2
11:05AM INF Starting job. suite="Firefox Tests"
11:05AM INF Starting job. suite="Chrome Tests"
⠋ Suites completed: 1/2
[...]
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

