### PR TITLE
Relocate cypress cloud package

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -21,7 +21,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/ci/gitlab"
 	"github.com/saucelabs/saucectl/internal/ci/jenkins"
 	"github.com/saucelabs/saucectl/internal/cypress"
-	cypressSauce "github.com/saucelabs/saucectl/internal/cypress/sauce"
+	"github.com/saucelabs/saucectl/internal/saucecloud"
 	"github.com/saucelabs/saucectl/internal/docker"
 	legacyDocker "github.com/saucelabs/saucectl/internal/docker/legacydocker"
 	"github.com/saucelabs/saucectl/internal/fleet"
@@ -239,7 +239,7 @@ func runCypressInSauce(p cypress.Project) (int, error) {
 		AccessKey:  c.AccessKey,
 	}
 
-	r := cypressSauce.Runner{
+	r := saucecloud.CypressRunner{
 		Project:         p,
 		ProjectUploader: s,
 		JobStarter:      &tc,

--- a/internal/saucecloud/cypress_test.go
+++ b/internal/saucecloud/cypress_test.go
@@ -1,4 +1,4 @@
-package sauce
+package saucecloud
 
 import (
 	"archive/zip"
@@ -18,13 +18,13 @@ import (
 )
 
 func TestPreliminarySteps_Basic(t *testing.T) {
-	runner := Runner{Project: cypress.Project{Cypress: cypress.Cypress{Version: "5.6.2"}}}
+	runner := CypressRunner{Project: cypress.Project{Cypress: cypress.Cypress{Version: "5.6.2"}}}
 	assert.Nil(t, runner.checkCypressVersion())
 }
 
 func TestPreliminarySteps_NoCypressVersion(t *testing.T) {
 	want := "no cypress version provided"
-	runner := Runner{}
+	runner := CypressRunner{}
 	err := runner.checkCypressVersion()
 	assert.NotNil(t, err)
 	assert.Equal(t, err.Error(), want)
@@ -46,7 +46,7 @@ func TestRunSuite(t *testing.T) {
 			return job.Job{ID: id, Passed: true}, nil
 		},
 	}
-	runner := Runner{
+	runner := CypressRunner{
 		JobStarter: &starter,
 		JobReader:  &reader,
 	}
@@ -76,7 +76,7 @@ func TestRunSuites(t *testing.T) {
 	ccyReader := mocks.CCYReader{ReadAllowedCCYfn: func(ctx context.Context) (int, error) {
 		return 1, nil
 	}}
-	runner := Runner{
+	runner := CypressRunner{
 		JobStarter: &starter,
 		JobReader:  &reader,
 		CCYReader:  ccyReader,
@@ -99,7 +99,7 @@ func TestArchiveProject(t *testing.T) {
 		os.RemoveAll("./test-arch/")
 	}()
 
-	runner := Runner{
+	runner := CypressRunner{
 		Project: cypress.Project{
 			Cypress: cypress.Cypress{
 				ConfigFile:  "../../../tests/e2e/cypress.json",
@@ -139,7 +139,7 @@ func TestUploadProject(t *testing.T) {
 	uploader := &mocks.FakeProjectUploader{
 		UploadSuccess: true,
 	}
-	runner := Runner{
+	runner := CypressRunner{
 		ProjectUploader: uploader,
 	}
 	id, err := runner.uploadProject("/my-dummy-project.zip")
@@ -180,7 +180,7 @@ func TestRunProject(t *testing.T) {
 	uploader := &mocks.FakeProjectUploader{
 		UploadSuccess: true,
 	}
-	runner := Runner{
+	runner := CypressRunner{
 		JobStarter:      &starter,
 		JobReader:       &reader,
 		CCYReader:       ccyReader,
@@ -211,7 +211,7 @@ func TestLogSuiteConsole(t *testing.T) {
 			return []byte("dummy-content"), nil
 		},
 	}
-	runner := Runner{
+	runner := CypressRunner{
 		JobReader: reader,
 	}
 	res := result{

--- a/internal/saucecloud/cypress_test.go
+++ b/internal/saucecloud/cypress_test.go
@@ -102,8 +102,8 @@ func TestArchiveProject(t *testing.T) {
 	runner := CypressRunner{
 		Project: cypress.Project{
 			Cypress: cypress.Cypress{
-				ConfigFile:  "../../../tests/e2e/cypress.json",
-				ProjectPath: "../../../tests/e2e/cypress/",
+				ConfigFile:  "../../tests/e2e/cypress.json",
+				ProjectPath: "../../tests/e2e/cypress/",
 			},
 		},
 	}
@@ -188,8 +188,8 @@ func TestRunProject(t *testing.T) {
 		Project: cypress.Project{
 			Cypress: cypress.Cypress{
 				Version:     "5.6.0",
-				ConfigFile:  "../../../tests/e2e/cypress.json",
-				ProjectPath: "../../../tests/e2e/cypress/",
+				ConfigFile:  "../../tests/e2e/cypress.json",
+				ProjectPath: "../../tests/e2e/cypress/",
 			},
 			Suites: []cypress.Suite{
 				{Name: "dummy-suite"},


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Relocate the cypress cloud package to a newly shared `saucecloud` package.

No logic changes. Simple refactor.