### PR TITLE
Add docker parallelism

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -123,7 +123,7 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, erro
 	}
 
 	if d.Kind == config.KindCypress && d.APIVersion == config.VersionV1Alpha {
-		return runCypress(cmd, cli)
+		return runCypress(cmd)
 	}
 	if d.Kind == config.KindPlaywright && d.APIVersion == config.VersionV1Alpha {
 		return runPlaywright(cmd, cli)
@@ -156,7 +156,7 @@ func runLegacyMode(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
 	return r.RunProject()
 }
 
-func runCypress(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
+func runCypress(cmd *cobra.Command) (int, error) {
 	p, err := cypress.FromFile(cfgFilePath)
 	if err != nil {
 		return 1, err
@@ -209,7 +209,7 @@ func runCypress(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
 
 	switch testEnv {
 	case "docker":
-		return runCypressInDocker(p, tc, cli)
+		return runCypressInDocker(p, tc)
 	case "sauce":
 		return runCypressInSauce(p, regio, creds, tc)
 	default:
@@ -217,10 +217,10 @@ func runCypress(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
 	}
 }
 
-func runCypressInDocker(p cypress.Project, testco testcomposer.Client, cli *command.SauceCtlCli) (int, error) {
+func runCypressInDocker(p cypress.Project, testco testcomposer.Client) (int, error) {
 	log.Info().Msg("Running Cypress in Docker")
 
-	cd, err := docker.NewCypress(p, cli, &testco)
+	cd, err := docker.NewCypress(p, &testco)
 	if err != nil {
 		return 1, err
 	}
@@ -313,7 +313,7 @@ func runPlaywright(cmd *cobra.Command, cli *command.SauceCtlCli) (int, error) {
 func runPlaywrightInDocker(p playwright.Project, cli *command.SauceCtlCli, testco testcomposer.Client) (int, error) {
 	log.Info().Msg("Running Playwright in Docker")
 
-	cd, err := docker.NewPlaywright(p, cli, &testco)
+	cd, err := docker.NewPlaywright(p, &testco)
 	if err != nil {
 		return 1, err
 	}

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -172,8 +172,12 @@ func (r *ContainerRunner) run(containerID, suiteName string, cmd []string, env m
 	return containerID, output, jobDetailsURL, passed, nil
 }
 
-// readTestUrl reads test url from inside the test runner container.
+// readTestURL reads test url from inside the test runner container.
 func (r *ContainerRunner) readTestURL(containerID string) (string, error) {
+	// Set unknown when image does not support it.
+	if r.containerConfig.jobDetailsFilePath == "" {
+		return "unknown", nil
+	}
 	dir, err := ioutil.TempDir("", "result")
 	if err != nil {
 		return "", err

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/rs/zerolog/log"
-	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/dots"
 	"github.com/saucelabs/saucectl/internal/framework"
@@ -21,7 +20,6 @@ import (
 // ContainerRunner represents the container runner for docker.
 type ContainerRunner struct {
 	Ctx             context.Context
-	Cli             *command.SauceCtlCli
 	docker          *Handler
 	containerConfig *containerConfig
 	Framework       framework.Framework

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -136,10 +136,10 @@ func (r *ContainerRunner) setupImage(options containerStartOptions) (string, err
 
 func (r *ContainerRunner) run(containerID, suiteName string, cmd []string, env map[string]string) (string, string, bool, error) {
 	defer func() {
-		log.Info().Str("suite", suiteName).Msg("Tearing down environment")
+		log.Info().Msgf("%s: Tearing down environment", suiteName)
 		if err := r.docker.Teardown(r.Ctx, containerID); err != nil {
 			if !r.docker.IsErrNotFound(err) {
-				log.Error().Err(err).Str("suite", suiteName).Msg("Failed to tear down environment")
+				log.Error().Err(err).Msgf("%s: Failed to tear down environment", suiteName)
 			}
 		}
 	}()
@@ -158,7 +158,7 @@ func (r *ContainerRunner) run(containerID, suiteName string, cmd []string, env m
 
 func (r *ContainerRunner) beforeExec(containerID, suiteName string, tasks []string) error {
 	for _, task := range tasks {
-		log.Info().Str("suite", suiteName).Str("task", task).Msg("Running BeforeExec")
+		log.Info().Str("task", task).Msgf("%s: Running BeforeExec", suiteName)
 		exitCode, _, err := r.docker.ExecuteAttach(r.Ctx, containerID, strings.Fields(task), nil)
 		if err != nil {
 			return err
@@ -233,28 +233,28 @@ func (r *ContainerRunner) collectResults(results chan result, expected int) bool
 
 func (r *ContainerRunner) logSuite(res result) {
 	if res.containerID == "" {
-		log.Error().Err(res.err).Str("suite", res.suiteName).Msg("Failed to start suite.")
+		log.Error().Err(res.err).Msgf("%s: Failed to start suite.", res.suiteName)
 		return
 	}
 
 	// FIXME: Parse it
 	//jobDetailsPage := fmt.Sprintf("%s/tests/%s", r.Region.AppBaseURL(), res.job.ID)
 	if res.passed {
-		log.Info().Str("suite", res.suiteName).Bool("passed", res.passed).Msg("Suite finished.")
+		log.Info().Bool("passed", res.passed).Msgf("%s: Suite finished.", res.suiteName)
 	} else {
-		log.Error().Str("suite", res.suiteName).Bool("passed", res.passed).Msg("Suite finished.")
+		log.Error().Bool("passed", res.passed).Msgf("%s: Suite finished.", res.suiteName)
 	}
 
 	if !res.passed || r.ShowConsoleLog {
-		log.Info().Str("suite", res.suiteName).Msgf("console.log output: \n%s", res.output)
+		log.Info().Msgf("%s: console.log output: \n%s", res.suiteName, res.output)
 	}
 }
 
 func (r *ContainerRunner) runSuite(options containerStartOptions) (string, string, bool, error) {
-	log.Info().Str("suite", options.SuiteName).Msg("Setting up test environment")
+	log.Info().Msgf("%s: Setting up test environment", options.SuiteName)
 	containerID, err := r.setupImage(options)
 	if err != nil {
-		log.Err(err).Str("suite", options.SuiteName).Msg("Failed to setup test environment")
+		log.Err(err).Msgf("%s: Failed to setup test environment", options.SuiteName)
 		return containerID, "", false, err
 	}
 

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/dots"
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/jsonio"
 	"github.com/saucelabs/saucectl/internal/progress"
@@ -21,11 +22,25 @@ import (
 type ContainerRunner struct {
 	Ctx             context.Context
 	Cli             *command.SauceCtlCli
-	containerID     string
 	docker          *Handler
 	containerConfig *containerConfig
 	Framework       framework.Framework
 	ImageLoc        framework.ImageLocator
+}
+
+// containerStartOptions represent data required to start a new container.
+type containerStartOptions struct {
+	Docker      config.Docker
+	BeforeExec  []string
+	Project     interface{}
+	SuiteName   string
+	Environment map[string]string
+	Files       []string
+}
+
+// result represents the result of a local job
+type result struct {
+	Err error
 }
 
 func (r *ContainerRunner) pullImage(img string) error {
@@ -60,71 +75,71 @@ func (r *ContainerRunner) pullImage(img string) error {
 }
 
 // setupImage performs any necessary steps for a test runner to execute tests.
-func (r *ContainerRunner) setupImage(confd config.Docker, beforeExec []string, project interface{}, files []string) error {
+func (r *ContainerRunner) setupImage(confd config.Docker, beforeExec []string, project interface{}, files []string) (string, error) {
 	if !r.docker.IsInstalled() {
-		return fmt.Errorf("please verify that docker is installed and running: " +
+		return "", fmt.Errorf("please verify that docker is installed and running: " +
 			" follow the guide at https://docs.docker.com/get-docker/")
 	}
 
 	if confd.Image == "" {
 		img, err := r.ImageLoc.GetImage(r.Ctx, r.Framework)
 		if err != nil {
-			return fmt.Errorf("unable to determine which docker image to run: %w", err)
+			return "", fmt.Errorf("unable to determine which docker image to run: %w", err)
 		}
 		confd.Image = img
 	}
 
 	if err := r.pullImage(confd.Image); err != nil {
-		return err
+		return "", err
 	}
 
 	container, err := r.docker.StartContainer(r.Ctx, files, confd)
 	if err != nil {
-		return err
+		return "", err
 	}
-	r.containerID = container.ID
+	containerID := container.ID
 
 	pDir, err := r.docker.ProjectDir(r.Ctx, confd.Image)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	tmpDir, err := ioutil.TempDir("", "saucectl")
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer os.RemoveAll(tmpDir)
 
 	rcPath := filepath.Join(tmpDir, SauceRunnerConfigFile)
 	if err := jsonio.WriteFile(rcPath, project); err != nil {
-		return err
+		return "", err
 	}
 
-	if err := r.docker.CopyToContainer(r.Ctx, r.containerID, rcPath, pDir); err != nil {
-		return err
+	if err := r.docker.CopyToContainer(r.Ctx, containerID, rcPath, pDir); err != nil {
+		return "", err
 	}
 	r.containerConfig.sauceRunnerConfigPath = path.Join(pDir, SauceRunnerConfigFile)
 
 	// running pre-exec tasks
-	err = r.beforeExec(beforeExec)
+	err = r.beforeExec(containerID, beforeExec)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return container.ID, nil
 }
 
-func (r *ContainerRunner) run(cmd []string, env map[string]string) error {
+func (r *ContainerRunner) run(containerID string, cmd []string, env map[string]string) error {
 	defer func() {
 		log.Info().Msg("Tearing down environment")
-		if err := r.docker.Teardown(r.Ctx, r.containerID); err != nil {
+		if err := r.docker.Teardown(r.Ctx, containerID); err != nil {
 			if !r.docker.IsErrNotFound(err) {
 				log.Error().Err(err).Msg("Failed to tear down environment")
 			}
 		}
 	}()
 
-	exitCode, err := r.docker.ExecuteAttach(r.Ctx, r.containerID, r.Cli, cmd, env)
+	exitCode, err := r.docker.ExecuteAttach(r.Ctx, containerID, r.Cli, cmd, env)
 	log.Info().
 		Int("ExitCode", exitCode).
 		Msg("Command Finished")
@@ -138,10 +153,10 @@ func (r *ContainerRunner) run(cmd []string, env map[string]string) error {
 	return nil
 }
 
-func (r *ContainerRunner) beforeExec(tasks []string) error {
+func (r *ContainerRunner) beforeExec(containerID string, tasks []string) error {
 	for _, task := range tasks {
 		log.Info().Str("task", task).Msg("Running BeforeExec")
-		exitCode, err := r.docker.ExecuteAttach(r.Ctx, r.containerID, r.Cli, strings.Fields(task), nil)
+		exitCode, err := r.docker.ExecuteAttach(r.Ctx, containerID, r.Cli, strings.Fields(task), nil)
 		if err != nil {
 			return err
 		}
@@ -152,24 +167,57 @@ func (r *ContainerRunner) beforeExec(tasks []string) error {
 	return nil
 }
 
-// WIP
-type containerStartOptions struct {
-	Docker      config.Docker
-	BeforeExec  []string
-	Project     interface{}
-	SuiteName   string
-	Environment map[string]string
-	Files       []string
+func (r *ContainerRunner) createWorkerPool(ccy int) (chan containerStartOptions, chan result) {
+	jobOpts := make(chan containerStartOptions)
+	results := make(chan result, ccy)
+
+	log.Info().Int("concurrency", ccy).Msg("Launching workers.")
+	for i := 0; i < ccy; i++ {
+		go r.runJobs(jobOpts, results)
+	}
+
+	return jobOpts, results
+}
+
+func (r *ContainerRunner) runJobs(containerOpts <-chan containerStartOptions, results chan<- result) {
+	for opts := range containerOpts {
+		err := r.runSuite(opts)
+		rs := result{
+			Err: err,
+		}
+		results <- rs
+	}
+}
+
+func (r *ContainerRunner) collectResults(results chan result, expected int) bool {
+	// TODO find a better way to get the expected
+	//errCount := 0
+	completed := 0
+	inProgress := expected
+	//passed := true
+
+	waiter := dots.New(1)
+	waiter.Start()
+	for i := 0; i < expected; i++ {
+		<-results
+		completed++
+		inProgress--
+
+		fmt.Println("")
+		log.Info().Msgf("Suites completed: %d/%d", completed, expected)
+
+	}
+	waiter.Stop()
+	return false
 }
 
 func (r *ContainerRunner) runSuite(options containerStartOptions) error {
 	log.Info().Msg("Setting up test environment")
-	if err := r.setupImage(options.Docker, options.BeforeExec, options.Project, options.Files); err != nil {
+	containerID, err := r.setupImage(options.Docker, options.BeforeExec, options.Project, options.Files);
+	if err != nil {
 		log.Err(err).Msg("Failed to setup test environment")
 		return err
 	}
 
-	return r.run([]string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", options.SuiteName},
-		options.Environment)
-	return nil
+	return r.run(containerID, []string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", options.SuiteName}, options.Environment)
 }

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -59,7 +59,7 @@ func (r *ContainerRunner) pullImage(img string) error {
 	return nil
 }
 
-// setup performs any necessary steps for a test runner to execute tests.
+// setupImage performs any necessary steps for a test runner to execute tests.
 func (r *ContainerRunner) setupImage(confd config.Docker, beforeExec []string, project interface{}, files []string) error {
 	if !r.docker.IsInstalled() {
 		return fmt.Errorf("please verify that docker is installed and running: " +
@@ -149,5 +149,27 @@ func (r *ContainerRunner) beforeExec(tasks []string) error {
 			return fmt.Errorf("failed to run BeforeExec task: %s - exit code %d", task, exitCode)
 		}
 	}
+	return nil
+}
+
+// WIP
+type containerStartOptions struct {
+	Docker      config.Docker
+	BeforeExec  []string
+	Project     interface{}
+	SuiteName   string
+	Environment map[string]string
+	Files       []string
+}
+
+func (r *ContainerRunner) runSuite(options containerStartOptions) error {
+	log.Info().Msg("Setting up test environment")
+	if err := r.setupImage(options.Docker, options.BeforeExec, options.Project, options.Files); err != nil {
+		log.Err(err).Msg("Failed to setup test environment")
+		return err
+	}
+
+	return r.run([]string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", options.SuiteName},
+		options.Environment)
 	return nil
 }

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -281,7 +281,7 @@ func (r *ContainerRunner) logSuite(res result) {
 	}
 
 	if !res.passed || r.ShowConsoleLog {
-		log.Info().Msgf("%s: console.log output: \n%s", res.suiteName, res.output)
+		log.Info().Msgf("%s: console.log output: \n%s", res.suiteName, res.consoleOutput)
 	}
 }
 

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -159,7 +159,7 @@ func (r *ContainerRunner) run(containerID, suiteName string, cmd []string, env m
 
 	passed = true
 	if exitCode != 0 {
-		err = fmt.Errorf("exitCode is %d", exitCode)
+		log.Warn().Str("suite", suiteName).Msgf("exitCode is %d", exitCode)
 		passed = false
 	}
 
@@ -167,7 +167,7 @@ func (r *ContainerRunner) run(containerID, suiteName string, cmd []string, env m
 	if err != nil {
 		log.Warn().Msgf("unable to retrieve test result url: %s", err)
 	}
-	return output, jobDetailsURL, passed, nil
+	return output, jobDetailsURL, passed, err
 }
 
 // readTestURL reads test url from inside the test runner container.

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -117,7 +117,7 @@ func (r *ContainerRunner) startContainer(options containerStartOptions) (string,
 		return "", err
 	}
 
-	r.containerConfig.jobDetailsFilePath, err = r.docker.JobDetailsURLFile(r.Ctx, options.Docker.Image)
+	r.containerConfig.jobInfoFilePath, err = r.docker.JobInfoFile(r.Ctx, options.Docker.Image)
 	if err != nil {
 		return "", err
 	}
@@ -179,7 +179,7 @@ func (r *ContainerRunner) run(containerID, suiteName string, cmd []string, env m
 // readTestURL reads test url from inside the test runner container.
 func (r *ContainerRunner) readJobInfo(containerID string) (jobInfo, error) {
 	// Set unknown when image does not support it.
-	if r.containerConfig.jobDetailsFilePath == "" {
+	if r.containerConfig.jobInfoFilePath == "" {
 		return jobInfo{JobDetailsURL: "unknown"}, nil
 	}
 	dir, err := ioutil.TempDir("", "result")
@@ -188,11 +188,11 @@ func (r *ContainerRunner) readJobInfo(containerID string) (jobInfo, error) {
 	}
 	defer os.RemoveAll(dir)
 
-	err = r.docker.CopyFromContainer(r.Ctx, containerID, r.containerConfig.jobDetailsFilePath, dir)
+	err = r.docker.CopyFromContainer(r.Ctx, containerID, r.containerConfig.jobInfoFilePath, dir)
 	if err != nil {
 		return jobInfo{}, err
 	}
-	fileName := filepath.Base(r.containerConfig.jobDetailsFilePath)
+	fileName := filepath.Base(r.containerConfig.jobInfoFilePath)
 	filePath := filepath.Join(dir, fileName)
 	content, err := ioutil.ReadFile(filePath)
 

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -42,7 +42,7 @@ type result struct {
 	containerID   string
 	err           error
 	passed        bool
-	output        string
+	consoleOutput string
 	suiteName     string
 	jobDetailsURL string
 }
@@ -226,7 +226,7 @@ func (r *ContainerRunner) runJobs(containerOpts <-chan containerStartOptions, re
 			containerID:   containerID,
 			jobDetailsURL: jobDetailsURL,
 			passed:        passed,
-			output:        output,
+			consoleOutput: output,
 			err:           err,
 		}
 	}

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -290,11 +290,11 @@ func (r *ContainerRunner) runSuite(options containerStartOptions) (containerID s
 	containerID, err = r.startContainer(options)
 	if err != nil {
 		log.Err(err).Msgf("%s: Failed to setup test environment", options.SuiteName)
-		return containerID, "", "", false, err
+		return
 	}
 
 	output, jobDetailsURL, passed, err = r.run(containerID, options.SuiteName,
 		[]string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", options.SuiteName},
 		options.Environment)
-	return containerID, output, jobDetailsURL, passed, err
+	return
 }

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -165,15 +165,15 @@ func (r *ContainerRunner) run(containerID, suiteName string, cmd []string, env m
 		passed = false
 	}
 
-	jobDetailsUrl, err := r.readTestUrl(containerID)
+	jobDetailsURL, err := r.readTestURL(containerID)
 	if err != nil {
 		log.Warn().Msgf("unable to retrieve test result url: %s", err)
 	}
-	return containerID, output, jobDetailsUrl, passed, nil
+	return containerID, output, jobDetailsURL, passed, nil
 }
 
 // readTestUrl reads test url from inside the test runner container.
-func (r *ContainerRunner) readTestUrl(containerID string) (string, error) {
+func (r *ContainerRunner) readTestURL(containerID string) (string, error) {
 	dir, err := ioutil.TempDir("", "result")
 	if err != nil {
 		return "", err
@@ -218,11 +218,11 @@ func (r *ContainerRunner) createWorkerPool(ccy int) (chan containerStartOptions,
 
 func (r *ContainerRunner) runJobs(containerOpts <-chan containerStartOptions, results chan<- result) {
 	for opts := range containerOpts {
-		containerID, output, jobDetailsUrl, passed, err := r.runSuite(opts)
+		containerID, output, jobDetailsURL, passed, err := r.runSuite(opts)
 		results <- result{
 			suiteName:     opts.SuiteName,
 			containerID:   containerID,
-			jobDetailsURL: jobDetailsUrl,
+			jobDetailsURL: jobDetailsURL,
 			passed:        passed,
 			output:        output,
 			err:           err,

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -143,10 +143,10 @@ func (r *ContainerRunner) startContainer(options containerStartOptions) (string,
 
 func (r *ContainerRunner) run(containerID, suiteName string, cmd []string, env map[string]string) (output string, jobDetailsURL string, passed bool, err error) {
 	defer func() {
-		log.Info().Msgf("%s: Tearing down environment", suiteName)
+		log.Info().Str("suite", suiteName).Msg("Tearing down environment")
 		if err := r.docker.Teardown(r.Ctx, containerID); err != nil {
 			if !r.docker.IsErrNotFound(err) {
-				log.Error().Err(err).Msgf("%s: Failed to tear down environment", suiteName)
+				log.Error().Err(err).Str("suite", suiteName).Msg("Failed to tear down environment")
 			}
 		}
 	}()

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -206,7 +206,7 @@ func (r *ContainerRunner) readJobInfo(containerID string) (jobInfo, error) {
 
 func (r *ContainerRunner) beforeExec(containerID, suiteName string, tasks []string) error {
 	for _, task := range tasks {
-		log.Info().Str("task", task).Msgf("%s: Running BeforeExec", suiteName)
+		log.Info().Str("task", task).Str("suite", suiteName).Msg("Running BeforeExec")
 		exitCode, _, err := r.docker.ExecuteAttach(r.Ctx, containerID, strings.Fields(task), nil)
 		if err != nil {
 			return err
@@ -282,26 +282,26 @@ func (r *ContainerRunner) collectResults(results chan result, expected int) bool
 
 func (r *ContainerRunner) logSuite(res result) {
 	if res.containerID == "" {
-		log.Error().Err(res.err).Msgf("%s: Failed to start suite.", res.suiteName)
+		log.Error().Err(res.err).Str("suite", res.suiteName).Msg("Failed to start suite.")
 		return
 	}
 
 	if res.passed {
-		log.Info().Bool("passed", res.passed).Str("url", res.jobInfo.JobDetailsURL).Msgf("%s: Suite finished.", res.suiteName)
+		log.Info().Bool("passed", res.passed).Str("url", res.jobInfo.JobDetailsURL).Str("suite", res.suiteName).Msg("Suite finished.")
 	} else {
-		log.Error().Bool("passed", res.passed).Str("url", res.jobInfo.JobDetailsURL).Msgf("%s: Suite finished.", res.suiteName)
+		log.Error().Bool("passed", res.passed).Str("url", res.jobInfo.JobDetailsURL).Str("suite", res.suiteName).Msg("Suite finished.")
 	}
 
 	if !res.passed || r.ShowConsoleLog {
-		log.Info().Msgf("%s: console.log output: \n%s", res.suiteName, res.consoleOutput)
+		log.Info().Str("suite", res.suiteName).Msgf("console.log output: \n%s", res.consoleOutput)
 	}
 }
 
 func (r *ContainerRunner) runSuite(options containerStartOptions) (containerID string, output string, jobInfo jobInfo, passed bool, err error) {
-	log.Info().Msgf("%s: Setting up test environment", options.SuiteName)
+	log.Info().Str("suite", options.SuiteName).Msg("Setting up test environment")
 	containerID, err = r.startContainer(options)
 	if err != nil {
-		log.Err(err).Msgf("%s: Failed to setup test environment", options.SuiteName)
+		log.Err(err).Str("suite", options.SuiteName).Msg("Failed to setup test environment")
 		return
 	}
 

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/framework"
@@ -70,7 +69,6 @@ func (r *CypressRunner) RunProject() (int, error) {
 
 	hasErrors := r.collectResults(results, len(r.Project.Suites))
 	if hasErrors {
-		log.Error().Msgf("%d suite(s) failed", -1)
 		return 1, nil
 	}
 	return 0, nil

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -58,6 +58,10 @@ func (r *CypressRunner) RunProject() (int, error) {
 		r.Project.Docker.FileTransfer = config.DockerFileCopy
 	}
 
+	if err := r.fetchImage(&r.Project.Docker); err != nil {
+		return 1, err
+	}
+
 	containerOpts, results := r.createWorkerPool(r.Project.Sauce.Concurrency)
 	defer close(results)
 

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -2,7 +2,9 @@ package docker
 
 import (
 	"context"
+	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/cli/command"
+	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/framework"
 )
@@ -49,6 +51,11 @@ func (r *CypressRunner) RunProject() (int, error) {
 
 	if r.Project.Cypress.EnvFile != "" {
 		files = append(files, r.Project.Cypress.EnvFile)
+	}
+
+	if r.Project.Sauce.Concurrency > 1 {
+		log.Info().Msg("concurrency > 1: file transfer mode forced to copy.")
+		r.Project.Docker.FileTransfer = config.DockerFileCopy
 	}
 
 	containerOpts, results := r.createWorkerPool(r.Project.Sauce.Concurrency)

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"context"
 	"github.com/rs/zerolog/log"
-	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/framework"
@@ -16,12 +15,11 @@ type CypressRunner struct {
 }
 
 // NewCypress creates a new CypressRunner instance.
-func NewCypress(c cypress.Project, cli *command.SauceCtlCli, imageLoc framework.ImageLocator) (*CypressRunner, error) {
+func NewCypress(c cypress.Project, imageLoc framework.ImageLocator) (*CypressRunner, error) {
 	r := CypressRunner{
 		Project: c,
 		ContainerRunner: ContainerRunner{
 			Ctx:             context.Background(),
-			Cli:             cli,
 			docker:          nil,
 			containerConfig: &containerConfig{},
 			Framework: framework.Framework{

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -54,14 +54,15 @@ func (r *CypressRunner) RunProject() (int, error) {
 
 	errorCount := 0
 	for _, suite := range r.Project.Suites {
-		log.Info().Msg("Setting up test environment")
-		if err := r.setupImage(r.Project.Docker, r.Project.BeforeExec, r.Project, files); err != nil {
-			log.Err(err).Msg("Failed to setup test environment")
-			return 1, err
-		}
+		err := r.RunSuite(ContainerStartOptions{
+			Docker:      r.Project.Docker,
+			BeforeExec:  r.Project.BeforeExec,
+			Project:     r.Project,
+			SuiteName:   suite.Name,
+			Environment: suite.Config.Env,
+			Files:       files,
+		})
 
-		err := r.run([]string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", suite.Name},
-			suite.Config.Env)
 		if err != nil {
 			errorCount++
 		}

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -75,8 +75,8 @@ func (r *CypressRunner) RunProject() (int, error) {
 		close(containerOpts)
 	}()
 
-	hasErrors := r.collectResults(results, len(r.Project.Suites))
-	if hasErrors {
+	hasPassed := r.collectResults(results, len(r.Project.Suites))
+	if !hasPassed {
 		return 1, nil
 	}
 	return 0, nil

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -27,6 +27,7 @@ func NewCypress(c cypress.Project, cli *command.SauceCtlCli, imageLoc framework.
 				Version: c.Cypress.Version,
 			},
 			ImageLoc: imageLoc,
+			ShowConsoleLog: c.ShowConsoleLog,
 		},
 	}
 

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -52,7 +52,7 @@ func (r *CypressRunner) RunProject() (int, error) {
 	}
 
 	if r.Project.Sauce.Concurrency > 1 {
-		log.Info().Msg("concurrency > 1: file transfer mode forced to copy.")
+		log.Info().Msg("concurrency > 1: forcing file transfer mode to use 'copy'.")
 		r.Project.Docker.FileTransfer = config.DockerFileCopy
 	}
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -47,6 +47,8 @@ const SauceRunnerConfigFile = "sauce-runner.json"
 type containerConfig struct {
 	// sauceRunnerConfigPath is the container path to sauce-runner.json.
 	sauceRunnerConfigPath string
+	// jobDetailsFilePath is the container path to the file containing job details url on Sauce.
+	jobDetailsFilePath string
 }
 
 // CommonAPIClient is the interface for interacting with containers.
@@ -474,8 +476,8 @@ func (handler *Handler) ProjectDir(ctx context.Context, imageID string) (string,
 	return p, nil
 }
 
-// TestUrl returns the file containing the test url for the given image.
-func (handler *Handler) TestUrl(ctx context.Context, imageID string) (string, error) {
+// JobDetailsURLFile returns the file containing the job details url for the given image.
+func (handler *Handler) JobDetailsURLFile(ctx context.Context, imageID string) (string, error) {
 	ii, _, err := handler.client.ImageInspectWithRaw(ctx, imageID)
 	if err != nil {
 		return "", err
@@ -483,7 +485,7 @@ func (handler *Handler) TestUrl(ctx context.Context, imageID string) (string, er
 
 	// The image can tell us via a label where saucectl should find the url for the test details.
 	var p string
-	if v := ii.Config.Labels["com.saucelabs.test-url"]; v != "" {
+	if v := ii.Config.Labels["com.saucelabs.job-details-url"]; v != "" {
 		p = v
 	}
 	return p, nil

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -47,8 +47,8 @@ const SauceRunnerConfigFile = "sauce-runner.json"
 type containerConfig struct {
 	// sauceRunnerConfigPath is the container path to sauce-runner.json.
 	sauceRunnerConfigPath string
-	// jobDetailsFilePath is the container path to the file containing job details url on Sauce.
-	jobDetailsFilePath string
+	// jobInfoFilePath is the container path to the file containing job details url on Sauce.
+	jobInfoFilePath string
 }
 
 // CommonAPIClient is the interface for interacting with containers.
@@ -477,7 +477,7 @@ func (handler *Handler) ProjectDir(ctx context.Context, imageID string) (string,
 }
 
 // JobDetailsURLFile returns the file containing the job details url for the given image.
-func (handler *Handler) JobDetailsURLFile(ctx context.Context, imageID string) (string, error) {
+func (handler *Handler) JobInfoFile(ctx context.Context, imageID string) (string, error) {
 	ii, _, err := handler.client.ImageInspectWithRaw(ctx, imageID)
 	if err != nil {
 		return "", err
@@ -485,7 +485,7 @@ func (handler *Handler) JobDetailsURLFile(ctx context.Context, imageID string) (
 
 	// The image can tell us via a label where saucectl should find the url for the test details.
 	var p string
-	if v := ii.Config.Labels["com.saucelabs.job-details-url"]; v != "" {
+	if v := ii.Config.Labels["com.saucelabs.job-info"]; v != "" {
 		p = v
 	}
 	return p, nil

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -212,7 +212,7 @@ func (handler *Handler) StartContainer(ctx context.Context, options containerSta
 	if creds := credentials.Get(); creds != nil {
 		username = creds.Username
 		accessKey = creds.AccessKey
-		log.Info().Msgf("%s: Using credentials set by %s", options.SuiteName, creds.Source)
+		log.Info().Str("suite", options.SuiteName).Msgf("Using credentials set by %s", creds.Source)
 	}
 
 	hostConfig := &container.HostConfig{
@@ -234,7 +234,7 @@ func (handler *Handler) StartContainer(ctx context.Context, options containerSta
 		return nil, err
 	}
 
-	log.Info().Str("img", options.Docker.Image).Str("id", container.ID[:12]).Msgf("%s: Starting container", options.SuiteName)
+	log.Info().Str("img", options.Docker.Image).Str("id", container.ID[:12]).Str("suite", options.SuiteName).Msg("Starting container")
 	if err := handler.client.ContainerStart(ctx, container.ID, types.ContainerStartOptions{}); err != nil {
 		return nil, err
 	}
@@ -259,7 +259,7 @@ func (handler *Handler) StartContainer(ctx context.Context, options containerSta
 // copyTestFiles copies the files within the container.
 func copyTestFiles(ctx context.Context, handler *Handler, containerID, suiteName string, files []string, pDir string) error {
 	for _, file := range files {
-		log.Info().Str("from", file).Str("to", pDir).Msgf("%s: File copied", suiteName)
+		log.Info().Str("from", file).Str("to", pDir).Str("suite", suiteName).Msg("File copied")
 		if err := handler.CopyToContainer(ctx, containerID, file, pDir); err != nil {
 			return err
 		}
@@ -289,7 +289,7 @@ func createMounts(suiteName string, files []string, target string) ([]mount.Moun
 			TmpfsOptions:  nil,
 		}
 
-		log.Info().Str("from", f).Str("to", dest).Msgf("%s: File mounted", suiteName)
+		log.Info().Str("from", f).Str("to", dest).Str("suite", suiteName).Msg("File mounted")
 	}
 
 	return mm, nil

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -474,6 +474,21 @@ func (handler *Handler) ProjectDir(ctx context.Context, imageID string) (string,
 	return p, nil
 }
 
+// TestUrl returns the file containing the test url for the given image.
+func (handler *Handler) TestUrl(ctx context.Context, imageID string) (string, error) {
+	ii, _, err := handler.client.ImageInspectWithRaw(ctx, imageID)
+	if err != nil {
+		return "", err
+	}
+
+	// The image can tell us via a label where saucectl should find the url for the test details.
+	var p string
+	if v := ii.Config.Labels["com.saucelabs.test-url"]; v != "" {
+		p = v
+	}
+	return p, nil
+}
+
 // ContainerInspect returns the container information.
 func (handler *Handler) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
 	return handler.client.ContainerInspect(ctx, containerID)

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -476,7 +476,7 @@ func (handler *Handler) ProjectDir(ctx context.Context, imageID string) (string,
 	return p, nil
 }
 
-// JobDetailsURLFile returns the file containing the job details url for the given image.
+// JobInfoFile returns the file containing the job details url for the given image.
 func (handler *Handler) JobInfoFile(ctx context.Context, imageID string) (string, error) {
 	ii, _, err := handler.client.ImageInspectWithRaw(ctx, imageID)
 	if err != nil {

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -118,12 +118,12 @@ func TestStartContainer(t *testing.T) {
 	var err error
 
 	// Buggy container start
-	cont, err = handler.StartContainer(context.Background(), []string{project.Cypress.ConfigFile, project.Cypress.ProjectPath}, config.Docker{})
+	cont, err = handler.StartContainer(context.Background(), containerStartOptions{Files:[]string{project.Cypress.ConfigFile, project.Cypress.ProjectPath}, Docker: config.Docker{}})
 	assert.NotNil(t, err)
 
 	// Successfull container start
 	mockDocker.ContainerCreateSuccess = true
-	cont, err = handler.StartContainer(context.Background(), []string{project.Cypress.ConfigFile, project.Cypress.ProjectPath}, config.Docker{})
+	cont, err = handler.StartContainer(context.Background(), containerStartOptions{Files:[]string{project.Cypress.ConfigFile, project.Cypress.ProjectPath}, Docker: config.Docker{}})
 	assert.Nil(t, err)
 	assert.NotNil(t, cont)
 }

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -85,7 +85,7 @@ func TestCreateMounts(t *testing.T) {
 		files = append(files, f.Source)
 	}
 	dest := "dest/"
-	mounts, _ := createMounts(files, dest)
+	mounts, _ := createMounts("fakeSuite", files, dest)
 	assert.Len(t, mounts, len(want))
 	for _, w := range want {
 		m := mounts[w.Idx]

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -2,6 +2,8 @@ package docker
 
 import (
 	"context"
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/framework"
 	"path/filepath"
 
@@ -49,6 +51,10 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 	}
 	r.Project.Playwright.ProjectPath = filepath.Base(r.Project.Playwright.ProjectPath)
 
+	if r.Project.Sauce.Concurrency > 1 {
+		log.Info().Msg("concurrency > 1: file transfer mode forced to copy.")
+		r.Project.Docker.FileTransfer = config.DockerFileCopy
+	}
 
 	containerOpts, results := r.createWorkerPool(r.Project.Sauce.Concurrency)
 	defer close(results)

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -23,7 +23,6 @@ func NewPlaywright(c playwright.Project, cli *command.SauceCtlCli, imageLoc fram
 		ContainerRunner: ContainerRunner{
 			Ctx:             context.Background(),
 			Cli:             cli,
-			containerID:     "",
 			docker:          nil,
 			containerConfig: &containerConfig{},
 			Framework: framework.Framework{
@@ -52,7 +51,7 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 
 	errorCount := 0
 	for _, suite := range r.Project.Suites {
-		err := r.RunSuite(ContainerStartOptions{
+		err := r.runSuite(containerStartOptions{
 			Docker: r.Project.Docker,
 			BeforeExec: r.Project.BeforeExec,
 			Project: r.Project,

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -29,6 +29,7 @@ func NewPlaywright(c playwright.Project, cli *command.SauceCtlCli, imageLoc fram
 				Version: c.Playwright.Version,
 			},
 			ImageLoc: imageLoc,
+			ShowConsoleLog: c.ShowConsoleLog,
 		},
 	}
 

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -50,7 +50,7 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 	r.Project.Playwright.ProjectPath = filepath.Base(r.Project.Playwright.ProjectPath)
 
 	if r.Project.Sauce.Concurrency > 1 {
-		log.Info().Msg("concurrency > 1: file transfer mode forced to copy.")
+		log.Info().Msg("concurrency > 1: forcing file transfer mode to use 'copy'.")
 		r.Project.Docker.FileTransfer = config.DockerFileCopy
 	}
 

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -73,8 +73,8 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 		close(containerOpts)
 	}()
 
-	hasErrors := r.collectResults(results, len(r.Project.Suites))
-	if hasErrors {
+	hasPasssed := r.collectResults(results, len(r.Project.Suites))
+	if !hasPasssed {
 		return 1, nil
 	}
 	return 0, nil

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -56,6 +56,10 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 		r.Project.Docker.FileTransfer = config.DockerFileCopy
 	}
 
+	if err := r.fetchImage(&r.Project.Docker); err != nil {
+		return 1, err
+	}
+
 	containerOpts, results := r.createWorkerPool(r.Project.Sauce.Concurrency)
 	defer close(results)
 
@@ -73,8 +77,8 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 		close(containerOpts)
 	}()
 
-	hasPasssed := r.collectResults(results, len(r.Project.Suites))
-	if !hasPasssed {
+	hasPassed := r.collectResults(results, len(r.Project.Suites))
+	if !hasPassed {
 		return 1, nil
 	}
 	return 0, nil

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -52,14 +52,15 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 
 	errorCount := 0
 	for _, suite := range r.Project.Suites {
-		log.Info().Msg("Setting up test environment")
-		if err := r.setupImage(r.Project.Docker, r.Project.BeforeExec, r.Project, files); err != nil {
-			log.Err(err).Msg("Failed to setup test environment")
-			return 1, err
-		}
+		err := r.RunSuite(ContainerStartOptions{
+			Docker: r.Project.Docker,
+			BeforeExec: r.Project.BeforeExec,
+			Project: r.Project,
+			SuiteName: suite.Name,
+			Environment: suite.Env,
+			Files: files,
+		})
 
-		err := r.run([]string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", suite.Name},
-			suite.Env)
 		if err != nil {
 			errorCount++
 		}

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -7,7 +7,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/framework"
 	"path/filepath"
 
-	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/internal/playwright"
 )
 
@@ -18,12 +17,11 @@ type PlaywrightRunner struct {
 }
 
 // NewPlaywright creates a new PlaywrightRunner instance.
-func NewPlaywright(c playwright.Project, cli *command.SauceCtlCli, imageLoc framework.ImageLocator) (*PlaywrightRunner, error) {
+func NewPlaywright(c playwright.Project, imageLoc framework.ImageLocator) (*PlaywrightRunner, error) {
 	r := PlaywrightRunner{
 		Project: c,
 		ContainerRunner: ContainerRunner{
 			Ctx:             context.Background(),
-			Cli:             cli,
 			docker:          nil,
 			containerConfig: &containerConfig{},
 			Framework: framework.Framework{


### PR DESCRIPTION
## Proposed changes

Implement parallelism for docker mode.

Relates to:
- https://github.com/saucelabs/sauce-cypress-runner/pull/101
- https://github.com/saucelabs/sauce-playwright-runner/pull/67
- https://github.com/saucelabs/sauce-testcafe-runner/pull/39

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Implements logic for running docker in parallel.
Forces fileTransfer to be `copy` when running in parallel mode to avoid side-effects due to shared folder.
Log console only if tests fails (except if `--show-console-log` is provided).

Remaining to do:
- [x] Extract test link (link to app.saucelabs.com)
- [x] Pull image before splitting work across different workers
