### PR TITLE
In playwright force browser to be playwright

### DIFF
--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -45,7 +45,7 @@ func (r *PlaywrightRunner) runSuites(fileID string) bool {
 			Suite:            s.Name,
 			Framework:        "playwright",
 			FrameworkVersion: s.PlaywrightVersion,
-			BrowserName:      s.Params.BrowserName,
+			BrowserName:      "playwright",
 			BrowserVersion:   s.PlaywrightVersion,
 			PlatformName:     s.PlatformName,
 			Name:             r.Project.Sauce.Metadata.Name + " - " + s.Name,


### PR DESCRIPTION
## Proposed changes

As playwright is considered to be a browser, we need to enforce this setting for each playwright running in cloud.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

