### PR TITLE
saucectl configure: Enhance error visibility

### DIFF
--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -120,13 +120,13 @@ func Run() error {
 	}
 
 	if !creds.IsValid() {
-		fmt.Println("Credentials provided looks invalid and won't be saved.")
-		return nil
+		log.Error().Msg("Credentials provided looks invalid and won't be saved.")
+		return fmt.Errorf("invalid credentials provided")
 	}
 	if err := creds.Store(); err != nil {
 		return fmt.Errorf("unable to save credentials: %s", err)
 	}
-	fmt.Println("You're all set ! ")
+	log.Info().Msg("You're all set ! ")
 	return nil
 }
 

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -37,8 +37,8 @@ func Command(cli *command.SauceCtlCli) *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVarP(&cliUsername, "username", "u", "", "username, available on your saucelabs account")
-	cmd.Flags().StringVarP(&cliAccessKey, "accessKey", "a", "", "accessKey, available on your saucelabs account")
+	cmd.Flags().StringVarP(&cliUsername, "username", "u", "", "username, available on your sauce labs account")
+	cmd.Flags().StringVarP(&cliAccessKey, "accessKey", "a", "", "accessKey, available on your sauce labs account")
 	return cmd
 }
 

--- a/cli/command/configure/cmd.go
+++ b/cli/command/configure/cmd.go
@@ -120,7 +120,7 @@ func Run() error {
 	}
 
 	if !creds.IsValid() {
-		log.Error().Msg("Credentials provided looks invalid and won't be saved.")
+		log.Error().Msg("The provided credentials appear to be invalid and will NOT be saved.")
 		return fmt.Errorf("invalid credentials provided")
 	}
 	if err := creds.Store(); err != nil {


### PR DESCRIPTION
## Proposed changes

Updates:
- Exit code to be 1 when credential are invalid
- Message should be red and in an `ERR` line

Result:
```
$> (echo test; sleep 2; echo test) | ./saucectl configure ; echo $?
10:08:09 INF Start Configure Command

Don't have an account? Signup here:
https://bit.ly/saucectl-signup

Already have an account? Get your username and access key here:
https://app.saucelabs.com/user-settings


? SauceLabs username test
? SauceLabs access key test


10:08:11 ERR Credentials provided looks invalid and won't be saved.
10:08:11 ERR failed to execute configure command error="invalid credentials provided"
1
$>
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->