### PR TITLE
Cypress: Add priority to rootDir over cypress project folder

### DIFF
--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -44,17 +44,16 @@ func NewCypress(c cypress.Project, ms framework.MetadataService) (*CypressRunner
 
 // RunProject runs the tests defined in config.Project.
 func (r *CypressRunner) RunProject() (int, error) {
-	files := []string{
-		r.Project.Cypress.ConfigFile,
-		r.Project.Cypress.ProjectPath,
+	var files []string
+
+	if r.Project.RootDir != "" {
+		files = append(files, r.Project.RootDir)
+	} else {
+		files = append(files, r.Project.Cypress.ConfigFile, r.Project.Cypress.ProjectPath)
 	}
 
 	if r.Project.Cypress.EnvFile != "" {
 		files = append(files, r.Project.Cypress.EnvFile)
-	}
-
-	if r.Project.RootDir != "" {
-		files = append(files, r.Project.RootDir)
 	}
 
 	if r.Project.Sauce.Concurrency > 1 {

--- a/internal/saucecloud/cypress.go
+++ b/internal/saucecloud/cypress.go
@@ -25,17 +25,16 @@ func (r *CypressRunner) RunProject() (int, error) {
 		return 1, err
 	}
 
-	files := []string{
-		r.Project.Cypress.ConfigFile,
-		r.Project.Cypress.ProjectPath,
+	var files []string
+
+	if r.Project.RootDir != "" {
+		files = append(files, r.Project.RootDir)
+	} else {
+		files = append(files, r.Project.Cypress.ConfigFile, r.Project.Cypress.ProjectPath)
 	}
 
 	if r.Project.Cypress.EnvFile != "" {
 		files = append(files, r.Project.Cypress.EnvFile)
-	}
-
-	if r.Project.RootDir != "" {
-		files = append(files, r.Project.RootDir)
 	}
 
 	if r.Project.DryRun {


### PR DESCRIPTION
## Proposed changes

Currently, when running cypress run (either docker or cloud), if `rootDir` is defined, cypress project will be added twice at 2 different locations.

Example here:
```
10:22:29 INF Starting container id=2a03ebf5b78d img=saucelabs/stt-cypress-mocha-node:latest suite="saucy test"
10:22:29 INF File copied from=tests/cypress.json suite="saucy test" to=/home/seluser/__project__/
10:22:30 INF File copied from=tests/cypress suite="saucy test" to=/home/seluser/__project__/
10:22:30 INF File copied from=. suite="saucy test" to=/home/seluser/__project__/
```
`cypress.json` will be both in `/home/seluser/__project__/` and `/home/seluser/__project__/tests/`.

This PR remove this duplication.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->