### PR TITLE
Have the 'new' command acquire release information from test-composer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ format:
 
 #test: @ Run tests
 test:
-	go test -v ./...
+	go test ./...
 
 #coverage: @ Run test and check coverage
 coverage:

--- a/cli/command/new/cmd_test.go
+++ b/cli/command/new/cmd_test.go
@@ -60,10 +60,3 @@ func TestUpdateRegionPlaywright(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "eu-central-1", c.Sauce.Region)
 }
-
-func TestGetRepositoryValues(t *testing.T) {
-	org, repo, err := getRepositoryValues("playwright")
-	assert.Equal(t, "saucelabs", org)
-	assert.Equal(t, "sauce-playwright-runner", repo)
-	assert.NilError(t, err)
-}

--- a/cli/command/new/templates.go
+++ b/cli/command/new/templates.go
@@ -22,10 +22,10 @@ var (
 	templateFileName = "saucetpl.tar.gz"
 )
 
-func getReleaseArtifact(org string, repo string) (io.ReadCloser, error) {
+func getReleaseArtifact(org, repo, tag string) (io.ReadCloser, error) {
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 	ghClient := github.NewClient(nil)
-	release, _, err := ghClient.Repositories.GetLatestRelease(ctx, org, repo)
+	release, _, err := ghClient.Repositories.GetReleaseByTag(ctx, org, repo, tag)
 	if err != nil {
 		return nil, err
 	}
@@ -92,8 +92,8 @@ func extractFile(name string, mode int64, src io.Reader, overWriteAll *bool) err
 }
 
 // FetchAndExtractTemplate gathers latest version of the template for the repo and extracts it locally.
-func FetchAndExtractTemplate(org string, repo string) error {
-	artifactStream, err := getReleaseArtifact(org, repo)
+func FetchAndExtractTemplate(org, repo, tag string) error {
+	artifactStream, err := getReleaseArtifact(org, repo, tag)
 	if err != nil {
 		return err
 	}

--- a/cli/command/new/templates_test.go
+++ b/cli/command/new/templates_test.go
@@ -90,7 +90,7 @@ func TestGetReleaseArtifact(t *testing.T) {
 		},
 	}
 
-	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-repo/releases/latest",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-repo/releases/tags/fake-tag",
 		func(req *http.Request) (*http.Response, error) {
 			resp, err := httpmock.NewJsonResponse(200, validRelease)
 			if err != nil {
@@ -112,7 +112,7 @@ func TestGetReleaseArtifact(t *testing.T) {
 		},
 	)
 
-	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-buggy-repo/releases/latest",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-buggy-repo/releases/tags/fake-tag",
 		func(req *http.Request) (*http.Response, error) {
 			resp, err := httpmock.NewJsonResponse(200, invalidRelease)
 			if err != nil {
@@ -122,11 +122,11 @@ func TestGetReleaseArtifact(t *testing.T) {
 		},
 	)
 
-	rc, err := getReleaseArtifact("fake-org", "fake-repo")
+	rc, err := getReleaseArtifact("fake-org", "fake-repo", "fake-tag")
 	assert.Nil(t, err)
 	rc.Close()
 
-	rc, err = getReleaseArtifact("fake-org", "fake-buggy-repo")
+	rc, err = getReleaseArtifact("fake-org", "fake-buggy-repo", "fake-tag")
 	assert.Error(t, err, "no " + templateFileName + " found")
 	assert.Nil(t, rc)
 }
@@ -164,7 +164,7 @@ func TestFetchAndExtractTemplate(t *testing.T) {
 			},
 		},
 	}
-	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-repo/releases/latest",
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/fake-org/fake-repo/releases/tags/fake-tag",
 		func(req *http.Request) (*http.Response, error) {
 			resp, err := httpmock.NewJsonResponse(200, validRelease)
 			if err != nil {
@@ -180,7 +180,7 @@ func TestFetchAndExtractTemplate(t *testing.T) {
 		},
 	)
 
-	err := FetchAndExtractTemplate("fake-org", "fake-repo")
+	err := FetchAndExtractTemplate("fake-org", "fake-repo", "fake-tag")
 	assert.Nil(t, err)
 	os.Remove("./test-folder/test-config.yml")
 	os.Remove("./test-folder")
@@ -221,6 +221,6 @@ func TestFetchAndExtractTemplateTimeoutingConnection(t *testing.T) {
 		},
 	)
 
-	err := FetchAndExtractTemplate("fake-org", "fake-repo")
+	err := FetchAndExtractTemplate("fake-org", "fake-repo", "fake-tag")
 	assert.Error(t, err, "call is expected to timeout")
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Have the 'new' command acquire release information from test-composer.
This means only fully blessed releases that have been configured in test-composer are part of the `saucectl new` process.
