### PR TITLE
Add function for segmenting git release metadata

### DIFF
--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -36,6 +36,7 @@ type Metadata struct {
 // Returns an error if GitRelease is malformed.
 // The expected GitRelease format is "org/repo:tag".
 func GitReleaseSegments(m *Metadata) (org, repo, tag string, err error) {
+	// :punct: is a bit more generous than what would actually appear, but was chosen for the sake for readability.
 	r := regexp.MustCompile("(?P<org>[[:punct:][:word:]]+)\\/(?P<repo>[[:punct:][:word:]]+):(?P<tag>[[:punct:][:word:]]+)")
 	matches := r.FindStringSubmatch(m.GitRelease)
 

--- a/internal/framework/framework_test.go
+++ b/internal/framework/framework_test.go
@@ -1,0 +1,64 @@
+package framework
+
+import "testing"
+
+func TestGitReleaseSegments(t *testing.T) {
+	type args struct {
+		m *Metadata
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantOrg  string
+		wantRepo string
+		wantTag  string
+		wantErr  bool
+	}{
+		{
+			name: "the regular usecase",
+			args: args{
+				&Metadata{
+					GitRelease: "sauce/this-is-spicy:v1",
+				},
+			},
+			wantOrg:  "sauce",
+			wantRepo: "this-is-spicy",
+			wantTag:  "v1",
+			wantErr:  false,
+		},
+		{
+			name: "malformed",
+			args: args{
+				&Metadata{
+					GitRelease: "totally random string",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty",
+			args: args{
+				&Metadata{},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOrg, gotRepo, gotTag, err := GitReleaseSegments(tt.args.m)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GitReleaseSegments() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotOrg != tt.wantOrg {
+				t.Errorf("GitReleaseSegments() gotOrg = %v, want %v", gotOrg, tt.wantOrg)
+			}
+			if gotRepo != tt.wantRepo {
+				t.Errorf("GitReleaseSegments() gotRepo = %v, want %v", gotRepo, tt.wantRepo)
+			}
+			if gotTag != tt.wantTag {
+				t.Errorf("GitReleaseSegments() gotTag = %v, want %v", gotTag, tt.wantTag)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Add function for segmenting git release metadata.
