### PR TITLE
Add a more generic interface for retrieving metadata

### DIFF
--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -25,7 +25,7 @@ type ContainerRunner struct {
 	docker          *Handler
 	containerConfig *containerConfig
 	Framework       framework.Framework
-	ImageLoc        framework.ImageLocator
+	FrameworkMeta   framework.MetadataService
 	ShowConsoleLog  bool
 }
 
@@ -93,11 +93,14 @@ func (r *ContainerRunner) fetchImage(docker *config.Docker) error {
 	}
 
 	if docker.Image == "" {
-		img, err := r.ImageLoc.GetImage(r.Ctx, r.Framework)
+		m, err := r.FrameworkMeta.Search(r.Ctx, framework.SearchOptions{
+			Name:             r.Framework.Name,
+			FrameworkVersion: r.Framework.Version,
+		})
 		if err != nil {
 			return fmt.Errorf("unable to determine which docker image to run: %w", err)
 		}
-		docker.Image = img
+		docker.Image = m.DockerImage
 	}
 
 	if err := r.pullImage(docker.Image); err != nil {

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -15,7 +15,7 @@ type CypressRunner struct {
 }
 
 // NewCypress creates a new CypressRunner instance.
-func NewCypress(c cypress.Project, imageLoc framework.ImageLocator) (*CypressRunner, error) {
+func NewCypress(c cypress.Project, ms framework.MetadataService) (*CypressRunner, error) {
 	r := CypressRunner{
 		Project: c,
 		ContainerRunner: ContainerRunner{
@@ -26,7 +26,7 @@ func NewCypress(c cypress.Project, imageLoc framework.ImageLocator) (*CypressRun
 				Name:    c.Kind,
 				Version: c.Cypress.Version,
 			},
-			ImageLoc: imageLoc,
+			FrameworkMeta:  ms,
 			ShowConsoleLog: c.ShowConsoleLog,
 		},
 	}

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -17,7 +17,7 @@ type PlaywrightRunner struct {
 }
 
 // NewPlaywright creates a new PlaywrightRunner instance.
-func NewPlaywright(c playwright.Project, imageLoc framework.ImageLocator) (*PlaywrightRunner, error) {
+func NewPlaywright(c playwright.Project, ms framework.MetadataService) (*PlaywrightRunner, error) {
 	r := PlaywrightRunner{
 		Project: c,
 		ContainerRunner: ContainerRunner{
@@ -28,7 +28,7 @@ func NewPlaywright(c playwright.Project, imageLoc framework.ImageLocator) (*Play
 				Name:    c.Kind,
 				Version: c.Playwright.Version,
 			},
-			ImageLoc:       imageLoc,
+			FrameworkMeta:  ms,
 			ShowConsoleLog: c.ShowConsoleLog,
 		},
 	}

--- a/internal/docker/testcafe.go
+++ b/internal/docker/testcafe.go
@@ -16,7 +16,7 @@ type TestcafeRunner struct {
 }
 
 // NewTestcafe creates a new TestcafeRunner instance.
-func NewTestcafe(c testcafe.Project, imageLoc framework.ImageLocator) (*TestcafeRunner, error) {
+func NewTestcafe(c testcafe.Project, ms framework.MetadataService) (*TestcafeRunner, error) {
 	r := TestcafeRunner{
 		Project: c,
 		ContainerRunner: ContainerRunner{
@@ -26,7 +26,7 @@ func NewTestcafe(c testcafe.Project, imageLoc framework.ImageLocator) (*Testcafe
 				Name:    c.Kind,
 				Version: c.Testcafe.Version,
 			},
-			ImageLoc:       imageLoc,
+			FrameworkMeta:  ms,
 			ShowConsoleLog: c.ShowConsoleLog,
 		},
 	}
@@ -42,7 +42,7 @@ func NewTestcafe(c testcafe.Project, imageLoc framework.ImageLocator) (*Testcafe
 // RunProject runs the tests defined in config.Project.
 func (r *TestcafeRunner) RunProject() (int, error) {
 	if r.Project.Sauce.Concurrency > 1 {
-		log.Info().Msg(("concurrency > 1: forcing file transfer mode to use 'copy'."))
+		log.Info().Msg("concurrency > 1: forcing file transfer mode to use 'copy'.")
 		r.Project.Docker.FileTransfer = config.DockerFileCopy
 	}
 	if err := r.fetchImage(&r.Project.Docker); err != nil {

--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -8,7 +8,22 @@ type Framework struct {
 	Version string
 }
 
-// ImageLocator represents an interface for retrieving (docker) images for a given framework.
-type ImageLocator interface {
-	GetImage(ctx context.Context, f Framework) (string, error)
+// MetadataService represents an interface for retrieving framework metadata.
+type MetadataService interface {
+	Search(ctx context.Context, opts SearchOptions) (Metadata, error)
+}
+
+// SearchOptions represents read query options for MetadataService.Search().
+type SearchOptions struct {
+	Name             string
+	FrameworkVersion string
+}
+
+// Metadata represents test runner metadata.
+type Metadata struct {
+	FrameworkName      string
+	FrameworkVersion   string
+	CloudRunnerVersion string
+	DockerImage        string
+	GitRelease         string
 }

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -175,7 +175,7 @@ func (c *Client) doJSONResponse(req *http.Request, expectStatus int, v interface
 	return json.NewDecoder(res.Body).Decode(v)
 }
 
-// GetImage returns a docker image for the given framework f.
+// Search returns metadata for the given search options opts.
 func (c *Client) Search(ctx context.Context, opts framework.SearchOptions) (framework.Metadata, error) {
 	url := fmt.Sprintf("%s/v1/testcomposer/frameworks/%s", c.URL, opts.Name)
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Add a more generic interface for retrieving metadata.
This can then be used by the templator (aka example generator) and image retrieval as well as any other metadata in the future, without the need to further extend the interface.