### PR TITLE
new: Raise error if no credentials set

### DIFF
--- a/cli/command/new/cmd.go
+++ b/cli/command/new/cmd.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/fatih/color"
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/cli/command"
 	"github.com/saucelabs/saucectl/internal/credentials"
@@ -76,8 +77,8 @@ func Command(cli *command.SauceCtlCli) *cobra.Command {
 func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 	creds := credentials.Get()
 	if creds == nil {
-		log.Error().Msg("\nsaucectl requires a valid Sauce Labs account to run."+
-			"\nTo configure your Sauce Labs account use:" +
+		color.Red("\nsaucectl requires a valid Sauce Labs account to run.")
+		fmt.Println("\nTo configure your Sauce Labs account use:" +
 			"\n$ saucectl configure\n")
 		return fmt.Errorf("no credentials set")
 	}

--- a/cli/command/new/cmd.go
+++ b/cli/command/new/cmd.go
@@ -76,9 +76,10 @@ func Command(cli *command.SauceCtlCli) *cobra.Command {
 func Run(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) error {
 	creds := credentials.Get()
 	if creds == nil {
-		fmt.Println("\nIt looks you have not configured your SauceLab account !" +
-			"\nTo enjoy SauceLabs capabilities, configure your account by running:\n$ saucectl configure")
-		return nil
+		log.Error().Msg("\nsaucectl requires a valid Sauce Labs account to run."+
+			"\nTo configure your Sauce Labs account use:" +
+			"\n$ saucectl configure\n")
+		return fmt.Errorf("no credentials set")
 	}
 
 	cwd, err := os.Getwd()

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible // translates to v19.03.12
 	github.com/docker/go-connections v0.4.0
+	github.com/fatih/color v1.7.0 // indirect
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/google/go-github/v32 v32.1.0
 	github.com/gorilla/mux v1.7.4 // indirect

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -62,7 +62,9 @@ func FromFile() *Credentials {
 
 	yamlFile, err := os.ReadFile(filePath)
 	if err != nil {
-		log.Info().Msgf("failed to read credentials: %v", err)
+		if !os.IsNotExist(err) {
+			log.Info().Msgf("failed to read credentials: %v", err)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
## Proposed changes

`saucectl new` should raise an error if there is no credentials set.

<img width="654" alt="Screen Shot 2021-04-01 at 1 32 45 PM" src="https://user-images.githubusercontent.com/11074879/113350809-d3e7fd00-92ee-11eb-8609-9b9dab01bf43.png">

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
