### PR TITLE
Limit concurrency based on account settings

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -244,6 +244,7 @@ func runCypressInSauce(p cypress.Project) (int, error) {
 		ProjectUploader: s,
 		JobStarter:      &tc,
 		JobReader:       &rsto,
+		CCYReader:       &rsto,
 		Region:          re,
 	}
 	return r.RunProject()

--- a/internal/concurrency/concurrency.go
+++ b/internal/concurrency/concurrency.go
@@ -1,0 +1,24 @@
+package concurrency
+
+import (
+	"context"
+	"github.com/rs/zerolog/log"
+)
+
+// Min reads the allowed concurrency from r, compares it against ccy and returns the smaller value of the two.
+// A value of 1 is returned if r is unable to provide one.
+func Min(r Reader, ccy int) int {
+	allowed, err := r.ReadAllowedCCY(context.Background())
+	if err != nil {
+		log.Warn().Err(err).Msg("Unable to determine allowed concurrency. Using concurrency of 1.")
+		return 1
+	}
+
+	if ccy > allowed {
+		log.Warn().Msgf("Allowed concurrency is %d. Overriding configured value of %d.",
+			allowed, ccy)
+		return allowed
+	}
+
+	return ccy
+}

--- a/internal/concurrency/concurrency_test.go
+++ b/internal/concurrency/concurrency_test.go
@@ -2,6 +2,7 @@ package concurrency
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -54,6 +55,16 @@ func TestMin(t *testing.T) {
 				ccy: 20,
 			},
 			want: 10,
+		},
+		{
+			name: "on error",
+			args: args{
+				r: ccyReader{ReadAllowedCCYfn: func(ctx context.Context) (int, error) {
+					return 0, errors.New("better be expecting me")
+				}},
+				ccy: 20,
+			},
+			want: 1,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/concurrency/concurrency_test.go
+++ b/internal/concurrency/concurrency_test.go
@@ -1,0 +1,66 @@
+package concurrency
+
+import (
+	"context"
+	"testing"
+)
+
+// ccyReader is a mock implemention for the concurrency.Reader interface.
+type ccyReader struct {
+	ReadAllowedCCYfn func(ctx context.Context) (int, error)
+}
+
+// ReadAllowedCCY is a wrapper around ccyReader.ReadAllowedCCYfn.
+func (r ccyReader) ReadAllowedCCY(ctx context.Context) (int, error) {
+	return r.ReadAllowedCCYfn(ctx)
+}
+
+func TestMin(t *testing.T) {
+	type args struct {
+		r   Reader
+		ccy int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "below the limit",
+			args: args{
+				r: ccyReader{ReadAllowedCCYfn: func(ctx context.Context) (int, error) {
+					return 10, nil
+				}},
+				ccy: 5,
+			},
+			want: 5,
+		},
+		{
+			name: "at the limit",
+			args: args{
+				r: ccyReader{ReadAllowedCCYfn: func(ctx context.Context) (int, error) {
+					return 10, nil
+				}},
+				ccy: 10,
+			},
+			want: 10,
+		},
+		{
+			name: "above the limit",
+			args: args{
+				r: ccyReader{ReadAllowedCCYfn: func(ctx context.Context) (int, error) {
+					return 10, nil
+				}},
+				ccy: 20,
+			},
+			want: 10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Min(tt.args.r, tt.args.ccy); got != tt.want {
+				t.Errorf("Min() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/concurrency/reader.go
+++ b/internal/concurrency/reader.go
@@ -1,0 +1,11 @@
+package concurrency
+
+import (
+	"context"
+)
+
+// Reader is the interface for retrieving account wide concurrency settings from Sauce Labs.
+type Reader interface {
+	// ReadAllowedCCY returns the allowed (max) concurrency for the current account.
+	ReadAllowedCCY(ctx context.Context) (int, error)
+}

--- a/internal/resto/client.go
+++ b/internal/resto/client.go
@@ -37,7 +37,6 @@ type concurrencyResponse struct {
 			Allowed struct {
 				VMS    int `json:"vms"`
 				RDS    int `json:"rds"`
-				MacVMS int `json:"mac_vms"`
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Limit concurrency based on account settings. Users are limited either way on the server side, but this step ensures that we aren't needlessly queuing up the jobs on the server side, while giving the impression to the customer that those are indeed executed (rather than just sitting around in the queue and waiting for their turn).

Users are still able to limit their concurrency below what they have available. If they specify a higher value, they'll be limited to what is available on their account.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
