### PR TITLE
tar: Avoid removal of leading . while archiving

### DIFF
--- a/internal/archive/tar/tar.go
+++ b/internal/archive/tar/tar.go
@@ -61,7 +61,7 @@ func Archive(src string, matcher sauceignore.Matcher, opts Options) (io.Reader, 
 			if err != nil {
 				return err
 			}
-			header.Name = relName
+			header.Name = filepath.Join(src, relName)
 		}
 
 		if err := w.WriteHeader(header); err != nil {

--- a/internal/archive/tar/tar.go
+++ b/internal/archive/tar/tar.go
@@ -57,11 +57,11 @@ func Archive(src string, matcher sauceignore.Matcher, opts Options) (io.Reader, 
 		}
 
 		if baseDir != "" {
-			relName, err := filepath.Rel(src, file)
+			relName, err := filepath.Rel(baseDir, file)
 			if err != nil {
 				return err
 			}
-			header.Name = filepath.Join(src, relName)
+			header.Name = filepath.Join(baseDir, relName)
 		}
 
 		if err := w.WriteHeader(header); err != nil {

--- a/internal/archive/tar/tar.go
+++ b/internal/archive/tar/tar.go
@@ -36,7 +36,7 @@ func Archive(src string, matcher sauceignore.Matcher, opts Options) (io.Reader, 
 
 	baseDir := ""
 	if infoSrc.IsDir() {
-		baseDir = filepath.Base(src)
+		baseDir = src
 	}
 
 	walker := func(file string, fileInfo os.FileInfo, err error) error {
@@ -57,8 +57,11 @@ func Archive(src string, matcher sauceignore.Matcher, opts Options) (io.Reader, 
 		}
 
 		if baseDir != "" {
-			// Update the name to correctly reflect the desired destination when untaring
-			header.Name = filepath.Join(baseDir, strings.TrimPrefix(file, src))
+			relName, err := filepath.Rel(src, file)
+			if err != nil {
+				return err
+			}
+			header.Name = relName
 		}
 
 		if err := w.WriteHeader(header); err != nil {

--- a/internal/archive/tar/tar_test.go
+++ b/internal/archive/tar/tar_test.go
@@ -3,6 +3,7 @@ package tar
 import (
 	archTar "archive/tar"
 	"io"
+	"path/filepath"
 	"testing"
 
 	"gotest.tools/assert"
@@ -27,12 +28,14 @@ func TestArchive(t *testing.T) {
 
 	testCases := []struct {
 		name      string
+		dirName   string
 		matcher   sauceignore.Matcher
 		options   Options
 		wantFiles []wantFile
 	}{
 		{
 			name:    "tar it out",
+			dirName: dir.Path(),
 			matcher: sauceignore.NewMatcher([]sauceignore.Pattern{}),
 			wantFiles: []wantFile{
 				{isDir: true, name: "screenshots", completePath: "screenshots"},
@@ -44,7 +47,16 @@ func TestArchive(t *testing.T) {
 			},
 		},
 		{
-			name: "tar some.other.bar.js and skip some.foo.js file and screenshots folder",
+			name:    "only one file",
+			dirName: filepath.Join(dir.Path(), "some.foo.js"),
+			matcher: sauceignore.NewMatcher([]sauceignore.Pattern{}),
+			wantFiles: []wantFile{
+				{isDir: false, name: "some.foo.js", completePath: "some.foo.js"},
+			},
+		},
+		{
+			name:    "tar some.other.bar.js and skip some.foo.js file and screenshots folder",
+			dirName: dir.Path(),
 			matcher: sauceignore.NewMatcher([]sauceignore.Pattern{
 				sauceignore.NewPattern("some.foo.js"),
 				sauceignore.NewPattern("screenshots/"),
@@ -57,7 +69,7 @@ func TestArchive(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			reader, err := Archive(dir.Path(), tt.matcher, tt.options)
+			reader, err := Archive(tt.dirName, tt.matcher, tt.options)
 			if err != nil {
 				t.Error(err)
 			}

--- a/internal/archive/tar/tar_test.go
+++ b/internal/archive/tar/tar_test.go
@@ -3,6 +3,7 @@ package tar
 import (
 	archTar "archive/tar"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -69,7 +70,8 @@ func TestArchive(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			reader, err := Archive(tt.dirName, tt.matcher, tt.options)
+			os.Chdir(tt.dirName)
+			reader, err := Archive(".", tt.matcher, tt.options)
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
## Proposed changes

With `rootDir` being set to `.`, all files and folders in that folder are getting there `.` remove when archived.
(`.sauceignore` become `sauceignore`, `.sauce` become `sauce`).

This PR fixes this issue.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->