### PR TITLE
Capture TestComposer jobID from API correctly

### DIFF
--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -16,7 +16,7 @@ var DoneStates = []string{StateComplete, StateError}
 // Job represents test details and metadata of a test run (aka Job), that is usually associated with a particular test
 // execution instance (e.g. VM).
 type Job struct {
-	ID     string `json:"jobID"`
+	ID     string `json:"id"`
 	Passed bool   `json:"passed"`
 	Status string `json:"status"`
 	Error  string `json:"error"`

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -16,7 +16,7 @@ var DoneStates = []string{StateComplete, StateError}
 // Job represents test details and metadata of a test run (aka Job), that is usually associated with a particular test
 // execution instance (e.g. VM).
 type Job struct {
-	ID     string `json:"id"`
+	ID     string `json:"jobID"`
 	Passed bool   `json:"passed"`
 	Status string `json:"status"`
 	Error  string `json:"error"`

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -91,13 +91,15 @@ func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID str
 		return "", err
 	}
 
-	var j Job
+	j := struct {
+		JobID string
+	}{}
 	err = json.Unmarshal(body, &j)
 	if err != nil {
 		return
 	}
 
-	return j.ID, nil
+	return j.JobID, nil
 }
 
 // Register registers a fleet with the given buildID and test suites.

--- a/internal/testcomposer/testcomposer_test.go
+++ b/internal/testcomposer/testcomposer_test.go
@@ -34,8 +34,8 @@ func (r *Responder) Play(w http.ResponseWriter, req *http.Request) {
 	r.Index++
 }
 
-func respondJSON(w http.ResponseWriter, v interface{}) {
-	w.WriteHeader(200)
+func respondJSON(w http.ResponseWriter, v interface{}, httpStatus int) {
+	w.WriteHeader(httpStatus)
 	b, err := json.Marshal(v)
 
 	if err != nil {
@@ -93,10 +93,11 @@ func TestTestComposer_StartJob(t *testing.T) {
 			want:    "fake-job-id",
 			wantErr: nil,
 			serverFunc: func(w http.ResponseWriter, r *http.Request) {
-				respondJSON(w, Job{
-					ID:    "fake-job-id",
-					Owner: "fake-owner",
-				})
+				respondJSON(w, struct {
+					JobID string `json:"jobID"`
+				}{
+					JobID: "fake-job-id",
+				}, 201)
 			},
 		},
 		{
@@ -349,7 +350,7 @@ func TestTestComposer_CheckFrameworkAvailability(t *testing.T) {
 				URL:        mockTestComposerServer.URL,
 			},
 			args: args{
-				ctx: context.TODO(),
+				ctx:       context.TODO(),
 				framework: "fake-framework",
 			},
 			want: nil,
@@ -364,7 +365,7 @@ func TestTestComposer_CheckFrameworkAvailability(t *testing.T) {
 				URL:        mockTestComposerServer.URL,
 			},
 			args: args{
-				ctx: context.TODO(),
+				ctx:       context.TODO(),
 				framework: "fake-framework",
 			},
 			want: errors.New("not part of preview"),
@@ -380,7 +381,7 @@ func TestTestComposer_CheckFrameworkAvailability(t *testing.T) {
 				URL:        mockTestComposerServer.URL,
 			},
 			args: args{
-				ctx: context.TODO(),
+				ctx:       context.TODO(),
 				framework: "fake-framework",
 			},
 			want: errors.New("unexpected response code:'500', msg:''"),
@@ -395,7 +396,7 @@ func TestTestComposer_CheckFrameworkAvailability(t *testing.T) {
 				URL:        mockTestComposerServer.URL,
 			},
 			args: args{
-				ctx: context.TODO(),
+				ctx:       context.TODO(),
 				framework: "fake-framework",
 			},
 			want: errors.New("framework not supported"),


### PR DESCRIPTION
## Proposed changes

Field mapping between `test-composer` and `saucectl` were not consistent and generating non-errors.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
