### PR TITLE
Print out filetransfer mode enforcement only when there's a delta

### DIFF
--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -334,3 +334,12 @@ func (r *ContainerRunner) runSuite(options containerStartOptions) (containerID s
 		options.Environment)
 	return
 }
+
+// verifyFileTransferCompatibility will verify whether the configured FileTransfer docker settings are appropriate for
+// the given concurrency. If not, it'll apply the config.DockerFileCopy and print out a message to notify the user.
+func verifyFileTransferCompatibility(concurrency int, dockerConf *config.Docker) {
+	if concurrency > 1 && dockerConf.FileTransfer != config.DockerFileCopy {
+		log.Info().Msg("concurrency > 1: forcing file transfer mode to use 'copy'.")
+		dockerConf.FileTransfer = config.DockerFileCopy
+	}
+}

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -3,9 +3,6 @@ package docker
 import (
 	"context"
 
-	"github.com/rs/zerolog/log"
-
-	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/framework"
 )
@@ -56,10 +53,7 @@ func (r *CypressRunner) RunProject() (int, error) {
 		files = append(files, r.Project.Cypress.EnvFile)
 	}
 
-	if r.Project.Sauce.Concurrency > 1 {
-		log.Info().Msg("concurrency > 1: forcing file transfer mode to use 'copy'.")
-		r.Project.Docker.FileTransfer = config.DockerFileCopy
-	}
+	verifyFileTransferCompatibility(r.Project.Sauce.Concurrency, &r.Project.Docker)
 
 	if err := r.fetchImage(&r.Project.Docker); err != nil {
 		return 1, err

--- a/internal/docker/playwright.go
+++ b/internal/docker/playwright.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/rs/zerolog/log"
-	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/playwright"
 )
@@ -49,10 +47,7 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 	}
 	r.Project.Playwright.ProjectPath = filepath.Base(r.Project.Playwright.ProjectPath)
 
-	if r.Project.Sauce.Concurrency > 1 {
-		log.Info().Msg("concurrency > 1: forcing file transfer mode to use 'copy'.")
-		r.Project.Docker.FileTransfer = config.DockerFileCopy
-	}
+	verifyFileTransferCompatibility(r.Project.Sauce.Concurrency, &r.Project.Docker)
 
 	if err := r.fetchImage(&r.Project.Docker); err != nil {
 		return 1, err

--- a/internal/docker/puppeteer.go
+++ b/internal/docker/puppeteer.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"github.com/saucelabs/saucectl/internal/puppeteer"
 
-	"github.com/rs/zerolog/log"
-	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/framework"
 )
 
@@ -41,10 +39,8 @@ func NewPuppeteer(c puppeteer.Project, ms framework.MetadataService) (*PuppeterR
 
 // RunProject runs the tests defined in config.Project.
 func (r *PuppeterRunner) RunProject() (int, error) {
-	if r.Project.Sauce.Concurrency > 1 {
-		log.Info().Msg("concurrency > 1: forcing file transfer mode to use 'copy'.")
-		r.Project.Docker.FileTransfer = config.DockerFileCopy
-	}
+	verifyFileTransferCompatibility(r.Project.Sauce.Concurrency, &r.Project.Docker)
+
 	if err := r.fetchImage(&r.Project.Docker); err != nil {
 		return 1, err
 	}

--- a/internal/docker/testcafe.go
+++ b/internal/docker/testcafe.go
@@ -3,8 +3,6 @@ package docker
 import (
 	"context"
 
-	"github.com/rs/zerolog/log"
-	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/testcafe"
 )
@@ -41,10 +39,8 @@ func NewTestcafe(c testcafe.Project, ms framework.MetadataService) (*TestcafeRun
 
 // RunProject runs the tests defined in config.Project.
 func (r *TestcafeRunner) RunProject() (int, error) {
-	if r.Project.Sauce.Concurrency > 1 {
-		log.Info().Msg("concurrency > 1: forcing file transfer mode to use 'copy'.")
-		r.Project.Docker.FileTransfer = config.DockerFileCopy
-	}
+	verifyFileTransferCompatibility(r.Project.Sauce.Concurrency, &r.Project.Docker)
+
 	if err := r.fetchImage(&r.Project.Docker); err != nil {
 		return 1, err
 	}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Print out filetransfer mode enforcement only when there's a delta.
Prior to this change, the user would always see this message, even if copy mode was already being used.
