### PR TITLE
Fix suite filter for espresso

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -530,6 +530,12 @@ func runEspresso(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as
 		return 1, err
 	}
 
+	if cmd.Flags().Lookup("suite").Changed {
+		if err := filterEspressoSuite(&p); err != nil {
+			return 1, err
+		}
+	}
+
 	tc.URL = regio.APIBaseURL()
 	rs.URL = regio.APIBaseURL()
 	as.URL = regio.APIBaseURL()


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Fixes the suite filtering for espresso (filter function wasn't invoked before). This allows suites to be filtered via the CLI arg `--suite`.