### PR TITLE
Playwright native configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,9 +158,6 @@ jobs:
   playwright:
     needs: basic
     runs-on: ubuntu-latest
-    container:
-      image: saucelabs/stt-playwright-jest-node:v0.1.6
-      options: --user 1001
 
     steps:
       # appears that checkout@v2 uses javascript which is not compatible

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -1,20 +1,23 @@
 apiVersion: v1alpha
 kind: playwright
-metadata:
-  name: Testing Playwright Support
-  tags:
-    - e2e
-  build: "$BUILD_ID"
+sauce:
+  region: us-west-1
+  metadata:
+    name: Testing Playwright Support
+    tags:
+      - e2e
+    build: "$BUILD_ID"
+docker:
+  fileTransfer: mount
+  image:
+    name: saucelabs/stt-playwright-jest-node
+    tag: latest
 playwright:
-  configFile: "dummy.json"
-  envFile: ""
+  projectPath: tests/e2e/playwright/
+  params:
+#    browserName: firefox
 suites:
   - name: "saucy test"
     match: ".*.(spec|test).js$"
     settings:
       browserName: "firefox"
-image:
-  base: saucelabs/stt-playwright-jest-node
-  version: latest
-sauce:
-  region: us-west-1

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -1,11 +1,13 @@
 apiVersion: v1alpha
+kind: playwright
 metadata:
   name: Testing Playwright Support
   tags:
     - e2e
   build: "$BUILD_ID"
-files:
-  - ./tests/e2e/playwright/example.test.js
+playwright:
+  configFile: "dummy.json"
+  envFile: ""
 suites:
   - name: "saucy test"
     match: ".*.(spec|test).js$"

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -10,9 +10,6 @@ sauce:
     build: "$BUILD_ID"
 docker:
   fileTransfer: mount
-  image:
-    name: saucelabs/stt-playwright-jest-node
-    tag: v0.3.0
 playwright:
   projectPath: tests/e2e/playwright/
   version: 1.7.1

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -15,9 +15,18 @@ docker:
 playwright:
   projectPath: tests/e2e/playwright/
   params:
-#    browserName: firefox
+    browserName: firefox
 suites:
   - name: "saucy test"
-    match: ".*.(spec|test).js$"
-    settings:
+    # Sauce Specific
+    browserName: "firefox" # ignored for now
+    browserVersion: "84" # Ignored for now
+    platformName: "Windows 10"
+
+    config:
+      env:
+        FOO: bar
+
+    # Playwright-test settings
+    param:
       browserName: "firefox"

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -22,10 +22,7 @@ suites:
     browserName: "firefox" # ignored for now
     browserVersion: "84" # Ignored for now
     platformName: "Windows 10"
-
-    config:
-      env:
-        FOO: bar
+    testMatch: '**/*.js'
 
     # Playwright-test settings
     param:

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -18,9 +18,6 @@ playwright:
     browserName: firefox
 suites:
   - name: "saucy test"
-    # Sauce Specific
-    browserName: "firefox" # ignored for now
-    browserVersion: "84" # Ignored for now
     platformName: "Windows 10"
     testMatch: '**/*.js'
 

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -2,6 +2,7 @@ apiVersion: v1alpha
 kind: playwright
 sauce:
   region: us-west-1
+  concurrency: 1
   metadata:
     name: Testing Playwright Support
     tags:
@@ -14,6 +15,7 @@ docker:
     tag: latest
 playwright:
   projectPath: tests/e2e/playwright/
+  version: 1.7.1
   params:
     browserName: firefox
 suites:

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -10,9 +10,6 @@ sauce:
     build: "$BUILD_ID"
 docker:
   fileTransfer: mount
-  image:
-    name: saucelabs/stt-playwright-jest-node
-    tag: latest
 playwright:
   projectPath: tests/e2e/playwright/
   version: 1.7.1

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -10,6 +10,9 @@ sauce:
     build: "$BUILD_ID"
 docker:
   fileTransfer: mount
+  image:
+    name: saucelabs/stt-playwright-jest-node
+    tag: v0.3.0
 playwright:
   projectPath: tests/e2e/playwright/
   version: 1.7.1

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -26,5 +26,5 @@ suites:
     # Playwright-test settings
     param:
       browserName: "firefox"
-      headful: true
+      headful: false
       slowMo: 1000

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -26,3 +26,5 @@ suites:
     # Playwright-test settings
     param:
       browserName: "firefox"
+      headful: true
+      slowMo: 1000

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ coverage:
 
 #playwright-ci: @ Run tests against playwright in CI mode
 playwright-ci: build-linux
-	docker run --name playwright-ci -e "CI=true" -v $(shell pwd):/home/gitty/ -w "/home/gitty" --rm saucelabs/stt-playwright-jest-node:latest "/home/gitty/saucectl" run -c ./.sauce/playwright.yml --verbose
+	docker run --name playwright-ci -e "CI=true" -v $(shell pwd):/home/gitty/ -w "/home/gitty" --rm saucelabs/stt-playwright-node:latest "/home/gitty/saucectl" run -c ./.sauce/playwright.yml --verbose
 
 #puppeteer-ci: @ Run tests against puppeteer in CI mode
 puppeteer-ci: build-linux

--- a/cli/command/new/cmd.go
+++ b/cli/command/new/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/saucelabs/saucectl/cli/config"
 	"github.com/saucelabs/saucectl/cli/credentials"
 	"github.com/saucelabs/saucectl/internal/cypress"
+	"github.com/saucelabs/saucectl/internal/playwright"
 	"github.com/saucelabs/saucectl/internal/yaml"
 	"github.com/spf13/cobra"
 	"github.com/tj/survey"
@@ -134,6 +135,14 @@ func updateRegion(cfgFile string, region string) error {
 
 	if d.Kind == config.KindCypress && d.APIVersion == config.VersionV1Alpha {
 		c, err := cypress.FromFile(cfgFile)
+		if err != nil {
+			return err
+		}
+		c.Sauce.Region = region
+		return yaml.WriteFile(cfgPath, c)
+	}
+	if d.Kind == config.KindPlaywright && d.APIVersion == config.VersionV1Alpha {
+		c, err := playwright.FromFile(cfgFile)
 		if err != nil {
 			return err
 		}

--- a/cli/command/new/cmd_test.go
+++ b/cli/command/new/cmd_test.go
@@ -49,7 +49,7 @@ func TestUpdateRegionCypress(t *testing.T) {
 
 func TestUpdateRegionPlaywright(t *testing.T) {
 	dir := fs.NewDir(t, "fixtures",
-		fs.WithFile("config.yml", "apiVersion: v1alpha\nkind: playwright", fs.WithMode(0644)))
+		fs.WithFile("config.yml", "apiVersion: v1alpha\nkind: playwright\nplaywright:\n  projectPath: dummy-folder", fs.WithMode(0644)))
 	path, _ := os.Getwd()
 	defer func () {
 		os.Chdir(path)

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -275,16 +275,6 @@ func runPlaywright(cli *command.SauceCtlCli) (int, error) {
 
 	p.Sauce.Metadata.ExpandEnv()
 
-	// Merge env from CLI args and job config. CLI args take precedence.
-	for k, v := range env {
-		for _, s := range p.Suites {
-			if s.Config.Env == nil {
-				s.Config.Env = map[string]string{}
-			}
-			s.Config.Env[k] = v
-		}
-	}
-
 	if p.Sauce.Region == "" {
 		p.Sauce.Region = defaultRegion
 	}

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -328,6 +328,7 @@ func runPlaywrightInSauce(p playwright.Project) (int, error) {
 		ProjectUploader: s,
 		JobStarter:      &tc,
 		JobReader:       &rsto,
+		CCYReader:       &rsto,
 		Region:          re,
 	}
 	return r.RunProject()

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -264,6 +264,12 @@ func runPlaywright(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
 		p.ShowConsoleLog = true
 	}
 
+	if cmd.Flags().Lookup("suite").Changed {
+		if err := filterPlaywrightSuite(&p); err != nil {
+			return 1, err
+		}
+	}
+
 
 	switch testEnv {
 	case "docker":
@@ -455,6 +461,16 @@ func filterCypressSuite(c *cypress.Project) error {
 	for _, s := range c.Suites {
 		if s.Name == suiteName {
 			c.Suites = []cypress.Suite{s}
+			return nil
+		}
+	}
+	return fmt.Errorf("suite name '%s' is invalid", suiteName)
+}
+
+func filterPlaywrightSuite(c *playwright.Project) error {
+	for _, s := range c.Suites {
+		if s.Name == suiteName {
+			c.Suites = []playwright.Suite{s}
 			return nil
 		}
 	}

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -161,7 +161,7 @@ func runCypress(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
 
 	p.Sauce.Metadata.ExpandEnv()
 	applyDefaultValues(&p.Sauce)
-	overrideCliParameters(cmd, p.Sauce)
+	overrideCliParameters(cmd, &p.Sauce)
 
 	// Merge env from CLI args and job config. CLI args take precedence.
 	for k, v := range env {
@@ -258,7 +258,7 @@ func runPlaywright(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
 
 	p.Sauce.Metadata.ExpandEnv()
 	applyDefaultValues(&p.Sauce)
-	overrideCliParameters(cmd, p.Sauce)
+	overrideCliParameters(cmd, &p.Sauce)
 
 	if showConsoleLog {
 		p.ShowConsoleLog = true
@@ -492,7 +492,7 @@ func applyDefaultValues(sauce *config.SauceConfig) {
 	}
 }
 
-func overrideCliParameters(cmd *cobra.Command, sauce config.SauceConfig) {
+func overrideCliParameters(cmd *cobra.Command, sauce *config.SauceConfig) {
 	if cmd.Flags().Lookup("region").Changed {
 		sauce.Region = regionFlag
 	}

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/ci/gitlab"
 	"github.com/saucelabs/saucectl/internal/ci/jenkins"
 	cypressDocker "github.com/saucelabs/saucectl/internal/cypress/docker"
+	playwrightDocker "github.com/saucelabs/saucectl/internal/playwright/docker"
 	"github.com/saucelabs/saucectl/internal/docker"
 	"github.com/saucelabs/saucectl/internal/fleet"
 	"github.com/saucelabs/saucectl/internal/memseq"
@@ -303,12 +304,11 @@ func runPlaywright(cli *command.SauceCtlCli) (int, error) {
 func runPlaywrightInDocker(p playwright.Project, cli *command.SauceCtlCli) (int, error) {
 	log.Info().Msg("Running Playwright in Docker")
 
-	//cd, err := cypressDocker.New(p, cli)
-	//if err != nil {
-	//	return 1, err
-	//}
-	//return cd.RunProject()
-	return 0, errors.New("not implemented")
+	cd, err := playwrightDocker.New(p, cli)
+	if err != nil {
+		return 1, err
+	}
+	return cd.RunProject()
 }
 
 func newRunner(p config.Project, cli *command.SauceCtlCli) (runner.Testrunner, error) {

--- a/cli/command/run/cmd_test.go
+++ b/cli/command/run/cmd_test.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"github.com/saucelabs/saucectl/cli/config"
 	"path/filepath"
 	"testing"
 
@@ -118,5 +119,22 @@ func Test_apiBaseURL(t *testing.T) {
 				t.Errorf("apiBaseURL() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestApplyDefaultValues(t *testing.T) {
+	tests := []struct {
+		beginRegion    string
+		wantRegion string
+	}{
+		{beginRegion: "", wantRegion: defaultRegion},
+		{beginRegion: "dummy-region", wantRegion: "dummy-region"},
+	}
+	for _, tt := range tests {
+		sauce := config.SauceConfig{
+			Region: tt.beginRegion,
+		}
+		applyDefaultValues(&sauce)
+		assert.Equal(t, tt.wantRegion, sauce.Region)
 	}
 }

--- a/cli/command/run/cmd_test.go
+++ b/cli/command/run/cmd_test.go
@@ -211,3 +211,7 @@ func TestFilterPlaywrightSuite(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateCIProvider(t *testing.T) {
+	enableCIProviders()
+}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -136,6 +136,7 @@ const (
 // Kind* contains referenced config kinds
 const (
 	KindCypress = "cypress"
+	KindPlaywright = "playwright"
 )
 
 func readYaml(cfgFilePath string) ([]byte, error) {

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -56,3 +56,22 @@ func TestRunnerConfiguration(t *testing.T) {
 
 	assert.Equal(t, configObject.RootDir, "/foo/bar")
 }
+
+func TestLegacyRunnerConfiguration(t *testing.T) {
+	dir := fs.NewDir(t, "fixtures",
+		fs.WithFile("valid_config.yaml", "rootDir: /foo/bar\nsuites:\n- name: dummy\n  capabilities:\n    browserName: firefox", fs.WithMode(0755)))
+	defer dir.Remove()
+
+	configObject, err := NewJobConfiguration(dir.Path() + "/valid_config.yaml")
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "dummy", configObject.Suites[0].Name)
+	assert.Equal(t, "firefox", configObject.Suites[0].Capabilities.BrowserName)
+}
+
+func TestStandardizeVersionFormat(t *testing.T) {
+	assert.Equal(t, "5.6.0", StandardizeVersionFormat("v5.6.0"))
+	assert.Equal(t, "5.6.0", StandardizeVersionFormat("5.6.0"))
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/rs/zerolog v1.18.0
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0
 	github.com/tj/survey v2.0.6+incompatible
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -5,14 +5,13 @@ import (
 	"github.com/saucelabs/saucectl/cli/config"
 	"gopkg.in/yaml.v2"
 	"os"
-	"path/filepath"
 )
 
 // Project represents the cypress project configuration.
 type Project struct {
 	config.TypeDef `yaml:",inline"`
 	Sauce          config.SauceConfig `yaml:"sauce,omitempty" json:"sauce"`
-	Playwright     Playwright         `yaml:"cypress,omitempty" json:"cypress"`
+	Playwright     Playwright         `yaml:"playwright,omitempty" json:"playwright"`
 	Suites         []Suite            `yaml:"suites,omitempty" json:"suites"`
 	BeforeExec     []string           `yaml:"beforeExec,omitempty" json:"beforeExec"`
 	Docker         config.Docker      `yaml:"docker,omitempty" json:"docker"`
@@ -28,10 +27,16 @@ type Suite struct {
 	Config         SuiteConfig `yaml:"config,omitempty" json:"config"`
 }
 
-// SuiteConfig represents the cypress config overrides.
+// Params represents the playwright parameters
+type Params struct {
+	Browser string `yaml:"browserName,omitempty" json:"browserName,omitempty"`
+}
+
+// SuiteConfig represents the playwright config overrides.
 type SuiteConfig struct {
 	TestFiles []string          `yaml:"testFiles,omitempty" json:"testFiles"`
 	Env       map[string]string `yaml:"env,omitempty" json:"env"`
+	Params    Params            `yaml:"params,omitempty" json:"params"`
 }
 
 // Playwright represents crucial playwright configuration that is required for setting up a project.
@@ -39,6 +44,7 @@ type Playwright struct {
 	ConfigFile  string `yaml:"configFile,omitempty"`
 	EnvFile     string `yaml:"envFile,omitempty"`
 	ProjectPath string `yaml:"projectPath,omitempty"`
+	Params      Params `yaml:"params,omitempty"`
 }
 
 // FromFile creates a new playwright Project based on the filepath cfgPath.
@@ -55,23 +61,23 @@ func FromFile(cfgPath string) (Project, error) {
 		return Project{}, fmt.Errorf("failed to parse project config: %v", err)
 	}
 
-	if _, err := os.Stat(p.Playwright.ConfigFile); err != nil {
-		return p, fmt.Errorf("unable to locate %s", p.Playwright.ConfigFile)
-	}
-	configDir := filepath.Dir(p.Playwright.ConfigFile)
+	//if _, err := os.Stat(p.Playwright.ConfigFile); err != nil {
+	//	return p, fmt.Errorf("unable to locate %s", p.Playwright.ConfigFile)
+	//}
+	//configDir := filepath.Dir(p.Playwright.ConfigFile)
 
-	// We must locate the cypress folder.
-	cPath := filepath.Join(configDir, "cypress")
-	if _, err := os.Stat(cPath); err != nil {
-		return p, fmt.Errorf("unable to locate the cypress folder in %s", configDir)
-	}
-	p.Playwright.ProjectPath = cPath
+	//// We must locate the cypress folder.
+	//cPath := filepath.Join(configDir, "cypress")
+	//if _, err := os.Stat(cPath); err != nil {
+	//	return p, fmt.Errorf("unable to locate the cypress folder in %s", configDir)
+	//}
+	//p.Playwright.ProjectPath = cPath
 
 	// Optionally include the env file if it exists.
-	envFile := filepath.Join(configDir, "cypress.env.json")
-	if _, err := os.Stat(envFile); err == nil {
-		p.Playwright.EnvFile = envFile
-	}
+	//envFile := filepath.Join(configDir, "cypress.env.json")
+	//if _, err := os.Stat(envFile); err == nil {
+	//	p.Playwright.EnvFile = envFile
+	//}
 
 	// Default mode to Mount
 	if p.Docker.FileTransfer == "" {

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -1,0 +1,79 @@
+package playwright
+
+import (
+	"fmt"
+	"github.com/saucelabs/saucectl/cli/config"
+	"gopkg.in/yaml.v2"
+	"os"
+)
+
+// Project represents the cypress project configuration.
+type Project struct {
+	config.TypeDef                    `yaml:",inline"`
+	Sauce          config.SauceConfig `yaml:"sauce,omitempty" json:"sauce"`
+	Playwright     Playwright         `yaml:"cypress,omitempty" json:"cypress"`
+	Suites         []Suite            `yaml:"suites,omitempty" json:"suites"`
+	BeforeExec     []string           `yaml:"beforeExec,omitempty" json:"beforeExec"`
+	Docker         config.Docker      `yaml:"docker,omitempty" json:"docker"`
+	Npm            config.Npm         `yaml:"npm,omitempty" json:"npm"`
+}
+
+// Suite represents the cypress test suite configuration.
+type Suite struct {
+	Name           string      `yaml:"name,omitempty" json:"name"`
+	Browser        string      `yaml:"browser,omitempty" json:"browser"`
+	BrowserVersion string      `yaml:"browserVersion,omitempty" json:"browserVersion"`
+	PlatformName   string      `yaml:"platformName,omitempty" json:"platformName"`
+	Config         SuiteConfig `yaml:"config,omitempty" json:"config"`
+}
+
+// SuiteConfig represents the cypress config overrides.
+type SuiteConfig struct {
+	TestFiles []string          `yaml:"testFiles,omitempty" json:"testFiles"`
+	Env       map[string]string `yaml:"env,omitempty" json:"env"`
+}
+
+// Playwright represents crucial playwright configuration that is required for setting up a project.
+type Playwright struct {
+	ConfigFile string `yaml:"configFile,omitempty"`
+}
+
+// FromFile creates a new playwright Project based on the filepath cfgPath.
+func FromFile(cfgPath string) (Project, error) {
+	var p Project
+
+	f, err := os.Open(cfgPath)
+	defer f.Close()
+	if err != nil {
+		return Project{}, fmt.Errorf("failed to locate project config: %v", err)
+	}
+
+	if err = yaml.NewDecoder(f).Decode(&p); err != nil {
+		return Project{}, fmt.Errorf("failed to parse project config: %v", err)
+	}
+
+	if _, err := os.Stat(p.Playwright.ConfigFile); err != nil {
+		return p, fmt.Errorf("unable to locate %s", p.Playwright.ConfigFile)
+	}
+	//configDir := filepath.Dir(p.Playwright.ConfigFile)
+	//
+	//// We must locate the cypress folder.
+	//cPath := filepath.Join(configDir, "cypress")
+	//if _, err := os.Stat(cPath); err != nil {
+	//	return p, fmt.Errorf("unable to locate the cypress folder in %s", configDir)
+	//}
+	//p.Cypress.ProjectPath = cPath
+	//
+	//// Optionally include the env file if it exists.
+	//envFile := filepath.Join(configDir, "cypress.env.json")
+	//if _, err := os.Stat(envFile); err == nil {
+	//	p.Cypress.EnvFile = envFile
+	//}
+
+	// Default mode to Mount
+	if p.Docker.FileTransfer == "" {
+		p.Docker.FileTransfer = config.DockerFileMount
+	}
+
+	return p, nil
+}

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -18,33 +18,25 @@ type Project struct {
 	Npm            config.Npm         `yaml:"npm,omitempty" json:"npm"`
 }
 
+type SuiteConfig struct {
+	Env       map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+	TestFiles map[string]string `yaml:"testFiles,omitempty" json:"testFiles,omitempty"`
+}
+
 // Suite represents the cypress test suite configuration.
 type Suite struct {
-	Name           string      `yaml:"name,omitempty" json:"name"`
-	Browser        string      `yaml:"browser,omitempty" json:"browser"`
-	BrowserVersion string      `yaml:"browserVersion,omitempty" json:"browserVersion"`
-	PlatformName   string      `yaml:"platformName,omitempty" json:"platformName"`
-	Config         SuiteConfig `yaml:"config,omitempty" json:"config"`
-}
-
-// Params represents the playwright parameters
-type Params struct {
-	Browser string `yaml:"browserName,omitempty" json:"browserName,omitempty"`
-}
-
-// SuiteConfig represents the playwright config overrides.
-type SuiteConfig struct {
-	TestFiles []string          `yaml:"testFiles,omitempty" json:"testFiles"`
-	Env       map[string]string `yaml:"env,omitempty" json:"env"`
-	Params    Params            `yaml:"params,omitempty" json:"params"`
+	Name           string                 `yaml:"name,omitempty" json:"name"`
+	Browser        string                 `yaml:"browser,omitempty" json:"browserName"`
+	BrowserVersion string                 `yaml:"browserVersion,omitempty" json:"browserVersion"`
+	PlatformName   string                 `yaml:"platformName,omitempty" json:"platformName"`
+	Param          map[string]interface{} `yaml:"param,omitempty" json:"param,omitempty"`
+	Config         SuiteConfig            `yaml:"config,omitempty" json:"config,omitempty"`
 }
 
 // Playwright represents crucial playwright configuration that is required for setting up a project.
 type Playwright struct {
-	ConfigFile  string `yaml:"configFile,omitempty"`
-	EnvFile     string `yaml:"envFile,omitempty"`
-	ProjectPath string `yaml:"projectPath,omitempty"`
-	Params      Params `yaml:"params,omitempty"`
+	ProjectPath string                 `yaml:"projectPath,omitempty"`
+	Param       map[string]interface{} `yaml:"param,omitempty"`
 }
 
 // FromFile creates a new playwright Project based on the filepath cfgPath.
@@ -60,24 +52,6 @@ func FromFile(cfgPath string) (Project, error) {
 	if err = yaml.NewDecoder(f).Decode(&p); err != nil {
 		return Project{}, fmt.Errorf("failed to parse project config: %v", err)
 	}
-
-	//if _, err := os.Stat(p.Playwright.ConfigFile); err != nil {
-	//	return p, fmt.Errorf("unable to locate %s", p.Playwright.ConfigFile)
-	//}
-	//configDir := filepath.Dir(p.Playwright.ConfigFile)
-
-	//// We must locate the cypress folder.
-	//cPath := filepath.Join(configDir, "cypress")
-	//if _, err := os.Stat(cPath); err != nil {
-	//	return p, fmt.Errorf("unable to locate the cypress folder in %s", configDir)
-	//}
-	//p.Playwright.ProjectPath = cPath
-
-	// Optionally include the env file if it exists.
-	//envFile := filepath.Join(configDir, "cypress.env.json")
-	//if _, err := os.Stat(envFile); err == nil {
-	//	p.Playwright.EnvFile = envFile
-	//}
 
 	// Default mode to Mount
 	if p.Docker.FileTransfer == "" {

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -75,5 +75,10 @@ func FromFile(cfgPath string) (Project, error) {
 	if p.Docker.FileTransfer == "" {
 		p.Docker.FileTransfer = config.DockerFileMount
 	}
+
+	if p.Sauce.Concurrency < 1 {
+		p.Sauce.Concurrency = 1
+	}
+
 	return p, nil
 }

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -35,7 +35,7 @@ type Suite struct {
 	Name              string      `yaml:"name,omitempty" json:"name"`
 	PlaywrightVersion string      `yaml:"playwrightVersion,omitempty" json:"playwrightVersion,omitempty"`
 	TestMatch         string      `yaml:"testMatch,omitempty" json:"testMatch,omitempty"`
-	PlatformName      string      `yaml:"platformName,omitempty" json:"platformName"`
+	PlatformName      string      `yaml:"platformName,omitempty" json:"platformName,omitempty"`
 	Param             SuiteConfig `yaml:"param,omitempty" json:"param,omitempty"`
 }
 

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -8,6 +8,11 @@ import (
 	"path/filepath"
 )
 
+const (
+	// DefaultDockerImage represents the name of the docker image on Dockerhub
+	DefaultDockerImage = "saucelabs/stt-playwright-jest-node"
+)
+
 // Project represents the playwright project configuration.
 type Project struct {
 	config.TypeDef `yaml:",inline"`

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -31,7 +31,7 @@ type Playwright struct {
 	Version     string      `yaml:"version,omitempty" json:"version,omitempty"`
 	Params      SuiteConfig `yaml:"params,omitempty" json:"params,omitempty"`
 
-	// LocalProjectPath represents the project with nested folder removal (not in docker)
+	// LocalProjectPath represents the project before nested folder removal
 	LocalProjectPath string `yaml:"-" json:"-"`
 }
 
@@ -69,7 +69,7 @@ func FromFile(cfgPath string) (Project, error) {
 
 	// Default project path
 	if p.Playwright.ProjectPath == "" {
-		p.Playwright.ProjectPath = "./tests/"
+		return Project{}, fmt.Errorf("no project folder defined")
 	}
 
 	// Store local path since we provide only last level folder in runner

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -18,12 +18,6 @@ type Project struct {
 	Npm            config.Npm         `yaml:"npm,omitempty" json:"npm"`
 }
 
-// SuiteConfig represents the playwright configuration for one suite.
-type SuiteConfig struct {
-	Env       map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
-	TestFiles map[string]string `yaml:"testFiles,omitempty" json:"testFiles,omitempty"`
-}
-
 // Suite represents the playwright test suite configuration.
 type Suite struct {
 	Name           string                 `yaml:"name,omitempty" json:"name"`
@@ -31,7 +25,7 @@ type Suite struct {
 	BrowserVersion string                 `yaml:"browserVersion,omitempty" json:"browserVersion"`
 	PlatformName   string                 `yaml:"platformName,omitempty" json:"platformName"`
 	Param          map[string]interface{} `yaml:"param,omitempty" json:"param,omitempty"`
-	Config         SuiteConfig            `yaml:"config" json:"config"`
+	TestMatch      string                 `yaml:"testMatch,omitempty" json:"testMatch,omitempty"`
 }
 
 // Playwright represents crucial playwright configuration that is required for setting up a project.

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -18,20 +18,29 @@ type Project struct {
 	Npm            config.Npm         `yaml:"npm,omitempty" json:"npm"`
 }
 
-// Suite represents the playwright test suite configuration.
-type Suite struct {
-	Name           string                 `yaml:"name,omitempty" json:"name"`
-	Browser        string                 `yaml:"browserName,omitempty" json:"browserName"`
-	BrowserVersion string                 `yaml:"browserVersion,omitempty" json:"browserVersion"`
-	PlatformName   string                 `yaml:"platformName,omitempty" json:"platformName"`
-	Param          map[string]interface{} `yaml:"param,omitempty" json:"param,omitempty"`
-	TestMatch      string                 `yaml:"testMatch,omitempty" json:"testMatch,omitempty"`
-}
-
 // Playwright represents crucial playwright configuration that is required for setting up a project.
 type Playwright struct {
-	ProjectPath string                 `yaml:"projectPath,omitempty" json:"projectPath"`
-	Param       map[string]interface{} `yaml:"param,omitempty" json:"param"`
+	ProjectPath string      `yaml:"projectPath,omitempty" json:"projectPath,omitempty"`
+	Version     string      `yaml:"version,omitempty" json:"version,omitempty"`
+	Params      SuiteConfig `yaml:"params,omitempty" json:"params,omitempty"`
+}
+
+// Suite represents the playwright test suite configuration.
+type Suite struct {
+	Name              string      `yaml:"name,omitempty" json:"name"`
+	PlaywrightVersion string      `yaml:"playwrightVersion,omitempty" json:"playwrightVersion,omitempty"`
+	TestMatch         string      `yaml:"testMatch,omitempty" json:"testMatch,omitempty"`
+	PlatformName      string      `yaml:"platformName,omitempty" json:"platformName"`
+	Params            SuiteConfig `yaml:"params,omitempty" json:"params,omitempty"`
+}
+
+// SuiteConfig represents the configuration specific to a suite
+type SuiteConfig struct {
+	BrowserName         string `yaml:"browserName,omitempty" json:"browserName,omitempty"`
+	HeadFull            bool   `yaml:"headful,omitempty" json:"headful,omitempty"`
+	ScreenshotOnFailure bool   `yaml:"screenshotOnFailure,omitempty" json:"screenshotOnFailure,omitempty"`
+	SlowMo              uint   `yaml:"slowMo,omitempty" json:"slowMo,omitempty"`
+	Video               bool   `yaml:"video,omitempty" json:"video,omitempty"`
 }
 
 // FromFile creates a new playwright Project based on the filepath cfgPath.

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -5,6 +5,7 @@ import (
 	"github.com/saucelabs/saucectl/cli/config"
 	"gopkg.in/yaml.v2"
 	"os"
+	"path/filepath"
 )
 
 // Project represents the playwright project configuration.
@@ -23,6 +24,9 @@ type Playwright struct {
 	ProjectPath string      `yaml:"projectPath,omitempty" json:"projectPath,omitempty"`
 	Version     string      `yaml:"version,omitempty" json:"version,omitempty"`
 	Params      SuiteConfig `yaml:"params,omitempty" json:"params,omitempty"`
+
+	// LocalProjectPath represents the project with nested folder removal (not in docker)
+	LocalProjectPath string
 }
 
 // Suite represents the playwright test suite configuration.
@@ -61,6 +65,10 @@ func FromFile(cfgPath string) (Project, error) {
 	if p.Playwright.ProjectPath == "" {
 		p.Playwright.ProjectPath = "./tests/"
 	}
+
+	// Store local path since we provide only last level folder in runner
+	p.Playwright.LocalProjectPath = p.Playwright.ProjectPath
+	p.Playwright.ProjectPath = filepath.Base(p.Playwright.ProjectPath)
 
 	// Default mode to Mount
 	if p.Docker.FileTransfer == "" {

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -27,7 +27,7 @@ type Playwright struct {
 	Params      SuiteConfig `yaml:"params,omitempty" json:"params,omitempty"`
 
 	// LocalProjectPath represents the project with nested folder removal (not in docker)
-	LocalProjectPath string
+	LocalProjectPath string `yaml:"-" json:"-"`
 }
 
 // Suite represents the playwright test suite configuration.
@@ -36,7 +36,7 @@ type Suite struct {
 	PlaywrightVersion string      `yaml:"playwrightVersion,omitempty" json:"playwrightVersion,omitempty"`
 	TestMatch         string      `yaml:"testMatch,omitempty" json:"testMatch,omitempty"`
 	PlatformName      string      `yaml:"platformName,omitempty" json:"platformName"`
-	Params            SuiteConfig `yaml:"params,omitempty" json:"params,omitempty"`
+	Param             SuiteConfig `yaml:"param,omitempty" json:"param,omitempty"`
 }
 
 // SuiteConfig represents the configuration specific to a suite

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -49,7 +49,7 @@ type SuiteConfig struct {
 	BrowserName         string `yaml:"browserName,omitempty" json:"browserName,omitempty"`
 	HeadFull            bool   `yaml:"headful,omitempty" json:"headful,omitempty"`
 	ScreenshotOnFailure bool   `yaml:"screenshotOnFailure,omitempty" json:"screenshotOnFailure,omitempty"`
-	SlowMo              uint   `yaml:"slowMo,omitempty" json:"slowMo,omitempty"`
+	SlowMo              int   `yaml:"slowMo,omitempty" json:"slowMo,omitempty"`
 	Video               bool   `yaml:"video,omitempty" json:"video,omitempty"`
 }
 

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// DefaultDockerImage represents the name of the docker image on Dockerhub
-	DefaultDockerImage = "saucelabs/stt-playwright-jest-node"
+	DefaultDockerImage = "saucelabs/stt-playwright-node"
 )
 
 // Project represents the playwright project configuration.

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -26,11 +26,11 @@ type SuiteConfig struct {
 // Suite represents the cypress test suite configuration.
 type Suite struct {
 	Name           string                 `yaml:"name,omitempty" json:"name"`
-	Browser        string                 `yaml:"browser,omitempty" json:"browserName"`
+	Browser        string                 `yaml:"browserName,omitempty" json:"browserName"`
 	BrowserVersion string                 `yaml:"browserVersion,omitempty" json:"browserVersion"`
 	PlatformName   string                 `yaml:"platformName,omitempty" json:"platformName"`
 	Param          map[string]interface{} `yaml:"param,omitempty" json:"param,omitempty"`
-	Config         SuiteConfig            `yaml:"config,omitempty" json:"config,omitempty"`
+	Config         SuiteConfig            `yaml:"config" json:"config"`
 }
 
 // Playwright represents crucial playwright configuration that is required for setting up a project.

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -49,7 +49,7 @@ type SuiteConfig struct {
 	BrowserName         string `yaml:"browserName,omitempty" json:"browserName,omitempty"`
 	HeadFull            bool   `yaml:"headful,omitempty" json:"headful,omitempty"`
 	ScreenshotOnFailure bool   `yaml:"screenshotOnFailure,omitempty" json:"screenshotOnFailure,omitempty"`
-	SlowMo              int   `yaml:"slowMo,omitempty" json:"slowMo,omitempty"`
+	SlowMo              int    `yaml:"slowMo,omitempty" json:"slowMo,omitempty"`
 	Video               bool   `yaml:"video,omitempty" json:"video,omitempty"`
 }
 

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-// Project represents the cypress project configuration.
+// Project represents the playwright project configuration.
 type Project struct {
 	config.TypeDef `yaml:",inline"`
 	Sauce          config.SauceConfig `yaml:"sauce,omitempty" json:"sauce"`
@@ -18,12 +18,13 @@ type Project struct {
 	Npm            config.Npm         `yaml:"npm,omitempty" json:"npm"`
 }
 
+// SuiteConfig represents the playwright configuration for one suite.
 type SuiteConfig struct {
 	Env       map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 	TestFiles map[string]string `yaml:"testFiles,omitempty" json:"testFiles,omitempty"`
 }
 
-// Suite represents the cypress test suite configuration.
+// Suite represents the playwright test suite configuration.
 type Suite struct {
 	Name           string                 `yaml:"name,omitempty" json:"name"`
 	Browser        string                 `yaml:"browserName,omitempty" json:"browserName"`
@@ -35,8 +36,8 @@ type Suite struct {
 
 // Playwright represents crucial playwright configuration that is required for setting up a project.
 type Playwright struct {
-	ProjectPath string                 `yaml:"projectPath,omitempty"`
-	Param       map[string]interface{} `yaml:"param,omitempty"`
+	ProjectPath string                 `yaml:"projectPath,omitempty" json:"projectPath"`
+	Param       map[string]interface{} `yaml:"param,omitempty" json:"param"`
 }
 
 // FromFile creates a new playwright Project based on the filepath cfgPath.
@@ -51,6 +52,11 @@ func FromFile(cfgPath string) (Project, error) {
 
 	if err = yaml.NewDecoder(f).Decode(&p); err != nil {
 		return Project{}, fmt.Errorf("failed to parse project config: %v", err)
+	}
+
+	// Default project path
+	if p.Playwright.ProjectPath == "" {
+		p.Playwright.ProjectPath = "./tests/"
 	}
 
 	// Default mode to Mount

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -11,6 +11,7 @@ import (
 // Project represents the playwright project configuration.
 type Project struct {
 	config.TypeDef `yaml:",inline"`
+	ShowConsoleLog bool
 	Sauce          config.SauceConfig `yaml:"sauce,omitempty" json:"sauce"`
 	Playwright     Playwright         `yaml:"playwright,omitempty" json:"playwright"`
 	Suites         []Suite            `yaml:"suites,omitempty" json:"suites"`

--- a/internal/playwright/docker/docker.go
+++ b/internal/playwright/docker/docker.go
@@ -192,8 +192,8 @@ func (handler *Handler) StartContainer(ctx context.Context, c playwright.Project
 	}
 
 	files := []string{
-		c.Playwright.ConfigFile,
-		//c.Playwright.ProjectPath,
+		//c.Playwright.ConfigFile,
+		c.Playwright.ProjectPath,
 	}
 
 	//if c.Playwright.EnvFile != "" {

--- a/internal/playwright/docker/docker.go
+++ b/internal/playwright/docker/docker.go
@@ -1,0 +1,460 @@
+package docker
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/system"
+	"github.com/docker/go-connections/nat"
+	"github.com/phayes/freeport"
+	"github.com/rs/zerolog/log"
+
+	"github.com/saucelabs/saucectl/cli/config"
+	"github.com/saucelabs/saucectl/cli/credentials"
+	"github.com/saucelabs/saucectl/cli/streams"
+	"github.com/saucelabs/saucectl/cli/utils"
+	"github.com/saucelabs/saucectl/internal/playwright"
+)
+
+var (
+	containerStopTimeout   = time.Duration(10) * time.Second
+	containerRemoveOptions = types.ContainerRemoveOptions{
+		Force:         true,
+		RemoveLinks:   false,
+		RemoveVolumes: false,
+	}
+)
+
+// CommonAPIClient is the interface for interacting with containers.
+type CommonAPIClient interface {
+	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
+	ImageList(ctx context.Context, options types.ImageListOptions) ([]types.ImageSummary, error)
+	ImagePull(ctx context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error)
+	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (container.ContainerCreateCreatedBody, error)
+	ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error
+	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
+	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
+	ContainerStatPath(ctx context.Context, containerID, path string) (types.ContainerPathStat, error)
+	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
+	ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error)
+	ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error)
+	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
+	ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error
+	ContainerRemove(ctx context.Context, containerID string, options types.ContainerRemoveOptions) error
+	ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error)
+}
+
+// Handler represents the client to handle Docker tasks
+type Handler struct {
+	client CommonAPIClient
+}
+
+// CreateMock allows to get a handler with a custom interface
+func CreateMock(client CommonAPIClient) *Handler {
+	return &Handler{client}
+}
+
+// Create generates a docker client
+func Create() (*Handler, error) {
+	cl, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	handler := Handler{
+		client: cl,
+	}
+
+	return &handler, nil
+}
+
+// ValidateDependency checks if external dependencies are installed
+func (handler *Handler) ValidateDependency() error {
+	_, err := handler.client.ContainerList(context.Background(), types.ContainerListOptions{})
+	return err
+}
+
+// HasBaseImage checks if base image is installed
+func (handler *Handler) HasBaseImage(ctx context.Context, baseImage string) (bool, error) {
+	listFilters := filters.NewArgs()
+	listFilters.Add("reference", baseImage)
+	options := types.ImageListOptions{
+		All:     true,
+		Filters: listFilters,
+	}
+
+	images, err := handler.client.ImageList(ctx, options)
+	if err != nil {
+		return false, err
+	}
+
+	return len(images) > 0, nil
+}
+
+// GetImageFlavor returns a string that contains the image name and tag defined by the project.
+func (handler *Handler) GetImageFlavor(img config.Image) string {
+	// TODO - move this to ImageDefinition
+	tag := "latest"
+	if img.Tag != "" {
+		tag = img.Tag
+	}
+	return fmt.Sprintf("%s:%s", img.Name, tag)
+}
+
+// RegistryUsernameEnvKey represents the username environment variable for authenticating against a docker registry.
+const RegistryUsernameEnvKey = "REGISTRY_USERNAME"
+
+// RegistryPasswordEnvKey represents the password environment variable for authenticating against a docker registry.
+const RegistryPasswordEnvKey = "REGISTRY_PASSWORD"
+
+// NewImagePullOptions returns a new types.ImagePullOptions object. Credentials are also configured, if available
+// via environment variables (see RegistryUsernameEnvKey and RegistryPasswordEnvKey).
+func NewImagePullOptions() (types.ImagePullOptions, error) {
+	options := types.ImagePullOptions{}
+	registryUser, hasRegistryUser := os.LookupEnv(RegistryUsernameEnvKey)
+	registryPwd, hasRegistryPwd := os.LookupEnv(RegistryPasswordEnvKey)
+	// setup auth https://github.com/moby/moby/blob/master/api/types/client.go#L255
+	if hasRegistryUser && hasRegistryPwd {
+		log.Debug().Msg("Using registry environment variables credentials")
+		authConfig := types.AuthConfig{
+			Username: registryUser,
+			Password: registryPwd,
+		}
+		authJSON, err := json.Marshal(authConfig)
+		if err != nil {
+			return options, err
+		}
+		authStr := base64.URLEncoding.EncodeToString(authJSON)
+		options.RegistryAuth = authStr
+	}
+	return options, nil
+}
+
+// PullBaseImage pulls an image from Docker
+func (handler *Handler) PullBaseImage(ctx context.Context, img config.Image) error {
+	options, err := NewImagePullOptions()
+	if err != nil {
+		return err
+	}
+	baseImage := handler.GetImageFlavor(img)
+	responseBody, err := handler.client.ImagePull(ctx, baseImage, options)
+	if err != nil {
+		return err
+	}
+
+	defer responseBody.Close()
+
+	/**
+	 * ToDo(Christian): handle stdout
+	 */
+	out := streams.NewOut(ioutil.Discard)
+	if err := jsonmessage.DisplayJSONMessagesToStream(responseBody, out, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// StartContainer starts the Docker testrunner container
+func (handler *Handler) StartContainer(ctx context.Context, c playwright.Project) (*container.ContainerCreateCreatedBody, error) {
+	var (
+		ports        map[nat.Port]struct{}
+		portBindings map[nat.Port][]nat.PortBinding
+	)
+
+	port, err := freeport.GetFreePort()
+	if err != nil {
+		return nil, err
+	}
+
+	// binding port for accessing Chrome DevTools from outside
+	// of the container
+	ports, portBindings, err = nat.ParsePortSpecs(
+		[]string{fmt.Sprintf("%d:9222", port)},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	files := []string{
+		c.Playwright.ConfigFile,
+		//c.Playwright.ProjectPath,
+	}
+
+	//if c.Playwright.EnvFile != "" {
+	//	files = append(files, c.Playwright.EnvFile)
+	//}
+
+	img := handler.GetImageFlavor(c.Docker.Image)
+	pDir, err := handler.ProjectDir(ctx, img)
+	if err != nil {
+		return nil, err
+	}
+
+	var m []mount.Mount
+	if c.Docker.FileTransfer == config.DockerFileMount {
+		m, err = createMounts(files, pDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	username := ""
+	accessKey := ""
+	if creds := credentials.Get(); creds != nil {
+		username = creds.Username
+		accessKey = creds.AccessKey
+		log.Info().Msgf("Using credentials set by %s", creds.Source)
+	}
+
+	hostConfig := &container.HostConfig{
+		PortBindings: portBindings,
+		Mounts:       m,
+	}
+	networkConfig := &network.NetworkingConfig{}
+	containerConfig := &container.Config{
+		Image:        img,
+		ExposedPorts: ports,
+		Env: []string{
+			fmt.Sprintf("SAUCE_USERNAME=%s", username),
+			fmt.Sprintf("SAUCE_ACCESS_KEY=%s", accessKey),
+		},
+	}
+
+	container, err := handler.client.ContainerCreate(ctx, containerConfig, hostConfig, networkConfig, "")
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info().Str("img", img).Str("id", container.ID[:12]).Msg("Starting container")
+	if err := handler.client.ContainerStart(ctx, container.ID, types.ContainerStartOptions{}); err != nil {
+		return nil, err
+	}
+
+	if c.Docker.FileTransfer == config.DockerFileCopy {
+		if err := copyTestFiles(ctx, handler, container.ID, files, pDir); err != nil {
+			return nil, err
+		}
+	}
+
+	// We need to check the tty _before_ we do the ContainerExecCreate, because
+	// otherwise if we error out we will leak execIDs on the server (and
+	// there's no easy way to clean those up). But also in order to make "not
+	// exist" errors take precedence we do a dummy inspect first.
+	if _, err := handler.client.ContainerInspect(ctx, container.ID); err != nil {
+		return nil, err
+	}
+
+	return &container, nil
+}
+
+// copyTestFiles copies the files within the container.
+func copyTestFiles(ctx context.Context, handler *Handler, containerID string, files []string, pDir string) error {
+	for _, file := range files {
+		log.Info().Str("from", file).Str("to", pDir).Msg("File copied")
+		if err := handler.CopyToContainer(ctx, containerID, file, pDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// createMounts returns a list of mount bindings, binding files to target, such that {source}:{target}/{source}.
+func createMounts(files []string, target string) ([]mount.Mount, error) {
+	mm := make([]mount.Mount, len(files))
+	for i, f := range files {
+		absF, err := filepath.Abs(f)
+		if err != nil {
+			return mm, err
+		}
+
+		dest := path.Join(target, filepath.Base(f))
+
+		mm[i] = mount.Mount{
+			Type:          mount.TypeBind,
+			Source:        absF,
+			Target:        dest,
+			ReadOnly:      false,
+			Consistency:   mount.ConsistencyDefault,
+			BindOptions:   nil,
+			VolumeOptions: nil,
+			TmpfsOptions:  nil,
+		}
+
+		log.Info().Str("from", f).Str("to", dest).Msg("File mounted")
+	}
+
+	return mm, nil
+}
+
+// CopyFilesToContainer copies the given files into the container.
+func (handler *Handler) CopyFilesToContainer(ctx context.Context, srcContainerID string, files []string, targetDir string) error {
+	for _, fpath := range files {
+		if err := handler.CopyToContainer(ctx, srcContainerID, fpath, targetDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CopyToContainer copies the given file to the container.
+func (handler *Handler) CopyToContainer(ctx context.Context, containerID string, srcFile string, targetDir string) error {
+	srcInfo, err := archive.CopyInfoSourcePath(srcFile, true)
+	if err != nil {
+		return err
+	}
+
+	srcArchive, err := archive.TarResource(srcInfo)
+	if err != nil {
+		return err
+	}
+	defer srcArchive.Close()
+
+	dstInfo := archive.CopyInfo{IsDir: srcInfo.IsDir, Path: filepath.Join(targetDir, filepath.Base(srcInfo.Path))}
+	resolvedDstPath, preparedArchive, err := archive.PrepareArchiveCopy(srcArchive, srcInfo, dstInfo)
+	if err != nil {
+		return err
+	}
+	defer preparedArchive.Close()
+
+	return handler.client.CopyToContainer(ctx, containerID, resolvedDstPath, preparedArchive, types.CopyToContainerOptions{})
+}
+
+// CopyFromContainer downloads a file from the testrunner container
+func (handler *Handler) CopyFromContainer(ctx context.Context, srcContainerID string, srcPath string, dstPath string) error {
+	if err := utils.ValidateOutputPath(dstPath); err != nil {
+		return err
+	}
+
+	// if client requests to follow symbol link, then must decide target file to be copied
+	var rebaseName string
+	srcStat, err := handler.client.ContainerStatPath(ctx, srcContainerID, srcPath)
+	if err != nil {
+		return err
+	}
+
+	// If the destination is a symbolic link, we should follow it.
+	if srcStat.Mode&os.ModeSymlink != 0 {
+		linkTarget := srcStat.LinkTarget
+		if !system.IsAbs(linkTarget) {
+			// Join with the parent directory.
+			srcParent, _ := archive.SplitPathDirEntry(srcPath)
+			linkTarget = filepath.Join(srcParent, linkTarget)
+		}
+
+		linkTarget, rebaseName = archive.GetRebaseName(srcPath, linkTarget)
+		srcPath = linkTarget
+	}
+
+	content, stat, err := handler.client.CopyFromContainer(ctx, srcContainerID, srcPath)
+	if err != nil {
+		return err
+	}
+	defer content.Close()
+
+	srcInfo := archive.CopyInfo{
+		Path:       srcPath,
+		Exists:     true,
+		IsDir:      stat.Mode.IsDir(),
+		RebaseName: rebaseName,
+	}
+
+	preArchive := content
+	if srcInfo.RebaseName != "" {
+		_, srcBase := archive.SplitPathDirEntry(srcInfo.Path)
+		preArchive = archive.RebaseArchiveEntries(content, srcBase, srcInfo.RebaseName)
+	}
+	return archive.CopyTo(preArchive, srcInfo, dstPath)
+}
+
+// Execute runs the test in the Docker container and attaches to its stdout
+func (handler *Handler) Execute(ctx context.Context, srcContainerID string, cmd []string, env map[string]string) (*types.IDResponse, *types.HijackedResponse, error) {
+	execConfig := types.ExecConfig{
+		Cmd:          cmd,
+		AttachStdout: true,
+		AttachStderr: true,
+	}
+
+	// Set env vars for a particular suite
+	if len(env) > 0 {
+		envVars := []string{}
+		for k, v := range env {
+			envVars = append(envVars, k+"="+v)
+		}
+		execConfig.Env = envVars
+	}
+
+	createResp, err := handler.client.ContainerExecCreate(ctx, srcContainerID, execConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	execStartCheck := types.ExecStartCheck{
+		Tty: false,
+	}
+	resp, err := handler.client.ContainerExecAttach(ctx, createResp.ID, execStartCheck)
+	return &createResp, &resp, err
+}
+
+// ExecuteInspect checks exit code of test
+func (handler *Handler) ExecuteInspect(ctx context.Context, srcContainerID string) (int, error) {
+	inspectResp, err := handler.client.ContainerExecInspect(ctx, srcContainerID)
+	if err != nil {
+		return 1, err
+	}
+
+	return inspectResp.ExitCode, nil
+}
+
+// ContainerStop stops a running container
+func (handler *Handler) ContainerStop(ctx context.Context, srcContainerID string) error {
+	return handler.client.ContainerStop(ctx, srcContainerID, &containerStopTimeout)
+}
+
+// ContainerRemove removes testrunner container
+func (handler *Handler) ContainerRemove(ctx context.Context, srcContainerID string) error {
+	return handler.client.ContainerRemove(ctx, srcContainerID, containerRemoveOptions)
+}
+
+// ProjectDir returns the project directory as is configured for the given image.
+func (handler *Handler) ProjectDir(ctx context.Context, imageID string) (string, error) {
+	ii, _, err := handler.client.ImageInspectWithRaw(ctx, imageID)
+	if err != nil {
+		return "", err
+	}
+
+	// The image can tell us via a label where saucectl should mount the project files.
+	// We default to the working dir of the container as the default mounting target.
+	p := ii.Config.WorkingDir
+	if v := ii.Config.Labels["com.saucelabs.project-dir"]; v != "" {
+		p = v
+	}
+
+	return p, nil
+}
+
+// ContainerInspect returns the container information.
+func (handler *Handler) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+	return handler.client.ContainerInspect(ctx, containerID)
+}
+
+// IsErrNotFound returns true if the error is a NotFound error, which is returned
+// by the API when some object is not found.
+func (handler *Handler) IsErrNotFound(err error) bool {
+	return client.IsErrNotFound(err)
+}

--- a/internal/playwright/docker/docker.go
+++ b/internal/playwright/docker/docker.go
@@ -192,7 +192,6 @@ func (handler *Handler) StartContainer(ctx context.Context, c playwright.Project
 	}
 
 	files := []string{
-		//c.Playwright.ConfigFile,
 		c.Playwright.ProjectPath,
 	}
 

--- a/internal/playwright/docker/docker.go
+++ b/internal/playwright/docker/docker.go
@@ -192,12 +192,9 @@ func (handler *Handler) StartContainer(ctx context.Context, c playwright.Project
 	}
 
 	files := []string{
-		c.Playwright.ProjectPath,
+		c.Playwright.LocalProjectPath,
 	}
-
-	//if c.Playwright.EnvFile != "" {
-	//	files = append(files, c.Playwright.EnvFile)
-	//}
+	c.Playwright.ProjectPath = filepath.Base(c.Playwright.ProjectPath)
 
 	img := handler.GetImageFlavor(c.Docker.Image)
 	pDir, err := handler.ProjectDir(ctx, img)

--- a/internal/playwright/docker/docker.go
+++ b/internal/playwright/docker/docker.go
@@ -229,6 +229,7 @@ func (handler *Handler) StartContainer(ctx context.Context, c playwright.Project
 		Env: []string{
 			fmt.Sprintf("SAUCE_USERNAME=%s", username),
 			fmt.Sprintf("SAUCE_ACCESS_KEY=%s", accessKey),
+			fmt.Sprintf("SAUCE_IMAGE_NAME=%s", img),
 		},
 	}
 

--- a/internal/playwright/docker/docker_test.go
+++ b/internal/playwright/docker/docker_test.go
@@ -1,0 +1,197 @@
+package docker
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"github.com/docker/docker/api/types"
+	"github.com/saucelabs/saucectl/internal/playwright"
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+
+	"github.com/saucelabs/saucectl/cli/config"
+	"github.com/saucelabs/saucectl/cli/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewImagePullOptions(t *testing.T) {
+	os.Setenv(RegistryUsernameEnvKey, "fake-user")
+	os.Setenv(RegistryPasswordEnvKey, "fake-password")
+
+	opts, err := NewImagePullOptions()
+	if err != nil {
+		t.Fail()
+	}
+	want := map[string]string{"username": "fake-user", "password": "fake-password"}
+	value := map[string]string{}
+
+	decoded, err := base64.URLEncoding.DecodeString(opts.RegistryAuth)
+	assert.Nil(t, err)
+	err = json.Unmarshal(decoded, &value)
+	assert.Nil(t, err)
+	assert.Equal(t, value, want)
+}
+
+func TestImageFlavor(t *testing.T) {
+	tests := []struct {
+		Image string
+		Tag   string
+		Want  string
+	}{
+		{"dummy-image", "latest", "dummy-image:latest"},
+		{"dummy-image", "", "dummy-image:latest"},
+		{"dummy-image", "custom-tag", "dummy-image:custom-tag"},
+	}
+
+	handler := Handler{}
+	for _, tt := range tests {
+		img := config.Image{Name: tt.Image, Tag: tt.Tag}
+		have := handler.GetImageFlavor(img)
+		assert.Equal(t, have, tt.Want)
+	}
+}
+
+func TestHasBaseImage(t *testing.T) {
+	ctx := context.Background()
+	fc := mocks.FakeClient{}
+	handler := &Handler{client: &fc}
+
+	fc.ImageListSuccess = true
+	val, err := handler.HasBaseImage(ctx, "dummy-image")
+	assert.Nil(t, err)
+	assert.True(t, val)
+
+	fc.ImageListSuccess = false
+	val, err = handler.HasBaseImage(ctx, "dummy-image")
+	assert.NotNil(t, err)
+	assert.False(t, val)
+}
+
+func TestValidateDependency(t *testing.T) {
+	fc := mocks.FakeClient{}
+	handler := &Handler{client: &fc}
+
+	fc.ContainerListSuccess = true
+	err := handler.ValidateDependency()
+	assert.Nil(t, err)
+
+	fc.ContainerListSuccess = false
+	err = handler.ValidateDependency()
+	assert.NotNil(t, err)
+}
+
+func TestClient(t *testing.T) {
+	handler, err := Create()
+	assert.Nil(t, err)
+	assert.NotNil(t, handler)
+}
+
+func TestPullImageBase(t *testing.T) {
+	fc := mocks.FakeClient{}
+	handler := &Handler{client: &fc}
+
+	fc.ImagePullSuccess = false
+	err := handler.PullBaseImage(context.Background(), config.Image{Name: "dummy-name", Tag: "dummy-tag"})
+	assert.NotNil(t, err)
+}
+
+func TestCreateMounts(t *testing.T) {
+	cwd, _ := os.Getwd()
+	want := []struct {
+		Idx    int
+		Source string
+		Target string
+	}{
+		{Idx: 0, Source: "file1", Target: "dest/file1"},
+		{Idx: 1, Source: "dir1/file2", Target: "dest/file2"},
+		{Idx: 2, Source: "dir1/dir2/file3", Target: "dest/file3"},
+		{Idx: 3, Source: "dir1/dir2/file3", Target: "dest/file3"},
+	}
+
+	var files []string
+	for _, f := range want {
+		files = append(files, f.Source)
+	}
+	dest := "dest/"
+	mounts, _ := createMounts(files, dest)
+	assert.Len(t, mounts, len(want))
+	for _, w := range want {
+		m := mounts[w.Idx]
+		assert.Equal(t, path.Join(cwd, w.Source), m.Source)
+		assert.Equal(t, w.Target, m.Target)
+	}
+}
+
+func TestStartContainer(t *testing.T) {
+	project := playwright.Project{
+		Playwright: playwright.Playwright{
+			ProjectPath: "../../../tests/e2e/playwright",
+		},
+	}
+	mockDocker := mocks.FakeClient{
+		ContainerCreateSuccess:     false,
+		ContainerStartSuccess:      true,
+		ContainerInspectSuccess:    true,
+		ImageInspectWithRawSuccess: true,
+		CopyToContainerFn: func(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error {
+			return nil
+		},
+	}
+	handler := Handler{
+		client: &mockDocker,
+	}
+
+	var cont *container.ContainerCreateCreatedBody
+	var err error
+
+	// Buggy container start
+	cont, err = handler.StartContainer(context.Background(), project)
+	assert.NotNil(t, err)
+
+	// Successfull container start
+	mockDocker.ContainerCreateSuccess = true
+	cont, err = handler.StartContainer(context.Background(), project)
+	assert.Nil(t, err)
+	assert.NotNil(t, cont)
+}
+
+func TestExecuteInContainer(t *testing.T) {
+	mockDocker := mocks.FakeClient{
+		ContainerExecCreateSuccess: true,
+		ContainerExecAttachSuccess: true,
+	}
+	handler := Handler{
+		client: &mockDocker,
+	}
+
+	IDResponse, hijackedResponse, err := handler.Execute(context.Background(), "dummy-container-id", []string{"npm", "dummy-command"}, map[string]string{})
+	assert.Nil(t, err)
+	assert.NotNil(t, hijackedResponse)
+	assert.Equal(t, IDResponse.ID, "dummy-id")
+}
+
+func TestCopyFromContainer(t *testing.T) {
+	defer func() {
+		os.Remove("internal-file")
+	}()
+	client := &mocks.FakeClient{
+		ContainerStatPathSuccess: true,
+		CopyFromContainerSuccess: true,
+	}
+	handler := Handler{
+		client: client,
+	}
+
+	// Working
+	err := handler.CopyFromContainer(context.Background(), "dummy-container-id", "/dummy/source/internal-file", "./")
+	assert.Nil(t, err)
+
+	// Errored test
+	client.CopyFromContainerSuccess = false
+	err = handler.CopyFromContainer(context.Background(), "dummy-container-id", "/dummy/source/internal-file", "./")
+	assert.NotNil(t, err)
+}

--- a/internal/playwright/docker/runner.go
+++ b/internal/playwright/docker/runner.go
@@ -1,0 +1,273 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/saucelabs/saucectl/cli/command"
+	"github.com/saucelabs/saucectl/cli/progress"
+	"github.com/saucelabs/saucectl/cli/runner"
+	"github.com/saucelabs/saucectl/cli/streams"
+	"github.com/saucelabs/saucectl/internal/jsonio"
+	"github.com/saucelabs/saucectl/internal/playwright"
+)
+
+// SauceRunnerConfigFile represents the filename for the sauce runner configuration.
+const SauceRunnerConfigFile = "sauce-runner.json"
+
+type containerConfig struct {
+	// sauceRunnerConfigPath is the container path to sauce-runner.json.
+	sauceRunnerConfigPath string
+}
+
+// Runner represents the docker implementation of a test runner.
+type Runner struct {
+	Project         playwright.Project
+	Ctx             context.Context
+	Cli             *command.SauceCtlCli
+	containerID     string
+	docker          *Handler
+	containerConfig *containerConfig
+}
+
+// New creates a new Runner instance.
+func New(c playwright.Project, cli *command.SauceCtlCli) (*Runner, error) {
+	r := Runner{}
+	r.containerConfig = &containerConfig{}
+	r.Cli = cli
+	r.Ctx = context.Background()
+	r.Project = c
+
+	var err error
+	r.docker, err = Create()
+	if err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+// RunProject runs the tests defined in config.Project.
+func (r *Runner) RunProject() (int, error) {
+	errorCount := 0
+	for _, suite := range r.Project.Suites {
+		err := r.runSuite(suite)
+		if err != nil {
+			errorCount++
+		}
+	}
+	if errorCount > 0 {
+		log.Error().Msgf("%d suite(s) failed", errorCount)
+	}
+	return errorCount, nil
+}
+
+// setup performs any necessary steps for a test runner to execute tests.
+func (r *Runner) setup() error {
+	err := r.docker.ValidateDependency()
+	if err != nil {
+		return fmt.Errorf("please verify that docker is installed and running: %v, "+
+			" follow the guide at https://docs.docker.com/get-docker/", err)
+	}
+
+	// Check docker image name property from the config file.
+	if r.Project.Docker.Image.Name == "" {
+		return errors.New("no docker image specified")
+	}
+
+	// Check if image exists.
+	baseImage := r.docker.GetImageFlavor(r.Project.Docker.Image)
+	hasImage, err := r.docker.HasBaseImage(r.Ctx, baseImage)
+	if err != nil {
+		return err
+	}
+
+	// If it's our image, warn the user to not use the latest tag.
+	if strings.Index(r.Project.Docker.Image.Name, "saucelabs") == 0 && r.Project.Docker.Image.Tag == "latest" {
+		log.Warn().Msg("The use of 'latest' as the docker image tag is discouraged. " +
+			"We recommend pinning the image to a specific version. " +
+			"Please proceed with caution.")
+	}
+
+	// Only pull base image if not already installed.
+	if !hasImage {
+		progress.Show("Pulling image %s", baseImage)
+		defer progress.Stop()
+		if err := r.docker.PullBaseImage(r.Ctx, r.Project.Docker.Image); err != nil {
+			return err
+		}
+	}
+
+	container, err := r.docker.StartContainer(r.Ctx, r.Project)
+	if err != nil {
+		return err
+	}
+	r.containerID = container.ID
+
+	pDir, err := r.docker.ProjectDir(r.Ctx, baseImage)
+	if err != nil {
+		return err
+	}
+
+	tmpDir, err := ioutil.TempDir("", "saucectl")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	rcPath := filepath.Join(tmpDir, SauceRunnerConfigFile)
+	if err := jsonio.WriteFile(rcPath, r.Project); err != nil {
+		return err
+	}
+
+	if err := r.docker.CopyToContainer(r.Ctx, r.containerID, rcPath, pDir); err != nil {
+		return err
+	}
+	r.containerConfig.sauceRunnerConfigPath = path.Join(pDir, SauceRunnerConfigFile)
+
+	// running pre-exec tasks
+	err = r.beforeExec(r.Project.BeforeExec)
+	if err != nil {
+		return err
+	}
+	// start port forwarding
+	sockatCmd := []string{
+		"socat",
+		"tcp-listen:9222,reuseaddr,fork",
+		"tcp:localhost:9223",
+	}
+
+	if _, _, err := r.docker.Execute(r.Ctx, r.containerID, sockatCmd, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Runner) beforeExec(tasks []string) error {
+	for _, task := range tasks {
+		log.Info().Str("task", task).Msg("Running BeforeExec")
+		exitCode, err := r.execute(strings.Fields(task), nil)
+		if err != nil {
+			return err
+		}
+		if exitCode != 0 {
+			return fmt.Errorf("failed to run BeforeExec task: %s - exit code %d", task, exitCode)
+		}
+	}
+	return nil
+}
+
+func (r *Runner) execute(cmd []string, env map[string]string) (int, error) {
+	var (
+		out, stderr io.Writer
+		in          io.ReadCloser
+	)
+	out = r.Cli.Out()
+	stderr = r.Cli.Out()
+
+	if err := r.Cli.In().CheckTty(false, true); err != nil {
+		return 1, err
+	}
+	createResp, attachResp, err := r.docker.Execute(r.Ctx, r.containerID, cmd, env)
+	if err != nil {
+		return 1, err
+	}
+	defer attachResp.Close()
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		errCh <- func() error {
+			streamer := streams.IOStreamer{
+				Streams:      r.Cli,
+				InputStream:  in,
+				OutputStream: out,
+				ErrorStream:  stderr,
+				Resp:         *attachResp,
+			}
+
+			return streamer.Stream(r.Ctx)
+		}()
+	}()
+
+	if err := <-errCh; err != nil {
+		return 1, err
+	}
+
+	exitCode, err := r.docker.ExecuteInspect(r.Ctx, createResp.ID)
+	if err != nil {
+		return 1, err
+	}
+	return exitCode, nil
+
+}
+
+// run runs the tests defined in the config.Project.
+func (r *Runner) run(s playwright.Suite) (int, error) {
+	return r.execute([]string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", s.Name}, s.Config.Env)
+}
+
+// teardown cleans up the test environment.
+func (r *Runner) teardown(logDir string) error {
+	for _, containerSrcPath := range runner.LogFiles {
+		file := filepath.Base(containerSrcPath)
+		hostDstPath := filepath.Join(logDir, file)
+		if err := r.docker.CopyFromContainer(r.Ctx, r.containerID, containerSrcPath, hostDstPath); err != nil {
+			continue
+		}
+	}
+
+	// checks that container exists before stopping and removing it
+	if _, err := r.docker.ContainerInspect(r.Ctx, r.containerID); err != nil {
+		return err
+	}
+
+	if err := r.docker.ContainerStop(r.Ctx, r.containerID); err != nil {
+		return err
+	}
+
+	if err := r.docker.ContainerRemove(r.Ctx, r.containerID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Runner) runSuite(suite playwright.Suite) error {
+	defer func() {
+		log.Info().Msg("Tearing down environment")
+		if err := r.teardown(r.Cli.LogDir); err != nil {
+			if !r.docker.IsErrNotFound(err) {
+				log.Error().Err(err).Msg("Failed to tear down environment")
+			}
+		}
+	}()
+
+	log.Info().Msg("Setting up test environment")
+	if err := r.setup(); err != nil {
+		log.Err(err).Msg("Failed to setup test environment")
+		return err
+	}
+
+	exitCode, err := r.run(suite)
+	log.Info().
+		Int("ExitCode", exitCode).
+		Msg("Command Finished")
+
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("exitCode is %d", exitCode)
+	}
+	return nil
+}

--- a/internal/playwright/docker/runner.go
+++ b/internal/playwright/docker/runner.go
@@ -213,7 +213,7 @@ func (r *Runner) execute(cmd []string, env map[string]string) (int, error) {
 
 // run runs the tests defined in the config.Project.
 func (r *Runner) run(s playwright.Suite) (int, error) {
-	return r.execute([]string{"node", ".", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", s.Name}, map[string]string{})
+	return r.execute([]string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", s.Name}, map[string]string{})
 }
 
 // teardown cleans up the test environment.

--- a/internal/playwright/docker/runner.go
+++ b/internal/playwright/docker/runner.go
@@ -80,7 +80,7 @@ func (r *Runner) RunProject() (int, error) {
 func (r *Runner) defineDockerImage() error {
 	// Skip availability check since custom image is being used
 	if r.Project.Docker.Image.Name != "" && r.Project.Docker.Image.Tag != "" {
-		log.Info().Msgf("Ignoring Cypress version for Docker, using %s:%s", r.Project.Docker.Image.Name, r.Project.Docker.Image.Tag)
+		log.Info().Msgf("Ignoring Playwright version for Docker, using %s:%s", r.Project.Docker.Image.Name, r.Project.Docker.Image.Tag)
 		return nil
 	}
 

--- a/internal/playwright/docker/runner.go
+++ b/internal/playwright/docker/runner.go
@@ -213,7 +213,7 @@ func (r *Runner) execute(cmd []string, env map[string]string) (int, error) {
 
 // run runs the tests defined in the config.Project.
 func (r *Runner) run(s playwright.Suite) (int, error) {
-	return r.execute([]string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", s.Name}, map[string]string{})
+	return r.execute([]string{"node", ".", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", s.Name}, map[string]string{})
 }
 
 // teardown cleans up the test environment.

--- a/internal/playwright/docker/runner.go
+++ b/internal/playwright/docker/runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/saucelabs/saucectl/internal/cypress"
 	"io"
 	"io/ioutil"
 	"os"
@@ -89,11 +88,11 @@ func (r *Runner) defineDockerImage() error {
 		return fmt.Errorf("no cypress version provided")
 	}
 
-	if r.Project.Docker.Image.Name == cypress.DefaultDockerImage && r.Project.Docker.Image.Tag == "" {
+	if r.Project.Docker.Image.Name == playwright.DefaultDockerImage && r.Project.Docker.Image.Tag == "" {
 		r.Project.Docker.Image.Tag = "v" + r.Project.Playwright.Version
 	}
 	if r.Project.Docker.Image.Name == "" {
-		r.Project.Docker.Image.Name = cypress.DefaultDockerImage
+		r.Project.Docker.Image.Name = playwright.DefaultDockerImage
 		r.Project.Docker.Image.Tag = "v" + r.Project.Playwright.Version
 	}
 	return nil

--- a/internal/playwright/docker/runner.go
+++ b/internal/playwright/docker/runner.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
-
-	"github.com/rs/zerolog/log"
+	"time"
 
 	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/cli/progress"
@@ -112,6 +112,9 @@ func (r *Runner) setup() error {
 		return err
 	}
 	r.containerID = container.ID
+
+	// wait until Xvfb started
+	time.Sleep(1 * time.Second)
 
 	pDir, err := r.docker.ProjectDir(r.Ctx, baseImage)
 	if err != nil {

--- a/internal/playwright/docker/runner.go
+++ b/internal/playwright/docker/runner.go
@@ -213,7 +213,7 @@ func (r *Runner) execute(cmd []string, env map[string]string) (int, error) {
 
 // run runs the tests defined in the config.Project.
 func (r *Runner) run(s playwright.Suite) (int, error) {
-	return r.execute([]string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", s.Name}, s.Config.Env)
+	return r.execute([]string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", s.Name}, map[string]string{})
 }
 
 // teardown cleans up the test environment.

--- a/internal/playwright/docker/runner_test.go
+++ b/internal/playwright/docker/runner_test.go
@@ -1,0 +1,56 @@
+package docker
+
+import (
+	"github.com/saucelabs/saucectl/cli/command"
+	"github.com/saucelabs/saucectl/cli/config"
+	"github.com/saucelabs/saucectl/cli/mocks"
+	"github.com/saucelabs/saucectl/internal/playwright"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPreliminarySteps_Basic(t *testing.T) {
+	runner := Runner{Project: playwright.Project{Playwright: playwright.Playwright{Version: "5.6.2"}}}
+	assert.Nil(t, runner.defineDockerImage())
+}
+
+func TestPreliminarySteps_DefinedImage(t *testing.T) {
+	runner := Runner{
+		Project: playwright.Project{
+			Docker: config.Docker{
+				Image: config.Image{Name: "dummy-image", Tag: "dummy-tag"},
+			},
+		},
+	}
+	assert.Nil(t, runner.defineDockerImage())
+}
+
+func TestPreliminarySteps_NoDefinedImageNoCypressVersion(t *testing.T) {
+	want := "no cypress version provided"
+	runner := Runner{}
+	err := runner.defineDockerImage()
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), want)
+}
+
+func TestNewRunner(t *testing.T) {
+	p := playwright.Project{}
+	cli := command.NewSauceCtlCli()
+	r, err := New(p, cli)
+	assert.NotNil(t, r)
+	assert.Nil(t, err)
+}
+
+func TestTearDown(t *testing.T) {
+	docker := &mocks.FakeClient{
+		ContainerInspectSuccess: true,
+		ContainerStopSuccess:    true,
+		ContainerRemoveSuccess:  true,
+	}
+	runner := Runner{
+		docker: &Handler{
+			client: docker,
+		},
+	}
+	assert.Nil(t, runner.teardown("logs"))
+}

--- a/internal/playwright/sauce/runner.go
+++ b/internal/playwright/sauce/runner.go
@@ -1,0 +1,264 @@
+package sauce
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/saucelabs/saucectl/cli/credentials"
+	"github.com/saucelabs/saucectl/cli/dots"
+	"github.com/saucelabs/saucectl/cli/progress"
+	"github.com/saucelabs/saucectl/internal/archive/zip"
+	"github.com/saucelabs/saucectl/internal/job"
+	"github.com/saucelabs/saucectl/internal/jsonio"
+	"github.com/saucelabs/saucectl/internal/playwright"
+	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/resto"
+	"github.com/saucelabs/saucectl/internal/storage"
+)
+
+// Runner represents the Sauce Labs cloud implementation for cypress.
+type Runner struct {
+	Project         playwright.Project
+	ProjectUploader storage.ProjectUploader
+	JobStarter      job.Starter
+	JobReader       job.Reader
+	Region          region.Region
+}
+
+type result struct {
+	suiteName string
+	browser   string
+	job       job.Job
+	err       error
+}
+
+// RunProject runs the tests defined in cypress.Project.
+func (r *Runner) RunProject() (int, error) {
+	exitCode := 1
+
+	// Archive the project files.
+	tempDir, err := ioutil.TempDir(os.TempDir(), "saucectl-app-payload")
+	if err != nil {
+		return exitCode, err
+	}
+	defer os.RemoveAll(tempDir)
+
+	zipName, err := r.archiveProject(tempDir)
+	if err != nil {
+		return exitCode, err
+	}
+
+	fileID, err := r.uploadProject(zipName)
+	if err != nil {
+		return exitCode, err
+	}
+
+	passed := r.runSuites(fileID)
+	if passed {
+		exitCode = 0
+	}
+
+	return exitCode, nil
+}
+
+func (r *Runner) runSuites(fileID string) bool {
+	suites := make(chan playwright.Suite)
+	results := make(chan result, len(r.Project.Suites))
+	defer close(results)
+
+	// Create a pool of workers that run the suites.
+	log.Info().Int("concurrency", r.Project.Sauce.Concurrency).Msg("Launching workers.")
+	for i := 0; i < r.Project.Sauce.Concurrency; i++ {
+		go r.worker(fileID, suites, results)
+	}
+
+	// Submit suites to work on.
+	for _, s := range r.Project.Suites {
+		// Define frameworkVersion if not set at suite level
+		if s.PlaywrightVersion == "" {
+			s.PlaywrightVersion = r.Project.Playwright.Version
+		}
+		suites <- s
+	}
+	close(suites)
+
+	// Collect results.
+	errCount := 0
+	completed := 0
+	total := len(r.Project.Suites)
+	inProgress := total
+	passed := true
+
+	waiter := dots.New(1)
+	waiter.Start()
+	for i := 0; i < total; i++ {
+		res := <-results
+		// in case one of test suites not passed
+		if !res.job.Passed {
+			passed = false
+		}
+		completed++
+		inProgress--
+
+		// Logging is not synchronized over the different worker routines & dot routine.
+		// To avoid implementing a more complex solution centralizing output on only one
+		// routine, a new lines has simply been forced, to ensure that line starts from
+		// the beginning of the console.
+		fmt.Println("")
+		log.Info().Msg(fmt.Sprintf("Suites completed: %d/%d", completed, total))
+		r.logSuite(res)
+
+		if res.job.ID == "" || res.err != nil {
+			errCount++
+		}
+	}
+	waiter.Stop()
+	logSuitesResult(total, errCount)
+
+	return passed
+}
+
+func (r *Runner) worker(fileID string, suites <-chan playwright.Suite, results chan<- result) {
+	for s := range suites {
+		jobData, err := r.runSuite(s, fileID)
+
+		r := result{
+			suiteName: s.Name,
+			browser:   s.Params.BrowserName,
+			job:       jobData,
+			err:       err,
+		}
+		results <- r
+	}
+}
+
+func (r *Runner) runSuite(s playwright.Suite, fileID string) (job.Job, error) {
+	log.Info().Str("suite", s.Name).Str("region", r.Project.Sauce.Region).Msg("Starting job.")
+
+	opts := job.StartOptions{
+		User:             credentials.Get().Username,
+		AccessKey:        credentials.Get().AccessKey,
+		App:              fmt.Sprintf("storage:%s", fileID),
+		Suite:            s.Name,
+		Framework:        "playwright",
+		FrameworkVersion: s.PlaywrightVersion,
+		BrowserName:      s.Params.BrowserName,
+		BrowserVersion:   s.PlaywrightVersion,
+		PlatformName:     s.PlatformName,
+		Name:             r.Project.Sauce.Metadata.Name + " - " + s.Name,
+		Build:            r.Project.Sauce.Metadata.Build,
+		Tags:             r.Project.Sauce.Metadata.Tags,
+		Tunnel: job.TunnelOptions{
+			ID:     r.Project.Sauce.Tunnel.ID,
+			Parent: r.Project.Sauce.Tunnel.Parent,
+		},
+	}
+
+	id, err := r.JobStarter.StartJob(context.Background(), opts)
+	if err != nil {
+		return job.Job{}, err
+	}
+
+	jobDetailsPage := fmt.Sprintf("%s/tests/%s", r.Region.AppBaseURL(), id)
+	log.Info().Msg(fmt.Sprintf("Job started - %s", jobDetailsPage))
+
+	// High interval poll to not oversaturate the job reader with requests.
+	j, err := r.JobReader.PollJob(context.Background(), id, 15*time.Second)
+	if err != nil {
+		return job.Job{}, fmt.Errorf("failed to retrieve job status for suite %s", s.Name)
+	}
+
+	if !j.Passed {
+		// We may need to differentiate when a job has crashed vs. when there is errors.
+		return j, fmt.Errorf("suite '%s' has test failures", s.Name)
+	}
+
+	return j, nil
+}
+
+func (r *Runner) archiveProject(tempDir string) (string, error) {
+	zipName := filepath.Join(tempDir, "app.zip")
+	z, err := zip.NewWriter(zipName)
+	if err != nil {
+		return "", err
+	}
+	defer z.Close()
+
+	files := []string{
+		r.Project.Playwright.LocalProjectPath,
+	}
+
+	rcPath := filepath.Join(tempDir, "sauce-runner.json")
+	if err := jsonio.WriteFile(rcPath, r.Project); err != nil {
+		return "", err
+	}
+	files = append(files, rcPath)
+
+	for _, f := range files {
+		if err := z.Add(f, ""); err != nil {
+			return "", err
+		}
+	}
+
+	return zipName, z.Close()
+}
+
+func (r *Runner) uploadProject(filename string) (string, error) {
+	progress.Show("Uploading project")
+	resp, err := r.ProjectUploader.Upload(filename)
+	progress.Stop()
+	if err != nil {
+		return "", err
+	}
+	log.Info().Str("storageId", resp.ID).Msg("Project uploaded.")
+	return resp.ID, nil
+}
+
+func shouldShowConsole(r *Runner, res result) bool {
+	if !res.job.Passed {
+		return true
+	}
+	return r.Project.ShowConsoleLog
+}
+
+// logSuite display the result of a suite
+func (r *Runner) logSuite(res result) {
+	if res.job.ID == "" {
+		log.Error().Str("suite", res.suiteName).Msgf("failed to start")
+		log.Error().Str("suite", res.suiteName).Msgf("%s", res.err)
+		return
+	}
+	resultStr := "Passed"
+	if !res.job.Passed {
+		resultStr = "Failed"
+	}
+	jobDetailsPage := fmt.Sprintf("%s/tests/%s", r.Region.AppBaseURL(), res.job.ID)
+	log.Info().Str("suite", res.suiteName).Msgf("Status: %s - %s", resultStr, jobDetailsPage)
+	if shouldShowConsole(r, res) {
+		r.logSuiteConsole(res)
+	}
+}
+
+// logSuiteError display the console output when tests from a suite are failing
+func (r *Runner) logSuiteConsole(res result) {
+	// Display log only when at least it has started
+	assetContent, err := r.JobReader.GetJobAssetFileContent(context.Background(), res.job.ID, resto.ConsoleLogAsset)
+	if err != nil {
+		log.Warn().Str("suite", res.suiteName).Msg("Failed to get job asset.")
+	} else {
+		log.Info().Msg(fmt.Sprintf("Test %s %s", res.job.ID, resto.ConsoleLogAsset))
+		log.Info().Msg(string(assetContent))
+	}
+}
+
+func logSuitesResult(total, errCount int) {
+	log.Info().Msgf("Suites total: %d", total)
+	log.Info().Msgf("Suites passed: %d", total-errCount)
+	log.Info().Msgf("Suites failed: %d", errCount)
+}

--- a/internal/playwright/sauce/runner.go
+++ b/internal/playwright/sauce/runner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/saucelabs/saucectl/cli/dots"
 	"github.com/saucelabs/saucectl/cli/progress"
 	"github.com/saucelabs/saucectl/internal/archive/zip"
+	"github.com/saucelabs/saucectl/internal/concurrency"
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/jsonio"
 	"github.com/saucelabs/saucectl/internal/playwright"
@@ -28,6 +29,7 @@ type Runner struct {
 	ProjectUploader storage.ProjectUploader
 	JobStarter      job.Starter
 	JobReader       job.Reader
+	CCYReader       concurrency.Reader
 	Region          region.Region
 }
 
@@ -73,6 +75,7 @@ func (r *Runner) runSuites(fileID string) bool {
 	defer close(results)
 
 	// Create a pool of workers that run the suites.
+	r.Project.Sauce.Concurrency = concurrency.Min(r.CCYReader, r.Project.Sauce.Concurrency)
 	log.Info().Int("concurrency", r.Project.Sauce.Concurrency).Msg("Launching workers.")
 	for i := 0; i < r.Project.Sauce.Concurrency; i++ {
 		go r.worker(fileID, suites, results)

--- a/internal/playwright/sauce/runner.go
+++ b/internal/playwright/sauce/runner.go
@@ -130,7 +130,7 @@ func (r *Runner) worker(fileID string, suites <-chan playwright.Suite, results c
 
 		r := result{
 			suiteName: s.Name,
-			browser:   s.Params.BrowserName,
+			browser:   s.Param.BrowserName,
 			job:       jobData,
 			err:       err,
 		}
@@ -148,7 +148,7 @@ func (r *Runner) runSuite(s playwright.Suite, fileID string) (job.Job, error) {
 		Suite:            s.Name,
 		Framework:        "playwright",
 		FrameworkVersion: s.PlaywrightVersion,
-		BrowserName:      s.Params.BrowserName,
+		BrowserName:      s.Param.BrowserName,
 		BrowserVersion:   s.PlaywrightVersion,
 		PlatformName:     s.PlatformName,
 		Name:             r.Project.Sauce.Metadata.Name + " - " + s.Name,

--- a/internal/region/region_test.go
+++ b/internal/region/region_test.go
@@ -1,6 +1,9 @@
 package region
 
-import "testing"
+import (
+	"gotest.tools/assert"
+	"testing"
+)
 
 func TestFromString(t *testing.T) {
 	type args struct {
@@ -34,4 +37,10 @@ func TestFromString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestString(t *testing.T) {
+	name := "staging"
+	r := FromString(name)
+	assert.Equal(t, name, r.String())
 }

--- a/tests/e2e/playwright/example.test.js
+++ b/tests/e2e/playwright/example.test.js
@@ -1,6 +1,6 @@
-describe('saucectl demo test', () => {
-	test('should verify title of the page', async () => {
-		await page.goto('https://www.saucedemo.com/');
-		expect(await page.title()).toBe('Swag Labs');
-	});
+const { it, expect } = require('@playwright/test');
+
+it('should verify title of the page', async ({ page }) => {
+	await page.goto('https://www.saucedemo.com/');
+	expect(await page.title()).toBe('Swag Labs');
 });


### PR DESCRIPTION
## Proposed changes

Implement Playwright native configuration.
It ships both implementation for running locally and on Sauce Cloud.

Similar logic to https://github.com/saucelabs/saucectl/pull/158 may be implemented, to ensure consistency of behaviour.

To pass PR `saucectl tests pipeline / playwright (pull_request)`, we must have an image which is based on something else than `jest` (which is WIP).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

