### PR TITLE
Improve status logging

### DIFF
--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -285,12 +285,7 @@ func (r *ContainerRunner) collectResults(results chan result, expected int) bool
 	close(done)
 
 	if errCount != 0 {
-		relative := float64(errCount) / float64(expected) * 100
-		msg := fmt.Sprintf(" %d of %d suites have failed (%.0f%%) ", errCount, expected, relative)
-		dashes := strings.Repeat("─", len(msg)-2)
-		log.Error().Msgf("┌%s┐", dashes)
-		log.Error().Msg(msg)
-		log.Error().Msgf("└%s┘", dashes)
+		msg.LogTestFailure(errCount, expected)
 		return passed
 	}
 

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/msg"
 	"io/ioutil"
 	"os"
 	"path"
@@ -293,9 +294,7 @@ func (r *ContainerRunner) collectResults(results chan result, expected int) bool
 		return passed
 	}
 
-	log.Info().Msg("┌───────────────────────┐")
-	log.Info().Msg(" All suites have passed! ")
-	log.Info().Msg("└───────────────────────┘")
+	msg.LogTestSuccess()
 
 	return passed
 }

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -10,10 +10,10 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/config"
-	"github.com/saucelabs/saucectl/internal/dots"
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/jsonio"
 	"github.com/saucelabs/saucectl/internal/progress"
@@ -256,8 +256,19 @@ func (r *ContainerRunner) collectResults(results chan result, expected int) bool
 	inProgress := expected
 	passed := true
 
-	waiter := dots.New(1)
-	waiter.Start()
+	done := make(chan interface{})
+	go func() {
+		t := time.NewTicker(10 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-done:
+				break
+			case <-t.C:
+				log.Info().Msgf("Suites in progress: %d", inProgress)
+			}
+		}
+	}()
 	for i := 0; i < expected; i++ {
 		res := <-results
 		completed++
@@ -268,19 +279,23 @@ func (r *ContainerRunner) collectResults(results chan result, expected int) bool
 			passed = false
 		}
 
-		// Logging is not synchronized over the different worker routines & dot routine.
-		// To avoid implementing a more complex solution centralizing output on only one
-		// routine, a new lines has simply been forced, to ensure that line starts from
-		// the beginning of the console.
-		fmt.Println("")
-		log.Info().Msgf("Suites completed: %d/%d", completed, expected)
 		r.logSuite(res)
 	}
-	waiter.Stop()
+	close(done)
 
-	log.Info().Msgf("Suites expected: %d", expected)
-	log.Info().Msgf("Suites passed: %d", expected-errCount)
-	log.Info().Msgf("Suites failed: %d", errCount)
+	if errCount != 0 {
+		relative := float64(errCount) / float64(expected) * 100
+		msg := fmt.Sprintf(" %d of %d suites have failed (%.0f%%) ", errCount, expected, relative)
+		dashes := strings.Repeat("─", len(msg)-2)
+		log.Error().Msgf("┌%s┐", dashes)
+		log.Error().Msg(msg)
+		log.Error().Msgf("└%s┘", dashes)
+		return passed
+	}
+
+	log.Info().Msg("┌───────────────────────┐")
+	log.Info().Msg(" All suites have passed! ")
+	log.Info().Msg("└───────────────────────┘")
 
 	return passed
 }

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -1,0 +1,24 @@
+package msg
+
+import (
+	"fmt"
+	"github.com/rs/zerolog/log"
+	"strings"
+)
+
+// LogTestSuccess prints out a test success summary statement.
+func LogTestSuccess() {
+	log.Info().Msg("┌───────────────────────┐")
+	log.Info().Msg(" All suites have passed! ")
+	log.Info().Msg("└───────────────────────┘")
+}
+
+// LogTestFailure prints out a test failure summary statement.
+func LogTestFailure(errors, total int) {
+	relative := float64(errors) / float64(total) * 100
+	msg := fmt.Sprintf(" %d of %d suites have failed (%.0f%%) ", errors, total, relative)
+	dashes := strings.Repeat("─", len(msg)-2)
+	log.Error().Msgf("┌%s┐", dashes)
+	log.Error().Msg(msg)
+	log.Error().Msgf("└%s┘", dashes)
+}

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -3,11 +3,11 @@ package saucecloud
 import (
 	"context"
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/tunnel"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -94,18 +94,11 @@ func (r *CloudRunner) collectResults(results chan result, expected int) bool {
 	close(done)
 
 	if errCount != 0 {
-		relative := float64(errCount) / float64(expected) * 100
-		msg := fmt.Sprintf(" %d of %d suites have failed (%.0f%%) ", errCount, expected, relative)
-		dashes := strings.Repeat("─", len(msg)-2)
-		log.Error().Msgf("┌%s┐", dashes)
-		log.Error().Msg(msg)
-		log.Error().Msgf("└%s┘", dashes)
+		msg.LogTestFailure(errCount, expected)
 		return passed
 	}
 
-	log.Info().Msg("┌───────────────────────┐")
-	log.Info().Msg(" All suites have passed! ")
-	log.Info().Msg("└───────────────────────┘")
+	msg.LogTestSuccess()
 
 	return passed
 }

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/saucelabs/saucectl/internal/archive/zip"
 	"github.com/saucelabs/saucectl/internal/concurrency"
-	"github.com/saucelabs/saucectl/internal/dots"
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/jsonio"
 	"github.com/saucelabs/saucectl/internal/progress"
@@ -63,8 +62,19 @@ func (r *CloudRunner) collectResults(results chan result, expected int) bool {
 	inProgress := expected
 	passed := true
 
-	waiter := dots.New(1)
-	waiter.Start()
+	done := make(chan interface{})
+	go func() {
+		t := time.NewTicker(15 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-done:
+				break
+			case <-t.C:
+				log.Info().Msgf("Suites completed: %d/%d", completed, expected)
+			}
+		}
+	}()
 	for i := 0; i < expected; i++ {
 		res := <-results
 		// in case one of test suites not passed
@@ -74,19 +84,13 @@ func (r *CloudRunner) collectResults(results chan result, expected int) bool {
 		completed++
 		inProgress--
 
-		// Logging is not synchronized over the different worker routines & dot routine.
-		// To avoid implementing a more complex solution centralizing output on only one
-		// routine, a new lines has simply been forced, to ensure that line starts from
-		// the beginning of the console.
-		fmt.Println("")
-		log.Info().Msgf("Suites completed: %d/%d", completed, expected)
 		r.logSuite(res)
 
 		if res.job.ID == "" || res.err != nil {
 			errCount++
 		}
 	}
-	waiter.Stop()
+	close(done)
 
 	log.Info().Msgf("Suites expected: %d", expected)
 	log.Info().Msgf("Suites passed: %d", expected-errCount)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Improve status logging by replacing the dotter with a regular interval based log, since the dotter breaks the structured logging output.

Furthermore, simplify the test summary and increase its footprint so it's more of an eyecatcher.

Here's an example for test success:
![Screen Shot 2021-03-09 at 8 33 27 AM](https://user-images.githubusercontent.com/1869292/110504678-41b75500-80b2-11eb-9370-260655085e85.png)

And one for test failure:
![Screen Shot 2021-03-09 at 8 35 11 AM](https://user-images.githubusercontent.com/1869292/110504814-627faa80-80b2-11eb-96e7-f7eaaa4978be.png)

