### PR TITLE
rootDir defaults to . if empty

### DIFF
--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -10,6 +10,7 @@ sauce:
       - release team
       - other tag
     build: Release $CI_COMMIT_SHORT_SHA
+rootDir: tests/e2e/
 docker:
   # fileTransfer controls how test files are transferred to the docker container before tests are run (choice: mount|copy).
   # `mount` will mount files and folders into the container. Changes to these files and folders will be reflected on the
@@ -21,7 +22,7 @@ docker:
 #  image: saucelabs/stt-cypress-mocha-node:v5.6.0
 cypress:
   version: 5.6.0
-  configFile: "tests/e2e/cypress.json"  # We determine related files based on the location of the config file.
+  configFile: "cypress.json"  # We determine related files based on the location of the config file.
 suites:
   - name: "saucy test"
     browser: "chrome"

--- a/.sauce/cypress_cloud.yml
+++ b/.sauce/cypress_cloud.yml
@@ -10,6 +10,7 @@ sauce:
       - release team
       - other tag
     build: Release $CI_COMMIT_SHORT_SHA
+rootDir: tests/e2e/
 docker:
   # fileTransfer controls how test files are transferred to the docker container before tests are run (choice: mount|copy).
   # `mount` will mount files and folders into the container. Changes to these files and folders will be reflected on the
@@ -21,7 +22,7 @@ docker:
 #  image: saucelabs/stt-cypress-mocha-node:v5.6.0
 cypress:
   version: 5.6.0
-  configFile: "tests/e2e/cypress.json"  # We determine related files based on the location of the config file.
+  configFile: "cypress.json"  # Config file is relative to rootDir
 suites:
   - name: "saucy chrome test"
     browser: "googlechrome"

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -89,10 +89,11 @@ func FromFile(cfgPath string) (Project, error) {
 		return p, errors.New("missing framework version. Check available versions here: https://docs.staging.saucelabs.net/testrunner-toolkit#supported-frameworks-and-browsers")
 	}
 
-	if _, err := os.Stat(p.Cypress.ConfigFile); err != nil {
-		return p, fmt.Errorf("unable to locate %s", p.Cypress.ConfigFile)
+	cypressConfigFileCompletePath := filepath.Join(p.RootDir, p.Cypress.ConfigFile)
+	if _, err := os.Stat(cypressConfigFileCompletePath); err != nil {
+		return p, fmt.Errorf("unable to locate %s", cypressConfigFileCompletePath)
 	}
-	configDir := filepath.Dir(p.Cypress.ConfigFile)
+	configDir := filepath.Dir(cypressConfigFileCompletePath)
 
 	// We must locate the cypress folder.
 	cPath := filepath.Join(configDir, "cypress")

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -109,6 +109,13 @@ func FromFile(cfgPath string) (Project, error) {
 		}
 	}
 
+	// Default rootDir to .
+	if p.RootDir == "" {
+		p.RootDir = "."
+		log.Warn().Msg("'rootDir' is not defined. Using the current working directory instead " +
+			"(equivalent to 'rootDir: .'). Please set 'rootDir' explicitly in your config!")
+	}
+
 	// Optionally include the env file if it exists.
 	envFile := filepath.Join(configDir, "cypress.env.json")
 	if _, err := os.Stat(envFile); err == nil {

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -109,11 +109,6 @@ func FromFile(cfgPath string) (Project, error) {
 		}
 	}
 
-	// Default rootDir to .
-	if p.RootDir == "" {
-		p.RootDir = "."
-	}
-
 	// Optionally include the env file if it exists.
 	envFile := filepath.Join(configDir, "cypress.env.json")
 	if _, err := os.Stat(envFile); err == nil {

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -108,6 +108,11 @@ func FromFile(cfgPath string) (Project, error) {
 		}
 	}
 
+	// Default rootDir to .
+	if p.RootDir == "" {
+		p.RootDir = "."
+	}
+
 	// Optionally include the env file if it exists.
 	envFile := filepath.Join(configDir, "cypress.env.json")
 	if _, err := os.Stat(envFile); err == nil {

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -41,7 +41,7 @@ type containerStartOptions struct {
 	Project     interface{}
 	SuiteName   string
 	Environment map[string]string
-	Files       []string
+	RootDir     string
 	Sauceignore string
 }
 

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -43,11 +43,7 @@ func NewCypress(c cypress.Project, ms framework.MetadataService) (*CypressRunner
 func (r *CypressRunner) RunProject() (int, error) {
 	var files []string
 
-	if r.Project.RootDir != "" {
-		files = append(files, r.Project.RootDir)
-	} else {
-		files = append(files, r.Project.Cypress.ConfigFile, r.Project.Cypress.ProjectPath)
-	}
+	files = append(files, r.Project.RootDir)
 
 	if r.Project.Cypress.EnvFile != "" {
 		files = append(files, r.Project.Cypress.EnvFile)

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -41,14 +41,6 @@ func NewCypress(c cypress.Project, ms framework.MetadataService) (*CypressRunner
 
 // RunProject runs the tests defined in config.Project.
 func (r *CypressRunner) RunProject() (int, error) {
-	var files []string
-
-	files = append(files, r.Project.RootDir)
-
-	if r.Project.Cypress.EnvFile != "" {
-		files = append(files, r.Project.Cypress.EnvFile)
-	}
-
 	verifyFileTransferCompatibility(r.Project.Sauce.Concurrency, &r.Project.Docker)
 
 	if err := r.fetchImage(&r.Project.Docker); err != nil {
@@ -69,7 +61,7 @@ func (r *CypressRunner) RunProject() (int, error) {
 				Project:     r.Project,
 				SuiteName:   suite.Name,
 				Environment: suite.Config.Env,
-				Files:       files,
+				RootDir:     r.Project.RootDir,
 				Sauceignore: r.Project.Sauce.Sauceignore,
 			}
 		}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -219,9 +219,6 @@ func (handler *Handler) StartContainer(ctx context.Context, options containerSta
 			Target:        pDir,
 			ReadOnly:      false,
 			Consistency:   mount.ConsistencyDefault,
-			BindOptions:   nil,
-			VolumeOptions: nil,
-			TmpfsOptions:  nil,
 		})
 		log.Info().Str("from", options.RootDir).Str("to", pDir).Str("suite", options.SuiteName).
 			Msg("File mounted")

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -277,6 +277,8 @@ func copyTestFiles(ctx context.Context, handler *Handler, containerID, suiteName
 	if err := handler.CopyToContainer(ctx, containerID, projectFolder, pDir, matcher); err != nil {
 		return err
 	}
+	log.Info().Str("from", projectFolder).Str("to", pDir).Str("suite", suiteName).Msg("File copied")
+
 	return nil
 }
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -252,8 +252,10 @@ func (handler *Handler) StartContainer(ctx context.Context, options containerSta
 		if err != nil {
 			return nil, err
 		}
-		if err := copyTestFiles(ctx, handler, container.ID, options.SuiteName, options.Files, pDir, matcher); err != nil {
-			return nil, err
+		for _, file := range options.Files {
+			if err := copyTestFiles(ctx, handler, container.ID, options.SuiteName, file, pDir, matcher); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -269,13 +271,11 @@ func (handler *Handler) StartContainer(ctx context.Context, options containerSta
 }
 
 // copyTestFiles copies the files within the container.
-func copyTestFiles(ctx context.Context, handler *Handler, containerID, suiteName string, files []string, pDir string,
+func copyTestFiles(ctx context.Context, handler *Handler, containerID, suiteName string, projectFolder string, pDir string,
 	matcher sauceignore.Matcher) error {
-	for _, file := range files {
-		log.Info().Str("from", file).Str("to", pDir).Str("suite", suiteName).Msg("File copied")
-		if err := handler.CopyToContainer(ctx, containerID, file, pDir, matcher); err != nil {
-			return err
-		}
+
+	if err := handler.CopyToContainer(ctx, containerID, projectFolder, pDir, matcher); err != nil {
+		return err
 	}
 	return nil
 }
@@ -306,17 +306,6 @@ func createMounts(suiteName string, files []string, target string) ([]mount.Moun
 	}
 
 	return mm, nil
-}
-
-// CopyFilesToContainer copies the given files into the container.
-func (handler *Handler) CopyFilesToContainer(ctx context.Context, srcContainerID string, files []string, targetDir string,
-	matcher sauceignore.Matcher) error {
-	for _, fpath := range files {
-		if err := handler.CopyToContainer(ctx, srcContainerID, fpath, targetDir, matcher); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // CopyToContainer copies the given file to the container.

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/mocks"
 	"github.com/stretchr/testify/assert"
@@ -118,12 +117,12 @@ func TestStartContainer(t *testing.T) {
 	var err error
 
 	// Buggy container start
-	cont, err = handler.StartContainer(context.Background(), containerStartOptions{Files:[]string{project.Cypress.ConfigFile, project.Cypress.ProjectPath}, Docker: config.Docker{}})
+	cont, err = handler.StartContainer(context.Background(), containerStartOptions{RootDir: project.RootDir})
 	assert.NotNil(t, err)
 
 	// Successfull container start
 	mockDocker.ContainerCreateSuccess = true
-	cont, err = handler.StartContainer(context.Background(), containerStartOptions{Files:[]string{project.Cypress.ConfigFile, project.Cypress.ProjectPath}, Docker: config.Docker{}})
+	cont, err = handler.StartContainer(context.Background(), containerStartOptions{RootDir: project.RootDir})
 	assert.Nil(t, err)
 	assert.NotNil(t, cont)
 }

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -2,8 +2,6 @@ package docker
 
 import (
 	"context"
-	"path/filepath"
-
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/playwright"
 )
@@ -42,9 +40,6 @@ func NewPlaywright(c playwright.Project, ms framework.MetadataService) (*Playwri
 
 // RunProject runs the tests defined in config.Project.
 func (r *PlaywrightRunner) RunProject() (int, error) {
-	// FIXME address this hack
-	r.Project.Playwright.ProjectPath = filepath.Base(r.Project.Playwright.ProjectPath)
-
 	verifyFileTransferCompatibility(r.Project.Sauce.Concurrency, &r.Project.Docker)
 
 	if err := r.fetchImage(&r.Project.Docker); err != nil {
@@ -65,7 +60,7 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 				Project:     r.Project,
 				SuiteName:   suite.Name,
 				Environment: suite.Env,
-				RootDir:     r.Project.Playwright.LocalProjectPath,
+				RootDir:     r.Project.RootDir,
 				Sauceignore: r.Project.Sauce.Sauceignore,
 			}
 		}

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -42,9 +42,7 @@ func NewPlaywright(c playwright.Project, ms framework.MetadataService) (*Playwri
 
 // RunProject runs the tests defined in config.Project.
 func (r *PlaywrightRunner) RunProject() (int, error) {
-	files := []string{
-		r.Project.Playwright.LocalProjectPath,
-	}
+	// FIXME address this hack
 	r.Project.Playwright.ProjectPath = filepath.Base(r.Project.Playwright.ProjectPath)
 
 	verifyFileTransferCompatibility(r.Project.Sauce.Concurrency, &r.Project.Docker)
@@ -67,7 +65,7 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 				Project:     r.Project,
 				SuiteName:   suite.Name,
 				Environment: suite.Env,
-				Files:       files,
+				RootDir:     r.Project.Playwright.LocalProjectPath,
 				Sauceignore: r.Project.Sauce.Sauceignore,
 			}
 		}

--- a/internal/docker/puppeteer.go
+++ b/internal/docker/puppeteer.go
@@ -59,7 +59,7 @@ func (r *PuppeterRunner) RunProject() (int, error) {
 				Project:     r.Project,
 				SuiteName:   suite.Name,
 				Environment: suite.Env,
-				Files:       []string{r.Project.RootDir},
+				RootDir:     r.Project.RootDir,
 				Sauceignore: r.Project.Sauce.Sauceignore,
 			}
 		}

--- a/internal/docker/testcafe.go
+++ b/internal/docker/testcafe.go
@@ -59,7 +59,7 @@ func (r *TestcafeRunner) RunProject() (int, error) {
 				Project:     r.Project,
 				SuiteName:   suite.Name,
 				Environment: suite.Env,
-				Files:       []string{r.Project.RootDir},
+				RootDir:     r.Project.RootDir,
 				Sauceignore: r.Project.Sauce.Sauceignore,
 			}
 		}

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -81,7 +81,8 @@ func FromFile(cfgPath string) (Project, error) {
 		return Project{}, fmt.Errorf("could not find 'rootDir' in config yml, 'rootDir' must be set to specify project files")
 	} else if p.Playwright.ProjectPath != "" && p.RootDir == "" {
 		log.Warn().Msg("'playwright.projectPath' is deprecated. Consider using 'rootDir' instead")
-		p.RootDir = p.Playwright.ProjectPath
+		//p.RootDir = p.Playwright.ProjectPath
+		p.RootDir = "."
 	} else if p.Playwright.ProjectPath != "" && p.RootDir != "" {
 		log.Info().Msgf(
 			"Found both 'playwright.projectPath=%s' and 'rootDir=%s' in config. 'projectPath' is deprecated, so defaulting to rootDir '%s'",

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -79,12 +79,10 @@ func FromFile(cfgPath string) (Project, error) {
 	// Default project path
 	if p.Playwright.ProjectPath == "" && p.RootDir == "" {
 		return Project{}, fmt.Errorf("could not find 'rootDir' in config yml, 'rootDir' must be set to specify project files")
-	}
-	if p.Playwright.ProjectPath != "" && p.RootDir == "" {
+	} else if p.Playwright.ProjectPath != "" && p.RootDir == "" {
 		log.Warn().Msg("'playwright.projectPath' is deprecated. Consider using 'rootDir' instead")
 		p.RootDir = p.Playwright.ProjectPath
-	}
-	if p.Playwright.ProjectPath != "" && p.RootDir != "" {
+	} else if p.Playwright.ProjectPath != "" && p.RootDir != "" {
 		log.Info().Msgf(
 			"Found both 'playwright.projectPath=%s' and 'rootDir=%s' in config. 'projectPath' is deprecated, so defaulting to rootDir '%s'",
 			p.Playwright.ProjectPath, p.RootDir, p.RootDir,

--- a/internal/saucecloud/cypress.go
+++ b/internal/saucecloud/cypress.go
@@ -25,19 +25,13 @@ func (r *CypressRunner) RunProject() (int, error) {
 		return 1, err
 	}
 
-	files := []string{r.Project.RootDir}
-
-	if r.Project.Cypress.EnvFile != "" {
-		files = append(files, r.Project.Cypress.EnvFile)
-	}
-
 	if r.Project.DryRun {
-		if err := r.dryRun(r.Project, files, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
+		if err := r.dryRun(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
 			return exitCode, err
 		}
 		return 0, nil
 	}
-	fileID, err := r.archiveAndUpload(r.Project, files, r.Project.Sauce.Sauceignore)
+	fileID, err := r.archiveAndUpload(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore)
 	if err != nil {
 		return exitCode, err
 	}

--- a/internal/saucecloud/cypress.go
+++ b/internal/saucecloud/cypress.go
@@ -25,13 +25,7 @@ func (r *CypressRunner) RunProject() (int, error) {
 		return 1, err
 	}
 
-	var files []string
-
-	if r.Project.RootDir != "" {
-		files = append(files, r.Project.RootDir)
-	} else {
-		files = append(files, r.Project.Cypress.ConfigFile, r.Project.Cypress.ProjectPath)
-	}
+	files := []string{r.Project.RootDir}
 
 	if r.Project.Cypress.EnvFile != "" {
 		files = append(files, r.Project.Cypress.EnvFile)

--- a/internal/saucecloud/cypress_test.go
+++ b/internal/saucecloud/cypress_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -102,11 +103,14 @@ func TestArchiveProject(t *testing.T) {
 		os.RemoveAll("./test-arch/")
 	}()
 
+	cfg, _ := filepath.Abs("../../tests/e2e/cypress.json")
+	folder, _ := filepath.Abs("../../tests/e2e/cypress")
+
 	runner := CypressRunner{
 		Project: cypress.Project{
 			Cypress: cypress.Cypress{
-				ConfigFile:  "../../tests/e2e/cypress.json",
-				ProjectPath: "../../tests/e2e/cypress/",
+				ConfigFile:  cfg,
+				ProjectPath: folder,
 			},
 		},
 	}
@@ -187,6 +191,7 @@ func TestRunProject(t *testing.T) {
 	uploader := &mocks.FakeProjectUploader{
 		UploadSuccess: true,
 	}
+
 	runner := CypressRunner{
 		CloudRunner: CloudRunner{
 			JobStarter:      &starter,
@@ -195,10 +200,11 @@ func TestRunProject(t *testing.T) {
 			ProjectUploader: uploader,
 		},
 		Project: cypress.Project{
+			RootDir: ".",
 			Cypress: cypress.Cypress{
 				Version:     "5.6.0",
 				ConfigFile:  "../../tests/e2e/cypress.json",
-				ProjectPath: "../../tests/e2e/cypress/",
+				ProjectPath: "../../tests/e2e/cypress",
 			},
 			Suites: []cypress.Suite{
 				{Name: "dummy-suite"},

--- a/internal/saucecloud/cypress_test.go
+++ b/internal/saucecloud/cypress_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -103,24 +102,18 @@ func TestArchiveProject(t *testing.T) {
 		os.RemoveAll("./test-arch/")
 	}()
 
-	cfg, _ := filepath.Abs("../../tests/e2e/cypress.json")
-	folder, _ := filepath.Abs("../../tests/e2e/cypress")
-
 	runner := CypressRunner{
 		Project: cypress.Project{
+			RootDir: "../../tests/e2e/",
 			Cypress: cypress.Cypress{
-				ConfigFile:  cfg,
-				ProjectPath: folder,
+				ConfigFile:  "cypress.json",
 			},
 		},
 	}
 	wd, _ := os.Getwd()
 	log.Info().Msg(wd)
-	files := []string{
-		runner.Project.Cypress.ConfigFile,
-		runner.Project.Cypress.ProjectPath,
-	}
-	z, err := runner.archiveProject(runner.Project, "./test-arch/", files, "")
+
+	z, err := runner.archiveProject(runner.Project, "./test-arch/", runner.Project.RootDir, "")
 	if err != nil {
 		t.Fail()
 	}

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -23,13 +23,13 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 	}
 
 	if r.Project.DryRun {
-		if err := r.dryRun(r.Project, []string{r.Project.Playwright.LocalProjectPath}, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
+		if err := r.dryRun(r.Project, r.Project.Playwright.LocalProjectPath, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
 			return exitCode, err
 		}
 		return 0, nil
 	}
 
-	fileID, err := r.archiveAndUpload(r.Project, []string{r.Project.Playwright.LocalProjectPath}, r.Project.Sauce.Sauceignore)
+	fileID, err := r.archiveAndUpload(r.Project, r.Project.Playwright.LocalProjectPath, r.Project.Sauce.Sauceignore)
 	if err != nil {
 		return exitCode, err
 	}

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -23,13 +23,13 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 	}
 
 	if r.Project.DryRun {
-		if err := r.dryRun(r.Project, r.Project.Playwright.LocalProjectPath, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
+		if err := r.dryRun(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
 			return exitCode, err
 		}
 		return 0, nil
 	}
 
-	fileID, err := r.archiveAndUpload(r.Project, r.Project.Playwright.LocalProjectPath, r.Project.Sauce.Sauceignore)
+	fileID, err := r.archiveAndUpload(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore)
 	if err != nil {
 		return exitCode, err
 	}
@@ -43,7 +43,7 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 }
 
 func (r *PlaywrightRunner) getSuiteNames() string {
-	names := []string{}
+	var names []string
 	for _, s := range r.Project.Suites {
 		names = append(names, s.Name)
 	}

--- a/internal/saucecloud/testcafe.go
+++ b/internal/saucecloud/testcafe.go
@@ -23,13 +23,13 @@ func (r *TestcafeRunner) RunProject() (int, error) {
 	}
 
 	if r.Project.DryRun {
-		if err := r.dryRun(r.Project, []string{r.Project.RootDir}, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
+		if err := r.dryRun(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
 			return exitCode, err
 		}
 		return 0, nil
 	}
 
-	fileID, err := r.archiveAndUpload(r.Project, []string{r.Project.RootDir}, r.Project.Sauce.Sauceignore)
+	fileID, err := r.archiveAndUpload(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore)
 	if err != nil {
 		return exitCode, err
 	}

--- a/internal/testcafe/config.go
+++ b/internal/testcafe/config.go
@@ -82,7 +82,8 @@ func FromFile(cfgPath string) (Project, error) {
 		return p, fmt.Errorf("could not find 'rootDir' in config yml, 'rootDir' must be set to specify project files")
 	} else if p.Testcafe.ProjectPath != "" && p.RootDir == "" {
 		log.Warn().Msg("'testcafe.projectPath' is deprecated. Consider using 'rootDir' instead")
-		p.RootDir = p.Testcafe.ProjectPath
+		//p.RootDir = p.Testcafe.ProjectPath
+		p.RootDir = "."
 	} else if p.Testcafe.ProjectPath != "" && p.RootDir != "" {
 		log.Info().Msgf(
 			"Found both 'testcafe.projectPath=%s' and 'rootDir=%s' in config. 'projectPath' is deprecated, so defaulting to rootDir '%s'",

--- a/internal/testcafe/config.go
+++ b/internal/testcafe/config.go
@@ -58,7 +58,7 @@ type Screenshots struct {
 
 // Testcafe represents the configuration for testcafe.
 type Testcafe struct {
-	// ProjectPath is the path for testing project.
+	// Deprecated. ProjectPath is succeeded by Project.RootDir.
 	ProjectPath string `yaml:"projectPath,omitempty" json:"projectPath"`
 
 	// Version represents the testcafe framework version.
@@ -82,8 +82,7 @@ func FromFile(cfgPath string) (Project, error) {
 		return p, fmt.Errorf("could not find 'rootDir' in config yml, 'rootDir' must be set to specify project files")
 	} else if p.Testcafe.ProjectPath != "" && p.RootDir == "" {
 		log.Warn().Msg("'testcafe.projectPath' is deprecated. Consider using 'rootDir' instead")
-		//p.RootDir = p.Testcafe.ProjectPath
-		p.RootDir = "."
+		p.RootDir = p.Testcafe.ProjectPath
 	} else if p.Testcafe.ProjectPath != "" && p.RootDir != "" {
 		log.Info().Msgf(
 			"Found both 'testcafe.projectPath=%s' and 'rootDir=%s' in config. 'projectPath' is deprecated, so defaulting to rootDir '%s'",

--- a/internal/testcafe/config.go
+++ b/internal/testcafe/config.go
@@ -80,13 +80,10 @@ func FromFile(cfgPath string) (Project, error) {
 
 	if p.Testcafe.ProjectPath == "" && p.RootDir == "" {
 		return p, fmt.Errorf("could not find 'rootDir' in config yml, 'rootDir' must be set to specify project files")
-	}
-	if p.Testcafe.ProjectPath != "" && p.RootDir == "" {
+	} else if p.Testcafe.ProjectPath != "" && p.RootDir == "" {
 		log.Warn().Msg("'testcafe.projectPath' is deprecated. Consider using 'rootDir' instead")
 		p.RootDir = p.Testcafe.ProjectPath
-	}
-
-	if p.Testcafe.ProjectPath != "" && p.RootDir != "" {
+	} else if p.Testcafe.ProjectPath != "" && p.RootDir != "" {
 		log.Info().Msgf(
 			"Found both 'testcafe.projectPath=%s' and 'rootDir=%s' in config. 'projectPath' is deprecated, so defaulting to rootDir '%s'",
 			p.Testcafe.ProjectPath, p.RootDir, p.RootDir,


### PR DESCRIPTION
## Proposed changes

To keep file organisation as user configured it, default rootDir to `.`.
So it solve some issues concerning folder organisation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->