### PR TITLE
Remove project specific references from docker

### DIFF
--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -133,7 +133,16 @@ func (r *CypressRunner) setup() error {
 		}
 	}
 
-	container, err := r.docker.StartContainer(r.Ctx, r.Project)
+	files := []string{
+		r.Project.Cypress.ConfigFile,
+		r.Project.Cypress.ProjectPath,
+	}
+
+	if r.Project.Cypress.EnvFile != "" {
+		files = append(files, r.Project.Cypress.EnvFile)
+	}
+
+	container, err := r.docker.StartContainer(r.Ctx, files, r.Project.Docker)
 	if err != nil {
 		return err
 	}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -190,8 +190,8 @@ func (handler *Handler) StartContainer(ctx context.Context, files []string, conf
 		return nil, err
 	}
 
-	imgStr := handler.GetImageFlavor(conf.Image)
-	pDir, err := handler.ProjectDir(ctx, imgStr)
+	img := handler.GetImageFlavor(conf.Image)
+	pDir, err := handler.ProjectDir(ctx, img)
 	if err != nil {
 		return nil, err
 	}
@@ -218,12 +218,12 @@ func (handler *Handler) StartContainer(ctx context.Context, files []string, conf
 	}
 	networkConfig := &network.NetworkingConfig{}
 	containerConfig := &container.Config{
-		Image:        imgStr,
+		Image:        img,
 		ExposedPorts: ports,
 		Env: []string{
 			fmt.Sprintf("SAUCE_USERNAME=%s", username),
 			fmt.Sprintf("SAUCE_ACCESS_KEY=%s", accessKey),
-			fmt.Sprintf("SAUCE_IMAGE_NAME=%s", imgStr),
+			fmt.Sprintf("SAUCE_IMAGE_NAME=%s", img),
 		},
 	}
 
@@ -232,7 +232,7 @@ func (handler *Handler) StartContainer(ctx context.Context, files []string, conf
 		return nil, err
 	}
 
-	log.Info().Str("img", imgStr).Str("id", container.ID[:12]).Msg("Starting container")
+	log.Info().Str("img", img).Str("id", container.ID[:12]).Msg("Starting container")
 	if err := handler.client.ContainerStart(ctx, container.ID, types.ContainerStartOptions{}); err != nil {
 		return nil, err
 	}

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -150,12 +150,12 @@ func TestStartContainer(t *testing.T) {
 	var err error
 
 	// Buggy container start
-	cont, err = handler.StartContainer(context.Background(), project)
+	cont, err = handler.StartContainer(context.Background(), []string{project.Cypress.ConfigFile, project.Cypress.ProjectPath}, config.Docker{})
 	assert.NotNil(t, err)
 
 	// Successfull container start
 	mockDocker.ContainerCreateSuccess = true
-	cont, err = handler.StartContainer(context.Background(), project)
+	cont, err = handler.StartContainer(context.Background(), []string{project.Cypress.ConfigFile, project.Cypress.ProjectPath}, config.Docker{})
 	assert.Nil(t, err)
 	assert.NotNil(t, cont)
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Remove project specific references from docker. This will allow the docker implementation to be shared across various framework specific runners.
