### PR TITLE
Do not render out internal values of the config

### DIFF
--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -53,10 +53,10 @@ type Cypress struct {
 
 	// ProjectPath is the path to the cypress directory itself. Not set by the user, but is instead based on the
 	// location of ConfigFile.
-	ProjectPath string `json:"-"`
+	ProjectPath string `yaml:"-" json:"-"`
 
 	// EnvFile is the path to cypress.env.json. Not set by the user, but is instead based on the location of ConfigFile.
-	EnvFile string `json:"-"`
+	EnvFile string `yaml:"-" json:"-"`
 }
 
 // FromFile creates a new cypress Project based on the filepath cfgPath.


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Prevents internal values of the config from being rendered out. This happened on `saucectl new` when the template was rendered out.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
