### PR TITLE
Add platform defaults

### DIFF
--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -149,6 +149,10 @@ func FromFile(cfgPath string) (Project, error) {
 			env[k] = os.ExpandEnv(v)
 		}
 		p.Suites[i].Config.Env = env
+
+		if s.PlatformName == "" {
+			s.PlatformName = "Windows 10"
+		}
 	}
 
 	return p, nil

--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -66,7 +66,7 @@ func FromFile(cfgPath string) (Project, error) {
 	}
 
 	for sidx, suite := range p.Suites {
-		for didx, _ := range suite.Devices {
+		for didx := range suite.Devices {
 			// Adnroid is the only choice.
 			p.Suites[sidx].Devices[didx].PlatformName = Android
 		}

--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -65,6 +65,13 @@ func FromFile(cfgPath string) (Project, error) {
 		p.Sauce.Concurrency = 2
 	}
 
+	for sidx, suite := range p.Suites {
+		for didx, _ := range suite.Devices {
+			// Adnroid is the only choice.
+			p.Suites[sidx].Devices[didx].PlatformName = Android
+		}
+	}
+
 	return p, nil
 }
 
@@ -90,7 +97,7 @@ func Validate(p Project) error {
 		return errors.New("no suites defined")
 	}
 
-	for sidx, suite := range p.Suites {
+	for _, suite := range p.Suites {
 		if len(suite.Devices) == 0 {
 			return fmt.Errorf("missing devices configuration for suite: %s", suite.Name)
 		}
@@ -104,9 +111,6 @@ func Validate(p Project) error {
 			if len(device.PlatformVersions) == 0 {
 				// TODO - update message when handling device.Id
 				return fmt.Errorf("missing platform versions for device: %s", device.Name)
-			}
-			if device.PlatformName == "" || device.PlatformName != Android {
-				p.Suites[sidx].Devices[didx].PlatformName = Android
 			}
 		}
 	}

--- a/internal/espresso/config_test.go
+++ b/internal/espresso/config_test.go
@@ -146,33 +146,6 @@ func TestValidateThrowsErrors(t *testing.T) {
 	}
 }
 
-func TestValidatePlatformNameIsSet(t *testing.T) {
-	p := Project{
-		Espresso: Espresso{
-			App: "/path/to/app.apk",
-			TestApp: "/path/to/testApp.apk",
-		},
-		Suites: []Suite{
-			Suite{
-				Name: "valid espresso project",
-				Devices: []config.Device{
-					config.Device{
-						Name: "Android GoogleApi Emulator",
-						PlatformVersions: []string{"11.0"},
-					},
-				},
-			},
-		},
-	}
-	err := Validate(p)
-	assert.Nil(t, err)
-	for _, suite := range p.Suites {
-		for _, device := range suite.Devices {
-			assert.Equal(t, device.PlatformName, Android)
-		}
-	}
-}
-
 func TestFromFile(t *testing.T) {
 	dir := fs.NewDir(t, "espresso-cfg",
 		fs.WithFile("config.yml", `apiVersion: v1alpha
@@ -204,6 +177,7 @@ suites:
 				Devices: []config.Device{
 					{
 						Name: "Google Pixel C GoogleAPI Emulator",
+						PlatformName: Android,
 						PlatformVersions: []string{
 							"8.1",
 						},

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -113,6 +113,10 @@ func FromFile(cfgPath string) (Project, error) {
 			env[k] = os.ExpandEnv(v)
 		}
 		p.Suites[i].Env = env
+
+		if s.PlatformName == "" {
+			s.PlatformName = "Windows 10"
+		}
 	}
 
 	return p, nil

--- a/internal/testcafe/config_test.go
+++ b/internal/testcafe/config_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 )
 
-func TestSetDefaultValues (t *testing.T) {
+func TestSetDefaultValues(t *testing.T) {
 	s := Suite{
-		Speed: 0,
-		SelectorTimeout: 0,
+		Speed:            0,
+		SelectorTimeout:  0,
 		AssertionTimeout: 0,
-		PageLoadTimeout: 0,
+		PageLoadTimeout:  0,
 	}
 	setDefaultValues(&s)
 	assert.Equal(t, s.Speed, float64(1))
@@ -31,14 +31,78 @@ func TestSetDefaultValues (t *testing.T) {
 	assert.Equal(t, s.Speed, 0.5)
 
 	s = Suite{
-		Speed: 0,
-		SelectorTimeout: -1,
+		Speed:            0,
+		SelectorTimeout:  -1,
 		AssertionTimeout: -1,
-		PageLoadTimeout: -1,
+		PageLoadTimeout:  -1,
 	}
 	setDefaultValues(&s)
 	assert.Equal(t, s.Speed, float64(1))
 	assert.Equal(t, s.SelectorTimeout, 10000)
 	assert.Equal(t, s.AssertionTimeout, 3000)
 	assert.Equal(t, s.PageLoadTimeout, 3000)
+}
+
+func Test_appleDeviceRegex(t *testing.T) {
+	tests := []struct {
+		deviceName string
+		want       bool
+	}{
+		{
+			deviceName: "iPhone Simulator",
+			want:       true,
+		},
+		{
+			deviceName: "iphone simulator",
+			want:       true,
+		},
+		{
+			deviceName: "iPhone SE (2nd generation) Simulator",
+			want:       true,
+		},
+		{
+			deviceName: "iPhone 8 Simulator",
+			want:       true,
+		},
+		{
+			deviceName: "iPhone 8 Plus Simulator",
+			want:       true,
+		},
+		{
+			deviceName: "iPad Pro (12.9 inch) Simulator",
+			want:       true,
+		},
+		{
+			deviceName: "iPad Pro (12.9 inch) (4th generation) Simulator",
+			want:       true,
+		},
+		{
+			deviceName: "iPad Air Simulator",
+			want:       true,
+		},
+		{
+			deviceName: "iPad (8th generation) Simulator",
+			want:       true,
+		},
+		{
+			deviceName: "iPad mini (5th generation) Simulator",
+			want:       true,
+		},
+		{
+			deviceName: "Android GoogleAPI Emulator",
+			want:       false,
+		},
+		{
+			deviceName: "Google Pixel 3a GoogleAPI Emulator",
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.deviceName, func(t *testing.T) {
+			got := appleDeviceRegex.MatchString(tt.deviceName)
+			if got != tt.want {
+				t.Errorf("appleDeviceRegex.MatchString() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Adding platform defaults.
Left out puppeteer, since that one's docker only.
