### PR TITLE
Fix parsing wrong config issue

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,9 +212,9 @@ func Describe(cfgPath string) (TypeDef, error) {
 		return TypeDef{}, fmt.Errorf("failed to parse project configuration: %v", err)
 	}
 
-	// check if the config is for sauce
+	// Sanity check.
 	if d.APIVersion == "" {
-		return TypeDef{}, errors.New("invalid sauce config. You can check configration setting from here https://docs.saucelabs.com/testrunner-toolkit/configuration")
+		return TypeDef{}, errors.New("invalid sauce config, which is either malformed or corrupt, please refer to https://docs.saucelabs.com/testrunner-toolkit/configuration for creating a valid config")
 	}
 
 	// Normalize certain values for ease of use.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,6 +212,11 @@ func Describe(cfgPath string) (TypeDef, error) {
 		return TypeDef{}, fmt.Errorf("failed to parse project configuration: %v", err)
 	}
 
+	// check if the config is for sauce
+	if d.APIVersion == "" {
+		return TypeDef{}, errors.New("invalid sauce config. You can check configration setting from here https://docs.saucelabs.com/testrunner-toolkit/configuration")
+	}
+
 	// Normalize certain values for ease of use.
 	d.Kind = strings.ToLower(d.Kind)
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
If the config file is empty or invalid, it should point out there's no test file detected.
```
./saucectl run -c test.json
13:31:12 INF Running version v0.0.0+unknown
13:31:12 INF Reading config file config=test.json
13:31:12 ERR failed to execute run command error="invalid sauce config. You can check config from here https://docs.saucelabs.com/testrunner-toolkit/configuration"
```
## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->