### PR TITLE
Move legacy docker implementation to avoid collisions

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -23,7 +23,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/cypress"
 	cypressDocker "github.com/saucelabs/saucectl/internal/cypress/docker"
 	cypressSauce "github.com/saucelabs/saucectl/internal/cypress/sauce"
-	"github.com/saucelabs/saucectl/internal/docker"
+	legacyDocker "github.com/saucelabs/saucectl/internal/docker/legacydocker"
 	"github.com/saucelabs/saucectl/internal/fleet"
 	"github.com/saucelabs/saucectl/internal/memseq"
 	"github.com/saucelabs/saucectl/internal/playwright"
@@ -357,7 +357,7 @@ func newRunner(p config.Project, cli *command.SauceCtlCli) (runner.Testrunner, e
 		return ci.NewRunner(p, cli, seq, rc, cip)
 	}
 	log.Info().Msg("Starting local runner")
-	return docker.NewRunner(p, cli, &memseq.Sequencer{})
+	return legacyDocker.NewRunner(p, cli, &memseq.Sequencer{})
 }
 
 func createCIProvider() ci.Provider {

--- a/internal/docker/legacydocker/legacydocker_test.go
+++ b/internal/docker/legacydocker/legacydocker_test.go
@@ -1,4 +1,4 @@
-package docker
+package legacydocker
 
 import (
 	"archive/tar"
@@ -38,7 +38,7 @@ func TestValidateDependency(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{client: tc.Client}
+			handler := LegacyHandler{client: tc.Client}
 			err := handler.ValidateDependency()
 			assert.Equal(t, err, tc.ExpectedError)
 		})
@@ -53,7 +53,7 @@ func TestHasBaseImage(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{
+			handler := LegacyHandler{
 				client: tc.Client,
 			}
 			hasBaseImage, err := handler.HasBaseImage(ctx, "foobar")
@@ -112,7 +112,7 @@ func TestPullBaseImage(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{
+			handler := LegacyHandler{
 				client: tc.Client,
 			}
 			err := handler.PullBaseImage(ctx, *tc.JobConfig)
@@ -130,7 +130,7 @@ func TestGetImageFlavorDefault(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{
+			handler := LegacyHandler{
 				client: tc.Client,
 			}
 			baseImage := handler.GetImageFlavor(*tc.JobConfig)
@@ -148,7 +148,7 @@ func TestGetImageFlavorVersioned(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{
+			handler := LegacyHandler{
 				client: tc.Client,
 			}
 			baseImage := handler.GetImageFlavor(*tc.JobConfig)
@@ -189,7 +189,7 @@ func TestStartContainer(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{
+			handler := LegacyHandler{
 				client: tc.Client,
 			}
 			_, err := handler.StartContainer(ctx, *tc.JobConfig, *tc.Suite)
@@ -224,7 +224,7 @@ func TestCopyFromContainer(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{
+			handler := LegacyHandler{
 				client: tc.Client,
 			}
 			err := handler.CopyFromContainer(ctx, "containerId", srcFile, tc.DstPath)
@@ -247,7 +247,7 @@ func TestExecute(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{
+			handler := LegacyHandler{
 				client: tc.Client,
 			}
 			_, _, err := handler.Execute(ctx, "containerId", []string{"npm", "test"})
@@ -266,7 +266,7 @@ func TestExecuteExecuteInspect(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{
+			handler := LegacyHandler{
 				client: tc.Client,
 			}
 			exitCode, err := handler.ExecuteInspect(ctx, "containerId")
@@ -286,7 +286,7 @@ func TestContainerStop(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{
+			handler := LegacyHandler{
 				client: tc.Client,
 			}
 			err := handler.ContainerStop(ctx, "containerId")
@@ -305,7 +305,7 @@ func TestContainerRemove(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{
+			handler := LegacyHandler{
 				client: tc.Client,
 			}
 			err := handler.ContainerRemove(ctx, "containerId")
@@ -368,7 +368,7 @@ func TestHandler_CopyToContainer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := &Handler{
+			handler := &LegacyHandler{
 				client: tt.fields.client,
 			}
 			if err := handler.CopyToContainer(tt.args.ctx, tt.args.containerID, tt.args.srcFile, tt.args.targetDir); (err != nil) != tt.wantErr {
@@ -415,7 +415,7 @@ func TestHandler_ContainerInspect(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			handler := Handler{
+			handler := LegacyHandler{
 				client: tc.Client,
 			}
 			_, err := handler.ContainerInspect(ctx, "containerId")

--- a/internal/docker/legacydocker/legacyrunner.go
+++ b/internal/docker/legacydocker/legacyrunner.go
@@ -1,4 +1,4 @@
-package docker
+package legacydocker
 
 import (
 	"context"
@@ -32,7 +32,7 @@ const DefaultProjectPath = "/home/seluser"
 type LegacyRunner struct {
 	runner.BaseRunner
 	containerID string
-	docker      *Handler
+	docker      *LegacyHandler
 }
 
 // NewRunner creates a new LegacyRunner instance.
@@ -49,7 +49,7 @@ func NewRunner(c config.Project, cli *command.SauceCtlCli, seq fleet.Sequencer) 
 	r.Sequencer = seq
 
 	var err error
-	r.docker, err = Create()
+	r.docker, err = CreateLegacy()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/docker/legacydocker/legacyrunner_test.go
+++ b/internal/docker/legacydocker/legacyrunner_test.go
@@ -1,4 +1,4 @@
-package docker
+package legacydocker
 
 import (
 	"errors"
@@ -13,7 +13,7 @@ import (
 func TestDockerRunnerSetup(t *testing.T) {
 	type PassFailCase struct {
 		Name          string
-		Client        *Handler
+		Client        *LegacyHandler
 		ExpectedError error
 	}
 
@@ -21,22 +21,22 @@ func TestDockerRunnerSetup(t *testing.T) {
 		fs.WithFile("config.yaml", "foo: bar", fs.WithMode(0755)))
 
 	cases := []PassFailCase{
-		{"docker is not installed", CreateMock(&mocks.FakeClient{}), errors.New("docker is not installed")},
-		{"Pulling fails", CreateMock(&mocks.FakeClient{
+		{"docker is not installed", CreateLegacyMock(&mocks.FakeClient{}), errors.New("docker is not installed")},
+		{"Pulling fails", CreateLegacyMock(&mocks.FakeClient{
 			ContainerListSuccess: true,
 		}), errors.New("ImagePullFailure")},
-		{"Creating container fails", CreateMock(&mocks.FakeClient{
+		{"Creating container fails", CreateLegacyMock(&mocks.FakeClient{
 			ContainerListSuccess: true,
 			ImagePullSuccess:     true,
 		}), errors.New("ContainerCreateFailure")},
-		{"Copy from container fails", CreateMock(&mocks.FakeClient{
+		{"Copy from container fails", CreateLegacyMock(&mocks.FakeClient{
 			ContainerListSuccess:    true,
 			ImagePullSuccess:        true,
 			ContainerStartSuccess:   true,
 			ContainerCreateSuccess:  true,
 			ContainerInspectSuccess: true,
 		}), errors.New("CopyFromContainerFailure")},
-		// {"Can not find container config", docker.CreateMock(&mocks.FakeClient{
+		// {"Can not find container config", docker.CreateLegacyMock(&mocks.FakeClient{
 		// 	ContainerListSuccess:     true,
 		// 	ImagePullSuccess:         true,
 		// 	ContainerStartSuccess:    true,


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Move legacy docker implementation to avoid collisions.

No logic changes. Simple refactor.
