### PR TITLE
Update region without marshall/unmarshall

### DIFF
--- a/cli/command/new/cmd.go
+++ b/cli/command/new/cmd.go
@@ -142,7 +142,9 @@ func updateRegion(cfgFile string, region string) error {
 	if err != nil {
 		return err
 	}
-	// Volontary wide capture
-	replaced := strings.Replace(string(data),"\n  region: us-west-1\n", "\n  region: " + region + "\n", 1)
+	oldString := "\n  region: us-west-1\n"
+	replacement := "\n  region: " + region + "\n"
+
+	replaced := strings.Replace(string(data), oldString, replacement, 1)
 	return os.WriteFile(cfgPath, []byte(replaced), 0644)
 }

--- a/cli/command/new/cmd.go
+++ b/cli/command/new/cmd.go
@@ -10,15 +10,10 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/cli/command"
-	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/credentials"
-	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/framework"
-	"github.com/saucelabs/saucectl/internal/playwright"
 	"github.com/saucelabs/saucectl/internal/region"
-	"github.com/saucelabs/saucectl/internal/testcafe"
 	"github.com/saucelabs/saucectl/internal/testcomposer"
-	"github.com/saucelabs/saucectl/internal/yaml"
 	"github.com/spf13/cobra"
 	"github.com/tj/survey"
 )
@@ -143,40 +138,11 @@ func updateRegion(cfgFile string, region string) error {
 	cwd, _ := os.Getwd()
 	cfgPath := filepath.Join(cwd, cfgFile)
 
-	d, err := config.Describe(cfgFile)
+	data, err := os.ReadFile(cfgPath)
 	if err != nil {
 		return err
 	}
-
-	if d.Kind == config.KindCypress && d.APIVersion == config.VersionV1Alpha {
-		c, err := cypress.FromFile(cfgFile)
-		if err != nil {
-			return err
-		}
-		c.Sauce.Region = region
-		return yaml.WriteFile(cfgPath, c)
-	}
-	if d.Kind == config.KindPlaywright && d.APIVersion == config.VersionV1Alpha {
-		c, err := playwright.FromFile(cfgFile)
-		if err != nil {
-			return err
-		}
-		c.Sauce.Region = region
-		return yaml.WriteFile(cfgPath, c)
-	}
-	if d.Kind == config.KindTestcafe && d.APIVersion == config.VersionV1Alpha {
-		c, err := testcafe.FromFile(cfgFile)
-		if err != nil {
-			return err
-		}
-		c.Sauce.Region = region
-		return yaml.WriteFile(cfgPath, c)
-	}
-
-	c, err := config.NewJobConfiguration(cfgPath)
-	if err != nil {
-		return err
-	}
-	c.Sauce.Region = region
-	return yaml.WriteFile(cfgPath, c)
+	// Volontary wide capture
+	replaced := strings.Replace(string(data),"\n  region: us-west-1\n", "\n  region: " + region + "\n", 1)
+	return os.WriteFile(cfgPath, []byte(replaced), 0644)
 }

--- a/cli/command/new/cmd_test.go
+++ b/cli/command/new/cmd_test.go
@@ -2,6 +2,9 @@ package new
 
 import (
 	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/cypress"
+	"github.com/saucelabs/saucectl/internal/playwright"
+	"github.com/saucelabs/saucectl/internal/testcafe"
 	"gotest.tools/assert"
 	"gotest.tools/v3/fs"
 	"os"
@@ -9,29 +12,24 @@ import (
 )
 
 func TestUpdateRegion(t *testing.T) {
-	cfgFile := "./test-config.yml"
-	fd, err := os.Create(cfgFile)
-	assert.NilError(t, err)
-	fd.Close()
-
-	c, err := config.NewJobConfiguration(cfgFile)
-	assert.NilError(t, err)
-	assert.Equal(t, c.Sauce.Region, "")
-
-	err = updateRegion(cfgFile, "us-west-1")
-	assert.NilError(t, err)
-
-	c, err = config.NewJobConfiguration(cfgFile)
-	assert.NilError(t, err)
-	assert.Equal(t, c.Sauce.Region, "us-west-1")
-
-	err = os.Remove(cfgFile)
-	assert.NilError(t, err)
+	dir := fs.NewDir(t, "common",
+		fs.WithFile("config.yml", "apiVersion: v1alpha\nsauce:\n  region: us-west-1\n  concurrency: 1\n ", fs.WithMode(0644)))
+	path, _ := os.Getwd()
+	defer func() {
+		os.Chdir(path)
+		dir.Remove()
+	}()
+	os.Chdir(dir.Path())
+	err := updateRegion("config.yml", "eu-central-1")
+	assert.NilError(t, err, "region should be updated successfully")
+	c, err := config.NewJobConfiguration(dir.Join("config.yml"))
+	assert.NilError(t, err, "No error when reading file")
+	assert.Equal(t, "eu-central-1", c.Sauce.Region, "region is updated")
 }
 
 func TestUpdateRegionCypress(t *testing.T) {
-	dir := fs.NewDir(t, "fixtures",
-		fs.WithFile("config.yml", "apiVersion: v1alpha\nkind: cypress\ncypress:\n  configFile: cypress.json\n  version: 1.2.3", fs.WithMode(0644)),
+	dir := fs.NewDir(t, "cypress",
+		fs.WithFile("config.yml", "apiVersion: v1alpha\nkind: cypress\ncypress:\n  configFile: cypress.json\n  version: 1.2.3\nsauce:\n  region: us-west-1\n", fs.WithMode(0644)),
 		fs.WithFile("cypress.json", "{}", fs.WithMode(0644)),
 		fs.WithDir("cypress", fs.WithMode(0755)))
 	path, _ := os.Getwd()
@@ -39,24 +37,42 @@ func TestUpdateRegionCypress(t *testing.T) {
 		os.Chdir(path)
 		dir.Remove()
 	}()
-	assert.Equal(t, nil, os.Chdir(dir.Path()))
-	assert.Equal(t, nil, updateRegion("config.yml", "eu-central-1"))
-	c, err := config.NewJobConfiguration("config.yml")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "eu-central-1", c.Sauce.Region)
+	os.Chdir(dir.Path())
+	err := updateRegion("config.yml", "eu-central-1")
+	assert.NilError(t, err, "region should be updated successfully")
+	c, err := cypress.FromFile("config.yml")
+	assert.NilError(t, err, "No error when reading file")
+	assert.Equal(t, "eu-central-1", c.Sauce.Region, "region is updated")
 }
 
 func TestUpdateRegionPlaywright(t *testing.T) {
-	dir := fs.NewDir(t, "fixtures",
-		fs.WithFile("config.yml", "apiVersion: v1alpha\nkind: playwright\nplaywright:\n  projectPath: dummy-folder\n  version: 1.2.3", fs.WithMode(0644)))
+	dir := fs.NewDir(t, "playwright",
+		fs.WithFile("config.yml", "apiVersion: v1alpha\nkind: playwright\nplaywright:\n  projectPath: dummy-folder\n  version: 1.2.3\nsauce:\n  region: us-west-1\n", fs.WithMode(0644)))
 	path, _ := os.Getwd()
 	defer func() {
 		os.Chdir(path)
 		dir.Remove()
 	}()
-	assert.Equal(t, nil, os.Chdir(dir.Path()))
-	assert.Equal(t, nil, updateRegion("config.yml", "eu-central-1"))
-	c, err := config.NewJobConfiguration("config.yml")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "eu-central-1", c.Sauce.Region)
+	os.Chdir(dir.Path())
+	err := updateRegion("config.yml", "eu-central-1")
+	assert.NilError(t, err, "region should be updated successfully")
+	c, err := playwright.FromFile("config.yml")
+	assert.NilError(t, err, "No error when reading file")
+	assert.Equal(t, "eu-central-1", c.Sauce.Region, "region is updated")
+}
+
+func TestUpdateRegionTestCafe(t *testing.T) {
+	dir := fs.NewDir(t, "testcafe",
+		fs.WithFile("config.yml", "apiVersion: v1alpha\nkind: testcafe\ntestcafe:\n  projectPath: dummy-folder\n  version: 1.2.3\nsauce:\n  region: us-west-1\n", fs.WithMode(0644)))
+	path, _ := os.Getwd()
+	defer func() {
+		os.Chdir(path)
+		dir.Remove()
+	}()
+	os.Chdir(dir.Path())
+	err := updateRegion("config.yml", "eu-central-1")
+	assert.NilError(t, err, "region should be updated successfully")
+	c, err := testcafe.FromFile("config.yml")
+	assert.NilError(t, err, "No error when reading file")
+	assert.Equal(t, "eu-central-1", c.Sauce.Region, "region is updated")
 }


### PR DESCRIPTION
## Proposed changes 

Simply replace region string instead of marshall/unmarshall config file.
More efficient, and allow to keep comments provided in configuration files.

Also, it avoid from missing this update when adding new frameworks.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

It is relatively safe to simply rely on `string.Replace()` since we control the input, and this is really not likely that we will have the same field a the same level in Yaml.