### PR TITLE
fix: Set region URL in puppeteer setup steps

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -593,6 +593,7 @@ func runPuppeteer(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client) (
 		return 1, errors.New("no sauce region set")
 	}
 
+	rs.URL = regio.APIBaseURL()
 	tc.URL = regio.APIBaseURL()
 	return runPuppeteerInDocker(p, tc, rs)
 }


### PR DESCRIPTION
## Proposed changes

Removes the warning ` WRN failed to attach configuration`.

Relates to: https://github.com/saucelabs/saucectl-puppeteer-example/issues/4

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
