### PR TITLE
Don't return empty job when test failed

### DIFF
--- a/internal/cypress/sauce/runner.go
+++ b/internal/cypress/sauce/runner.go
@@ -170,8 +170,8 @@ func (r *Runner) runSuite(s cypress.Suite, fileID string) (job.Job, error) {
 	}
 
 	if !j.Passed {
-		// TODO do we need to differentiate test passes/failure vs. job failure (failed to start, crashed)?
-		return job.Job{}, fmt.Errorf("suite '%s' has test failures", s.Name)
+		// We may need to differentiate when a job has crashed vs. when there is errors.
+		return j, fmt.Errorf("suite '%s' has test failures", s.Name)
 	}
 
 	return j, nil


### PR DESCRIPTION
## Proposed changes

No jobId is currently returned when a job has errors.
Console is not printed nor link is provided.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
