### PR TITLE
fix: exit as failed when dockerMode tests don't pass

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -255,7 +255,7 @@ func runCypress(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as 
 
 	dockerProject, sauceProject := cypress.SplitSuites(p)
 	if len(dockerProject.Suites) != 0 {
-		if exitCode, err := runCypressInDocker(dockerProject, tc, rs); err != nil {
+		if exitCode, err := runCypressInDocker(dockerProject, tc, rs); err != nil || exitCode != 0 {
 			return exitCode, err
 		}
 	}
@@ -360,7 +360,7 @@ func runPlaywright(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, 
 
 	dockerProject, sauceProject := playwright.SplitSuites(p)
 	if len(dockerProject.Suites) != 0 {
-		if exitCode, err := runPlaywrightInDocker(dockerProject, tc, rs); err != nil {
+		if exitCode, err := runPlaywrightInDocker(dockerProject, tc, rs); err != nil || exitCode != 0 {
 			return exitCode, err
 		}
 	}
@@ -462,8 +462,9 @@ func runTestcafe(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as
 	as.URL = regio.APIBaseURL()
 
 	dockerProject, sauceProject := testcafe.SplitSuites(p)
+	exitCode := 0
 	if len(dockerProject.Suites) != 0 {
-		if exitCode, err := runTestcafeInDocker(dockerProject, tc, rs); err != nil {
+		if exitCode, err = runTestcafeInDocker(dockerProject, tc, rs); err != nil || exitCode != 0 {
 			return exitCode, err
 		}
 	}

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -255,7 +255,8 @@ func runCypress(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as 
 
 	dockerProject, sauceProject := cypress.SplitSuites(p)
 	if len(dockerProject.Suites) != 0 {
-		if exitCode, err := runCypressInDocker(dockerProject, tc, rs); err != nil || exitCode != 0 {
+		exitCode, err := runCypressInDocker(dockerProject, tc, rs)
+		if err != nil || exitCode != 0 {
 			return exitCode, err
 		}
 	}
@@ -360,7 +361,8 @@ func runPlaywright(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, 
 
 	dockerProject, sauceProject := playwright.SplitSuites(p)
 	if len(dockerProject.Suites) != 0 {
-		if exitCode, err := runPlaywrightInDocker(dockerProject, tc, rs); err != nil || exitCode != 0 {
+		exitCode, err := runPlaywrightInDocker(dockerProject, tc, rs)
+		if err != nil || exitCode != 0 {
 			return exitCode, err
 		}
 	}
@@ -462,9 +464,9 @@ func runTestcafe(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as
 	as.URL = regio.APIBaseURL()
 
 	dockerProject, sauceProject := testcafe.SplitSuites(p)
-	exitCode := 0
 	if len(dockerProject.Suites) != 0 {
-		if exitCode, err = runTestcafeInDocker(dockerProject, tc, rs); err != nil || exitCode != 0 {
+		exitCode, err := runTestcafeInDocker(dockerProject, tc, rs)
+		if err != nil || exitCode != 0 {
 			return exitCode, err
 		}
 	}


### PR DESCRIPTION
## Proposed changes

Test cases failing in DockerMode won't make `saucectl` exit with `exitCode != 0`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->