### PR TITLE
Dotter delay fix

### DIFF
--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -210,7 +210,7 @@ func (r *CloudRunner) logSuite(res result) {
 // logSuiteError display the console output when tests from a suite are failing
 func (r *CloudRunner) logSuiteConsole(res result) {
 	// To avoid clutter, we don't show the console on job passes.
-	if res.job.Passed || !r.ShowConsoleLog {
+	if res.job.Passed && !r.ShowConsoleLog {
 		return
 	}
 
@@ -219,7 +219,6 @@ func (r *CloudRunner) logSuiteConsole(res result) {
 	if err != nil {
 		log.Warn().Str("suite", res.suiteName).Msg("Failed to retrieve the console output.")
 	} else {
-		log.Info().Msg(fmt.Sprintf("Test %s %s", res.job.ID, ConsoleLogAsset))
-		log.Info().Msg(string(assetContent))
+		log.Info().Str("suite", res.suiteName).Msgf("console.log output: \n%s", assetContent)
 	}
 }

--- a/internal/saucecloud/cypress.go
+++ b/internal/saucecloud/cypress.go
@@ -54,26 +54,28 @@ func (r *CypressRunner) runSuites(fileID string) bool {
 	defer close(results)
 
 	// Submit suites to work on.
-	for _, s := range r.Project.Suites {
-		jobOpts <- job.StartOptions{
-			App:              fmt.Sprintf("storage:%s", fileID),
-			Suite:            s.Name,
-			Framework:        "cypress",
-			FrameworkVersion: r.Project.Cypress.Version,
-			BrowserName:      s.Browser,
-			BrowserVersion:   s.BrowserVersion,
-			PlatformName:     s.PlatformName,
-			Name:             r.Project.Sauce.Metadata.Name + " - " + s.Name,
-			Build:            r.Project.Sauce.Metadata.Build,
-			Tags:             r.Project.Sauce.Metadata.Tags,
-			Tunnel: job.TunnelOptions{
-				ID:     r.Project.Sauce.Tunnel.ID,
-				Parent: r.Project.Sauce.Tunnel.Parent,
-			},
-			ScreenResolution: s.ScreenResolution,
+	go func() {
+		for _, s := range r.Project.Suites {
+			jobOpts <- job.StartOptions{
+				App:              fmt.Sprintf("storage:%s", fileID),
+				Suite:            s.Name,
+				Framework:        "cypress",
+				FrameworkVersion: r.Project.Cypress.Version,
+				BrowserName:      s.Browser,
+				BrowserVersion:   s.BrowserVersion,
+				PlatformName:     s.PlatformName,
+				Name:             r.Project.Sauce.Metadata.Name + " - " + s.Name,
+				Build:            r.Project.Sauce.Metadata.Build,
+				Tags:             r.Project.Sauce.Metadata.Tags,
+				Tunnel: job.TunnelOptions{
+					ID:     r.Project.Sauce.Tunnel.ID,
+					Parent: r.Project.Sauce.Tunnel.Parent,
+				},
+				ScreenResolution: s.ScreenResolution,
+			}
 		}
-	}
-	close(jobOpts)
+		close(jobOpts)
+	}()
 
 	return r.collectResults(results, len(r.Project.Suites))
 }

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -35,30 +35,32 @@ func (r *PlaywrightRunner) runSuites(fileID string) bool {
 	defer close(results)
 
 	// Submit suites to work on.
-	for _, s := range r.Project.Suites {
-		// Define frameworkVersion if not set at suite level
-		if s.PlaywrightVersion == "" {
-			s.PlaywrightVersion = r.Project.Playwright.Version
+	go func() {
+		for _, s := range r.Project.Suites {
+			// Define frameworkVersion if not set at suite level
+			if s.PlaywrightVersion == "" {
+				s.PlaywrightVersion = r.Project.Playwright.Version
+			}
+			jobOpts <- job.StartOptions{
+				App:              fmt.Sprintf("storage:%s", fileID),
+				Suite:            s.Name,
+				Framework:        "playwright",
+				FrameworkVersion: s.PlaywrightVersion,
+				BrowserName:      "playwright",
+				BrowserVersion:   s.PlaywrightVersion,
+				PlatformName:     s.PlatformName,
+				Name:             r.Project.Sauce.Metadata.Name + " - " + s.Name,
+				Build:            r.Project.Sauce.Metadata.Build,
+				Tags:             r.Project.Sauce.Metadata.Tags,
+				Tunnel: job.TunnelOptions{
+					ID:     r.Project.Sauce.Tunnel.ID,
+					Parent: r.Project.Sauce.Tunnel.Parent,
+				},
+				ScreenResolution: s.ScreenResolution,
+			}
 		}
-		jobOpts <- job.StartOptions{
-			App:              fmt.Sprintf("storage:%s", fileID),
-			Suite:            s.Name,
-			Framework:        "playwright",
-			FrameworkVersion: s.PlaywrightVersion,
-			BrowserName:      "playwright",
-			BrowserVersion:   s.PlaywrightVersion,
-			PlatformName:     s.PlatformName,
-			Name:             r.Project.Sauce.Metadata.Name + " - " + s.Name,
-			Build:            r.Project.Sauce.Metadata.Build,
-			Tags:             r.Project.Sauce.Metadata.Tags,
-			Tunnel: job.TunnelOptions{
-				ID:     r.Project.Sauce.Tunnel.ID,
-				Parent: r.Project.Sauce.Tunnel.Parent,
-			},
-			ScreenResolution: s.ScreenResolution,
-		}
-	}
-	close(jobOpts)
+		close(jobOpts)
+	}()
 
 	return r.collectResults(results, len(r.Project.Suites))
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Queue up the jobs asynchronously.
This allows us to proceed to the result collection step immediately and therefore display the waiting dots without any delay.

Also included are minor log statement adjustments for a cleaner look overall.

Example output:
```
./saucectl run -c .sauce/cypress_cloud.yml --test-env sauce --ccy 1
15:43:07 INF Running version unknown-version
15:43:07 INF Reading config file config=.sauce/cypress_cloud.yml
15:43:07 INF Running Cypress in Sauce Labs
15:43:07 INF Project archived. bytes=307463
15:43:09 INF Project uploaded. storageId=49527225-e3ae-4bc3-87a9-f7c6c6238baf
15:43:09 INF Launching workers. concurrency=1
15:43:09 INF Starting suite. region=us-west-1 suite="saucy chrome test"
..15:43:11 INF Suite started. suite="saucy chrome test" url=https://app.saucelabs.com/tests/b828f488ce1740d5942769aff7eb9add
............................................................
15:44:11 INF Suites completed: 1/1
15:44:11 INF Suite finished. passed=true suite="saucy chrome test" url=https://app.saucelabs.com/tests/b828f488ce1740d5942769aff7eb9add
15:44:11 INF Suites expected: 1
15:44:11 INF Suites passed: 1
15:44:11 INF Suites failed: 0
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
