### PR TITLE
Update goreleaser config + workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: saucectl release
 on:
   push:
     tags:
-      - 'v*'
+      - v*
 
 env:
   GH_TOKEN: ${{secrets.GH_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@
 name: saucectl release
 
 on:
-  create:
+  push:
     tags:
       - 'v*'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,13 @@ jobs:
         run: |
           go test -coverprofile=coverage.out ./...
           goverreport -sort=block -order=desc -threshold=45
+
+      - name: Check GoReleaser config
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: check
+
       - name: Upload binary
         uses: actions/upload-artifact@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ builds:
       - -X github.com/saucelabs/saucectl/cli/version.Version={{.Version}}
       - -X github.com/saucelabs/saucectl/cli/version.GitCommit={{.Commit}}
 brews:
-  - github:
+  - tap:
       owner: saucelabs
       name: homebrew-saucectl
     folder: Formula


### PR DESCRIPTION
## Proposed changes

- Update GoReleaser configuration to remove deprecated & removed compatibility from old taps config.
- Check for GoReleaser configuration when creating a PR.
- Updated workflow `on:` field to trigger release only when building new tags not new branches See [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
