### PR TITLE
Pick default runner instead of latest when looking for a new template

### DIFF
--- a/cli/command/new/cmd.go
+++ b/cli/command/new/cmd.go
@@ -111,7 +111,7 @@ func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 
 	m, err := tc.Search(cmd.Context(), framework.SearchOptions{
 		Name:             answers.Framework,
-		FrameworkVersion: "latest",
+		FrameworkVersion: "",
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Pick default runner instead of latest when looking for a new template.

Prior to this change:
```
> saucectl new
     Choose a framework: Testcafe
     Choose the sauce labs region: us-west-1
13:23:08 INF Downloading template. release=https://github.com/saucelabs/sauce-testcafe-runner/releases/tag/v0.3.1

New project bootstrapped successfully! You can now run:
$ saucectl run
```
`v0.3.1` was picked because it's the latest release.

After this change:
```
> saucectl new
     Choose a framework: Testcafe
     Choose the sauce labs region: us-west-1
13:24:19 INF Downloading template. release=https://github.com/saucelabs/sauce-testcafe-runner/releases/tag/v0.2.5

New project bootstrapped successfully! You can now run:
$ saucectl run
```
`v0.2.5` is now picked because it's the default release.