### PR TITLE
Add concurrency flag to config

### DIFF
--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -2,6 +2,7 @@ apiVersion: v1alpha
 kind: cypress
 sauce:
   region: us-west-1
+  concurrency: 1 # Controls how many suites are executed at the same time.
   metadata:
     name: Testing Cypress Support
     tags:

--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -13,13 +13,13 @@ docker:
   fileTransfer: mount
   image:
     name: saucelabs/stt-cypress-mocha-node
-    tag: v0.2.0
+    tag: v0.3.3
 cypress:
   configFile: "tests/e2e/cypress.json"  # We determine related files based on the location of the config file.
 suites:
   - name: "saucy test"
     browser: "chrome"
-    platform: "Windows 10"
+    platformName: "Windows 10"
     config:
       env:
         hello: world

--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -2,7 +2,7 @@ apiVersion: v1alpha
 kind: cypress
 sauce:
   region: us-west-1
-  concurrency: 1 # Controls how many suites are executed at the same time.
+  concurrency: 1 # Controls how many suites are executed at the same time (sauce test env only).
   metadata:
     name: Testing Cypress Support
     tags:

--- a/.sauce/cypress_cloud.yml
+++ b/.sauce/cypress_cloud.yml
@@ -2,6 +2,7 @@ apiVersion: v1alpha
 kind: cypress
 sauce:
   region: us-west-1
+  concurrency: 1 # Controls how many suites are executed at the same time.
   metadata:
     name: Testing Cypress Support
     tags:

--- a/.sauce/cypress_cloud.yml
+++ b/.sauce/cypress_cloud.yml
@@ -2,7 +2,7 @@ apiVersion: v1alpha
 kind: cypress
 sauce:
   region: us-west-1
-  concurrency: 1 # Controls how many suites are executed at the same time.
+  concurrency: 1 # Controls how many suites are executed at the same time (sauce test env only).
   metadata:
     name: Testing Cypress Support
     tags:

--- a/.sauce/cypress_cloud.yml
+++ b/.sauce/cypress_cloud.yml
@@ -13,20 +13,20 @@ docker:
   fileTransfer: mount
   image:
     name: saucelabs/stt-cypress-mocha-node
-    tag: v0.2.0
+    tag: v0.3.3
 cypress:
   configFile: "tests/e2e/cypress.json"  # We determine related files based on the location of the config file.
 suites:
   - name: "saucy chrome test"
     browser: "googlechrome"
-    platform: "Windows 10"
+    platformName: "Windows 10"
     config:
       env:
         hello: world
       testFiles: [ "**/*.*" ] # Cypress native glob support.
   - name: "saucy microsoftedge test"
     browser: "microsoftedge"
-    platform: "Windows 10"
+    platformName: "Windows 10"
     config:
       env:
         hello: world

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -181,6 +181,10 @@ func runCypress(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
 		}
 	}
 
+	if cmd.Flags().Lookup("ccy").Changed {
+		p.Sauce.Concurrency = concurrency
+	}
+
 	switch testEnv {
 	case "docker":
 		return runCypressInDocker(p, cli)
@@ -238,7 +242,6 @@ func runCypressInSauce(p cypress.Project) (int, error) {
 		ProjectUploader: s,
 		JobStarter:      &tc,
 		JobReader:       &rsto,
-		Concurrency:     concurrency,
 		Region:          re,
 	}
 	return r.RunProject()

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -71,9 +71,10 @@ type Suite struct {
 
 // SauceConfig represents sauce labs related settings.
 type SauceConfig struct {
-	Region   string   `yaml:"region,omitempty" json:"region"`
-	Metadata Metadata `yaml:"metadata,omitempty" json:"metadata"`
-	Tunnel   Tunnel   `yaml:"tunnel,omitempty" json:"tunnel,omitempty"`
+	Region      string   `yaml:"region,omitempty" json:"region"`
+	Metadata    Metadata `yaml:"metadata,omitempty" json:"metadata"`
+	Tunnel      Tunnel   `yaml:"tunnel,omitempty" json:"tunnel,omitempty"`
+	Concurrency int      `yaml:"concurrency,omitempty" json:"concurrency,omitempty"`
 }
 
 // Tunnel represents a sauce labs tunnel.

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -85,5 +85,9 @@ func FromFile(cfgPath string) (Project, error) {
 		p.Docker.FileTransfer = config.DockerFileMount
 	}
 
+	if p.Sauce.Concurrency < 1 {
+		p.Sauce.Concurrency = 1
+	}
+
 	return p, nil
 }

--- a/internal/cypress/sauce/runner.go
+++ b/internal/cypress/sauce/runner.go
@@ -27,7 +27,6 @@ type Runner struct {
 	ProjectUploader storage.ProjectUploader
 	JobStarter      job.Starter
 	JobReader       job.Reader
-	Concurrency     int
 	Region          region.Region
 }
 
@@ -79,8 +78,8 @@ func (r *Runner) runSuites(fileID string) bool {
 	defer close(results)
 
 	// Create a pool of workers that run the suites.
-	log.Info().Int("concurrency", r.Concurrency).Msg("Launching workers.")
-	for i := 0; i < r.Concurrency; i++ {
+	log.Info().Int("concurrency", r.Project.Sauce.Concurrency).Msg("Launching workers.")
+	for i := 0; i < r.Project.Sauce.Concurrency; i++ {
 		go r.worker(fileID, suites, results)
 	}
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Add concurrency flag to config. The concurrency setting can now be applied via CLI args or the config itself. CLI arg takes precedence.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
