### PR TITLE
Add cli parameter to override tunnel-id/parent

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -55,7 +55,7 @@ var (
 	testEnv        string
 	showConsoleLog bool
 	concurrency    int
-	tunnelId       string
+	tunnelID       string
 	tunnelParent   string
 )
 
@@ -89,7 +89,7 @@ func Command(cli *command.SauceCtlCli) *cobra.Command {
 	cmd.Flags().StringVar(&testEnv, "test-env", "docker", "Specifies the environment in which the tests should run. Choice: docker|sauce.")
 	cmd.Flags().BoolVarP(&showConsoleLog, "show-console-log", "", false, "Shows suites console.log locally. By default console.log is only shown on failures.")
 	cmd.Flags().IntVar(&concurrency, "ccy", 1, "Concurrency specifies how many suites are run at the same time.")
-	cmd.Flags().StringVar(&tunnelId, "tunnel-id", "", "Overrides the sauce-connect tunnel-id to be used for the run.")
+	cmd.Flags().StringVar(&tunnelID, "tunnel-id", "", "Overrides the sauce-connect tunnel-id to be used for the run.")
 	cmd.Flags().StringVar(&tunnelParent, "tunnel-parent", "", "Overrides the sauce-connect tunnel-parent to be used for the run.")
 
 	// Hide undocumented flags that the user does not need to care about.
@@ -189,7 +189,7 @@ func runCypress(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
 	}
 
 	if cmd.Flags().Lookup("tunnel-id").Changed {
-		p.Sauce.Tunnel.ID = tunnelId
+		p.Sauce.Tunnel.ID = tunnelID
 	}
 	if cmd.Flags().Lookup("tunnel-parent").Changed {
 		p.Sauce.Tunnel.Parent = tunnelParent

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -55,6 +55,8 @@ var (
 	testEnv        string
 	showConsoleLog bool
 	concurrency    int
+	tunnelId       string
+	tunnelParent   string
 )
 
 // Command creates the `run` command
@@ -87,6 +89,8 @@ func Command(cli *command.SauceCtlCli) *cobra.Command {
 	cmd.Flags().StringVar(&testEnv, "test-env", "docker", "Specifies the environment in which the tests should run. Choice: docker|sauce.")
 	cmd.Flags().BoolVarP(&showConsoleLog, "show-console-log", "", false, "Shows suites console.log locally. By default console.log is only shown on failures.")
 	cmd.Flags().IntVar(&concurrency, "ccy", 1, "Concurrency specifies how many suites are run at the same time.")
+	cmd.Flags().StringVar(&tunnelId, "tunnel-id", "", "Overrides the sauce-connect tunnel-id to be used for the run.")
+	cmd.Flags().StringVar(&tunnelParent, "tunnel-parent", "", "Overrides the sauce-connect tunnel-parent to be used for the run.")
 
 	// Hide undocumented flags that the user does not need to care about.
 	_ = cmd.Flags().MarkHidden("sauce-api")
@@ -162,6 +166,7 @@ func runCypress(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
 		}
 	}
 
+
 	if p.Sauce.Region == "" {
 		p.Sauce.Region = defaultRegion
 	}
@@ -181,6 +186,13 @@ func runCypress(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
 
 	if cmd.Flags().Lookup("ccy").Changed {
 		p.Sauce.Concurrency = concurrency
+	}
+
+	if cmd.Flags().Lookup("tunnel-id").Changed {
+		p.Sauce.Tunnel.ID = tunnelId
+	}
+	if cmd.Flags().Lookup("tunnel-parent").Changed {
+		p.Sauce.Tunnel.Parent = tunnelParent
 	}
 
 	if err := cypress.Validate(p); err != nil {

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -89,8 +89,8 @@ func Command(cli *command.SauceCtlCli) *cobra.Command {
 	cmd.Flags().StringVar(&testEnv, "test-env", "docker", "Specifies the environment in which the tests should run. Choice: docker|sauce.")
 	cmd.Flags().BoolVarP(&showConsoleLog, "show-console-log", "", false, "Shows suites console.log locally. By default console.log is only shown on failures.")
 	cmd.Flags().IntVar(&concurrency, "ccy", 1, "Concurrency specifies how many suites are run at the same time.")
-	cmd.Flags().StringVar(&tunnelID, "tunnel-id", "", "Overrides the sauce-connect tunnel-id to be used for the run.")
-	cmd.Flags().StringVar(&tunnelParent, "tunnel-parent", "", "Overrides the sauce-connect tunnel-parent to be used for the run.")
+	cmd.Flags().StringVar(&tunnelID, "tunnel-id", "", "Sets the sauce-connect tunnel ID to be used for the run.")
+	cmd.Flags().StringVar(&tunnelParent, "tunnel-parent", "", "Sets the sauce-connect tunnel parent to be used for the run.")
 
 	// Hide undocumented flags that the user does not need to care about.
 	_ = cmd.Flags().MarkHidden("sauce-api")


### PR DESCRIPTION
## Proposed changes

Add cli parameter to allow overriding the configuration value of tunnel-id/tunnel-parent.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
