### PR TITLE
Add support for new puppeteer native config

### DIFF
--- a/.sauce/puppeteer.yml
+++ b/.sauce/puppeteer.yml
@@ -1,20 +1,20 @@
 apiVersion: v1alpha
-metadata:
-  name: Testing Puppeteer Support
-  tags:
-    - e2e
-    - release team
-    - other tag
-  build: Release $CI_COMMIT_SHORT_SHA
-files:
-  - ./tests/e2e/puppeteer/example.test.js
-suites:
-  - name: "chrome"
-    match: ".*.(spec|test).js$"
-    settings:
-      browserName: "chrome"
-image:
-  base: saucelabs/stt-puppeteer-jest-node
-  version: latest
+kind: puppeteer
 sauce:
   region: us-west-1
+  metadata:
+    name: Testing Puppeteer Support
+    tags:
+      - e2e
+      - release team
+      - other tag
+    build: Release $CI_COMMIT_SHORT_SHA
+rootDir: tests/e2e/puppeteer
+puppeteer:
+  version: 3.0.4
+suites:
+  - name: "chrome"
+    testMatch: ["**/example.test.js"]
+    browser: "chrome"
+docker:
+  image: saucelabs/stt-puppeteer-jest-node:latest

--- a/.sauce/puppeteer.yml
+++ b/.sauce/puppeteer.yml
@@ -16,5 +16,3 @@ suites:
   - name: "chrome"
     testMatch: ["**/example.test.js"]
     browser: "chrome"
-docker:
-  image: saucelabs/stt-puppeteer-jest-node:latest

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,7 @@ const (
 // Kind* contains referenced config kinds
 const (
 	KindCypress    = "cypress"
+	KindPuppeteer  = "puppeteer"
 	KindPlaywright = "playwright"
 	KindTestcafe   = "testcafe"
 )

--- a/internal/docker/puppeteer.go
+++ b/internal/docker/puppeteer.go
@@ -1,0 +1,76 @@
+package docker
+
+import (
+	"context"
+	"github.com/saucelabs/saucectl/internal/puppeteer"
+
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/framework"
+)
+
+// PuppeterRunner represents the docker implementation of a test runner.
+type PuppeterRunner struct {
+	ContainerRunner
+	Project puppeteer.Project
+}
+
+// NewPuppeteer creates a new PuppeterRunner instance.
+func NewPuppeteer(c puppeteer.Project, ms framework.MetadataService) (*PuppeterRunner, error) {
+	r := PuppeterRunner{
+		Project: c,
+		ContainerRunner: ContainerRunner{
+			Ctx:             context.Background(),
+			containerConfig: &containerConfig{},
+			Framework: framework.Framework{
+				Name:    c.Kind,
+				Version: c.Puppeteer.Version,
+			},
+			FrameworkMeta:  ms,
+			ShowConsoleLog: c.ShowConsoleLog,
+		},
+	}
+	var err error
+	r.docker, err = Create()
+	if err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+// RunProject runs the tests defined in config.Project.
+func (r *PuppeterRunner) RunProject() (int, error) {
+	if r.Project.Sauce.Concurrency > 1 {
+		log.Info().Msg("concurrency > 1: forcing file transfer mode to use 'copy'.")
+		r.Project.Docker.FileTransfer = config.DockerFileCopy
+	}
+	if err := r.fetchImage(&r.Project.Docker); err != nil {
+		return 1, err
+	}
+
+	containerOpts, results := r.createWorkerPool(r.Project.Sauce.Concurrency)
+	defer close(results)
+
+	go func() {
+		for _, suite := range r.Project.Suites {
+			containerOpts <- containerStartOptions{
+				Docker:      r.Project.Docker,
+				BeforeExec:  r.Project.BeforeExec,
+				Project:     r.Project,
+				SuiteName:   suite.Name,
+				Environment: suite.Env,
+				Files:       []string{r.Project.RootDir},
+				Sauceignore: r.Project.Sauce.Sauceignore,
+			}
+		}
+		close(containerOpts)
+	}()
+
+	hasPassed := r.collectResults(results, len(r.Project.Suites))
+	if !hasPassed {
+		return 1, nil
+	}
+
+	return 0, nil
+}

--- a/internal/puppeteer/config.go
+++ b/internal/puppeteer/config.go
@@ -1,0 +1,87 @@
+package puppeteer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/config"
+	"gopkg.in/yaml.v2"
+)
+
+// Project represents the puppeteer project configuration.
+type Project struct {
+	config.TypeDef `yaml:",inline"`
+	ShowConsoleLog bool
+	DryRun         bool               `yaml:"-" json:"-"`
+	Sauce          config.SauceConfig `yaml:"sauce,omitempty" json:"sauce"`
+	Suites         []Suite            `yaml:"suites,omitempty" json:"suites"`
+	BeforeExec     []string           `yaml:"beforeExec,omitempty" json:"beforeExec"`
+	Docker         config.Docker      `yaml:"docker,omitempty" json:"docker"`
+	Puppeteer      Puppeteer          `yaml:"puppeteer,omitempty" json:"puppeteer"`
+	Npm            config.Npm         `yaml:"npm,omitempty" json:"npm"`
+	RootDir        string             `yaml:"rootDir,omitempty" json:"rootDir"`
+}
+
+// Suite represents the puppeteer test suite configuration.
+type Suite struct {
+	Name      string            `yaml:"name,omitempty" json:"name"`
+	Browser   string            `yaml:"browser,omitempty" json:"browser"`
+	TestMatch []string          `yaml:"testMatch,omitempty" json:"testMatch"`
+	Env       map[string]string `yaml:"env,omitempty" json:"env"`
+}
+
+// Puppeteer represents the configuration for puppeteer.
+type Puppeteer struct {
+	// Version represents the puppeteer framework version.
+	Version string `yaml:"version,omitempty" json:"version"`
+}
+
+// FromFile creates a new puppeteer project based on the filepath.
+func FromFile(cfgPath string) (Project, error) {
+	var p Project
+
+	f, err := os.Open(cfgPath)
+	defer f.Close()
+	if err != nil {
+		return p, fmt.Errorf("failed to locate project config: %v", err)
+	}
+	if err = yaml.NewDecoder(f).Decode(&p); err != nil {
+		return p, fmt.Errorf("failed to parse project config: %v", err)
+	}
+
+	if p.RootDir == "" {
+		return p, fmt.Errorf("could not find 'rootDir' in config yml, 'rootDir' must be set to specify project files")
+	}
+
+	p.Puppeteer.Version = config.StandardizeVersionFormat(p.Puppeteer.Version)
+	if p.Puppeteer.Version == "" {
+		return p, errors.New("missing framework version. Check available versions here: https://docs.staging.saucelabs.net/testrunner-toolkit#supported-frameworks-and-browsers")
+	}
+
+	// Set default docker file transfer to mount
+	if p.Docker.FileTransfer == "" {
+		p.Docker.FileTransfer = config.DockerFileMount
+	}
+
+	if p.Docker.Image != "" {
+		log.Info().Msgf(
+			"Ignoring framework version for Docker, using provided image %s (only applicable to docker mode)",
+			p.Docker.Image)
+	}
+
+	if p.Sauce.Concurrency < 1 {
+		// Default concurrency is 2
+		p.Sauce.Concurrency = 2
+	}
+
+	for i, s := range p.Suites {
+		env := map[string]string{}
+		for k, v := range s.Env {
+			env[k] = os.ExpandEnv(v)
+		}
+		p.Suites[i].Env = env
+	}
+	return p, nil
+}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Add support for new puppeteer native config.
Docker mode only.

Corresponding puppeteer image changes: https://github.com/saucelabs/sauce-puppeteer-runner/pull/55

Suggest config layout:
```yaml
apiVersion: v1alpha
kind: puppeteer
sauce:
  region: us-west-1
  metadata:
    name: Testing Puppeteer Support
    tags:
      - e2e
      - release team
      - other tag
    build: Release $CI_COMMIT_SHORT_SHA
rootDir: tests/e2e/puppeteer
puppeteer:
  version: 3.0.4
suites:
  - name: "chrome"
    testMatch: ["**/example.test.js"]
    browser: "chrome"
docker:
  image: saucelabs/stt-puppeteer-jest-node:latest
```