### PR TITLE
Use rootDir for archiving files with testcafe

### DIFF
--- a/internal/saucecloud/testcafe.go
+++ b/internal/saucecloud/testcafe.go
@@ -23,13 +23,13 @@ func (r *TestcafeRunner) RunProject() (int, error) {
 	}
 
 	if r.Project.DryRun {
-		if err := r.dryRun(r.Project, []string{r.Project.Testcafe.ProjectPath}, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
+		if err := r.dryRun(r.Project, []string{r.Project.RootDir}, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
 			return exitCode, err
 		}
 		return 0, nil
 	}
 
-	fileID, err := r.archiveAndUpload(r.Project, []string{r.Project.Testcafe.ProjectPath}, r.Project.Sauce.Sauceignore)
+	fileID, err := r.archiveAndUpload(r.Project, []string{r.Project.RootDir}, r.Project.Sauce.Sauceignore)
 	if err != nil {
 		return exitCode, err
 	}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Use rootDir for archiving files with testcafe.
While the previous implementation did set the `rootDir` equal to the `projectPath` (if so specified), it failed to use the `rootDir` at the end of the day. So if the fallback wasn't used and the user specified `rootDir` directly, the archiving for sauce cloud would fail.

```
saucectl run --test-env sauce
15:55:39 INF Running version v0.0.0+unknown
15:55:39 INF Reading config file config=.sauce/config.yml
15:55:39 INF Running Testcafe in Sauce Labs
15:55:39 ERR failed to execute run command error="stat : no such file or directory"
```
