### PR TITLE
Fetch and print junit.xml for failed espresso suites

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/rs/zerolog v1.18.0
+	github.com/jedib0t/go-pretty/v6 v6.2.1
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/getsentry/sentry-go v0.10.0 h1:6gwY+66NHKqyZrdi6O2jGdo7wGdo9b3B69E01NFgT5g=
 github.com/getsentry/sentry-go v0.10.0/go.mod h1:kELm/9iCblqUYh+ZRML7PNdCvEuw24wBvJPYyi86cws=
@@ -153,6 +154,8 @@ github.com/jarcoal/httpmock v1.0.6 h1:e81vOSexXU3mJuJ4l//geOmKIt+Vkxerk1feQBC8D0
 github.com/jarcoal/httpmock v1.0.6/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/jedib0t/go-pretty/v6 v6.2.1 h1:O/3XdNfyWSyVLLIt1EeDhfP8AhNMjtBSh0MuZ4frg6U=
+github.com/jedib0t/go-pretty/v6 v6.2.1/go.mod h1:+nE9fyyHGil+PuISTCrp7avEdo6bqoMwqZnuiK2r2a0=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -195,6 +198,8 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
@@ -241,6 +246,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/internal/junit/junit.go
+++ b/internal/junit/junit.go
@@ -1,0 +1,55 @@
+package junit
+
+import "encoding/xml"
+
+type TestCase struct {
+	Name       string `xml:"name,attr"`
+	Assertions string `xml:"assertions,attr"`
+	Time       string `xml:"time,attr"`
+	ClassName  string `xml:"classname,attr"`
+	Status     string `xml:"status,attr"`
+	SystemOut  string `xml:"system-out"`
+	Error      string `xml:"error"`
+	Failure    string `xml:"failure"`
+}
+
+type TestSuite struct {
+	Name      string     `xml:"name,attr"`
+	Tests     string     `xml:"tests,attr"`
+	Errors    string     `xml:"errors,attr,omitempty"`
+	Failures  string     `xml:"failures,attr,omitempty"`
+	Time      string     `xml:"time,attr,omitempty"`
+	Disabled  string     `xml:"disabled,attr,omitempty"`
+	Skipped   string     `xml:"skipped,attr,omitempty"`
+	Timestamp string     `xml:"timestamp,attr,omitempty"`
+	Package   string     `xml:"package,attr,omitempty"`
+	TestCase  []TestCase `xml:"testcase"`
+	SystemOut string     `xml:"system-out"`
+}
+
+type TestSuites struct {
+	XMLName   xml.Name    `xml:"testsuites"`
+	TestSuite []TestSuite `xml:"testsuite"`
+	Name      string      `xml:"name,attr,omitempty"`
+	Time      string      `xml:"time,attr,omitempty"`
+	Tests     string      `xml:"tests,attr,omitempty"`
+	Failures  string      `xml:"failures,attr,omitempty"`
+	Disabled  string      `xml:"disabled,attr,omitempty"`
+	Errors    string      `xml:"errors,attr,omitempty"`
+}
+
+func Parse(data []byte) TestSuites {
+	tss := TestSuites{}
+	err := xml.Unmarshal(data, &tss)
+	// root <testsuites> is optional
+	if err != nil {
+		ts := TestSuite{}
+		err = xml.Unmarshal(data, &ts)
+		if err == nil {
+			return TestSuites{
+				TestSuite: []TestSuite{ts},
+			}
+		}
+	}
+	return tss
+}

--- a/internal/junit/junit.go
+++ b/internal/junit/junit.go
@@ -15,12 +15,12 @@ type TestCase struct {
 
 type TestSuite struct {
 	Name      string     `xml:"name,attr"`
-	Tests     string     `xml:"tests,attr"`
-	Errors    string     `xml:"errors,attr,omitempty"`
-	Failures  string     `xml:"failures,attr,omitempty"`
+	Tests     int        `xml:"tests,attr"`
+	Errors    int        `xml:"errors,attr,omitempty"`
+	Failures  int        `xml:"failures,attr,omitempty"`
+	Disabled  int        `xml:"disabled,attr,omitempty"`
+	Skipped   int        `xml:"skipped,attr,omitempty"`
 	Time      string     `xml:"time,attr,omitempty"`
-	Disabled  string     `xml:"disabled,attr,omitempty"`
-	Skipped   string     `xml:"skipped,attr,omitempty"`
 	Timestamp string     `xml:"timestamp,attr,omitempty"`
 	Package   string     `xml:"package,attr,omitempty"`
 	TestCase  []TestCase `xml:"testcase"`
@@ -32,24 +32,25 @@ type TestSuites struct {
 	TestSuite []TestSuite `xml:"testsuite"`
 	Name      string      `xml:"name,attr,omitempty"`
 	Time      string      `xml:"time,attr,omitempty"`
-	Tests     string      `xml:"tests,attr,omitempty"`
-	Failures  string      `xml:"failures,attr,omitempty"`
-	Disabled  string      `xml:"disabled,attr,omitempty"`
-	Errors    string      `xml:"errors,attr,omitempty"`
+	Tests     int         `xml:"tests,attr,omitempty"`
+	Failures  int         `xml:"failures,attr,omitempty"`
+	Disabled  int         `xml:"disabled,attr,omitempty"`
+	Errors    int         `xml:"errors,attr,omitempty"`
 }
 
-func Parse(data []byte) TestSuites {
+func Parse(data []byte) (TestSuites, error) {
 	tss := TestSuites{}
 	err := xml.Unmarshal(data, &tss)
-	// root <testsuites> is optional
 	if err != nil {
+		// root <testsuites> is optional
+		// parse a <testsuite> element instead
 		ts := TestSuite{}
 		err = xml.Unmarshal(data, &ts)
 		if err == nil {
-			return TestSuites{
-				TestSuite: []TestSuite{ts},
+			tss.TestSuite = []TestSuite{
+				ts,
 			}
 		}
 	}
-	return tss
+	return tss, err
 }

--- a/internal/junit/junit.go
+++ b/internal/junit/junit.go
@@ -2,6 +2,7 @@ package junit
 
 import "encoding/xml"
 
+// TestCase maps to <testcase> element
 type TestCase struct {
 	Name       string `xml:"name,attr"`
 	Assertions string `xml:"assertions,attr"`
@@ -13,6 +14,7 @@ type TestCase struct {
 	Failure    string `xml:"failure"`
 }
 
+// TestSuite maps to <testsuite> element
 type TestSuite struct {
 	Name      string     `xml:"name,attr"`
 	Tests     int        `xml:"tests,attr"`
@@ -27,6 +29,7 @@ type TestSuite struct {
 	SystemOut string     `xml:"system-out"`
 }
 
+// TestSuites maps to root junit <testsuites> element
 type TestSuites struct {
 	XMLName   xml.Name    `xml:"testsuites"`
 	TestSuite []TestSuite `xml:"testsuite"`
@@ -38,6 +41,8 @@ type TestSuites struct {
 	Errors    int         `xml:"errors,attr,omitempty"`
 }
 
+// Parse parses an xml-encoded byte string and returns a `TestSuites` struct
+// The root <testsuites> element is optional so if its missing, Parse will parse a <testsuite> and wrap it in a `TestSuites` struct
 func Parse(data []byte) (TestSuites, error) {
 	tss := TestSuites{}
 	err := xml.Unmarshal(data, &tss)

--- a/internal/junit/junit.go
+++ b/internal/junit/junit.go
@@ -44,18 +44,20 @@ type TestSuites struct {
 // Parse parses an xml-encoded byte string and returns a `TestSuites` struct
 // The root <testsuites> element is optional so if its missing, Parse will parse a <testsuite> and wrap it in a `TestSuites` struct
 func Parse(data []byte) (TestSuites, error) {
-	tss := TestSuites{}
+	var tss TestSuites
 	err := xml.Unmarshal(data, &tss)
 	if err != nil {
 		// root <testsuites> is optional
 		// parse a <testsuite> element instead
-		ts := TestSuite{}
-		err = xml.Unmarshal(data, &ts)
-		if err == nil {
-			tss.TestSuite = []TestSuite{
-				ts,
-			}
+		var ts TestSuite
+		if err = xml.Unmarshal(data, &ts); err != nil {
+			return tss, err
+		}
+
+		tss.TestSuite = []TestSuite{
+			ts,
 		}
 	}
+
 	return tss, err
 }

--- a/internal/junit/junit_test.go
+++ b/internal/junit/junit_test.go
@@ -1,0 +1,60 @@
+package junit
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	type testCase struct {
+		description string
+		data        []byte
+		want        TestSuites
+	}
+	testCases := []testCase{
+		{
+			description: "should parse without root testsuites element",
+			data: []byte(`
+			<testsuite errors="3" package="com.example.android.testing.androidjunitrunnersample" tests="66" time="42.962">
+			</testsuite>
+			`),
+			want: TestSuites{
+				TestSuite: []TestSuite{
+					{
+						Errors:  "3",
+						Package: "com.example.android.testing.androidjunitrunnersample",
+						Tests:   "66",
+						Time:    "42.962",
+					},
+				},
+			},
+		},
+		{
+			description: "should parse with root testsuites element",
+			data: []byte(`
+			<testsuites>
+				<testsuite errors="3" package="com.example.android.testing.androidjunitrunnersample" tests="66" time="42.962">
+				</testsuite>
+			</testsuites>
+			`),
+			want: TestSuites{
+				XMLName: xml.Name{Space: "", Local: "testsuites"},
+				TestSuite: []TestSuite{
+					{
+						Errors:  "3",
+						Package: "com.example.android.testing.androidjunitrunnersample",
+						Tests:   "66",
+						Time:    "42.962",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		got := Parse(tt.data)
+		assert.Equal(t, tt.want, got)
+	}
+}

--- a/internal/junit/junit_test.go
+++ b/internal/junit/junit_test.go
@@ -23,9 +23,9 @@ func TestParse(t *testing.T) {
 			want: TestSuites{
 				TestSuite: []TestSuite{
 					{
-						Errors:  "3",
+						Errors:  3,
 						Package: "com.example.android.testing.androidjunitrunnersample",
-						Tests:   "66",
+						Tests:   66,
 						Time:    "42.962",
 					},
 				},
@@ -43,9 +43,9 @@ func TestParse(t *testing.T) {
 				XMLName: xml.Name{Space: "", Local: "testsuites"},
 				TestSuite: []TestSuite{
 					{
-						Errors:  "3",
+						Errors:  3,
 						Package: "com.example.android.testing.androidjunitrunnersample",
-						Tests:   "66",
+						Tests:   66,
 						Time:    "42.962",
 					},
 				},
@@ -54,7 +54,8 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		got := Parse(tt.data)
+		got, _ := Parse(tt.data)
 		assert.Equal(t, tt.want, got)
+		assert.Equal(t, 0, got.Failures)
 	}
 }

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -343,6 +343,7 @@ func (r *CloudRunner) logSuiteConsole(res result) {
 				fmt.Printf("\t%d) %s.%s\n\n", errCount, tc.ClassName, tc.Name)
 				headerColor.Println("\tError was:")
 				bodyColor.Printf("\t%s\n", tc.Error)
+				errCount += 1
 			}
 		}
 	}

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/archive/zip"
 	"github.com/saucelabs/saucectl/internal/concurrency"
@@ -18,6 +20,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/download"
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/jsonio"
+	"github.com/saucelabs/saucectl/internal/junit"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/progress"
 	"github.com/saucelabs/saucectl/internal/region"
@@ -311,10 +314,40 @@ func (r *CloudRunner) logSuiteConsole(res result) {
 	// Display log only when at least it has started
 	assetContent, err := r.JobReader.GetJobAssetFileContent(context.Background(), res.job.ID, ConsoleLogAsset)
 	if err != nil {
-		// log.Warn().Str("suite", res.suiteName).Msg("Failed to retrieve the console output.")
 		assetContent, err = r.JobReader.GetJobAssetFileContent(context.Background(), res.job.ID, "junit.xml")
 		if err == nil {
-			log.Info().Str("suite", res.suiteName).Msgf("junit.xml output: \n%s", assetContent)
+			testsuites, err := junit.Parse(assetContent)
+			if err == nil {
+				headerColor := color.New(color.FgRed).Add(color.Bold).Add(color.Underline)
+				headerColor.Print("\nErrors:\n\n")
+				bodyColor := color.New(color.FgHiRed)
+				errCount := 1
+				for _, ts := range testsuites.TestSuite {
+					for _, tc := range ts.TestCase {
+						if tc.Error != "" {
+							fmt.Printf("\t%d) %s.%s\n\n", errCount, tc.ClassName, tc.Name)
+							headerColor.Println("\tError was:")
+							bodyColor.Printf("\t%s\n", tc.Error)
+						}
+					}
+				}
+
+				// Print summary table
+				fmt.Println()
+				t := table.NewWriter()
+				t.SetOutputMirror(os.Stdout)
+				t.AppendHeader(table.Row{"espresso testsuite", "tests", "pass", "fail", "error"})
+				for _, ts := range testsuites.TestSuite {
+					passed := ts.Tests - ts.Errors - ts.Failures
+					t.AppendRow(table.Row{ts.Package, ts.Tests, passed, ts.Failures, ts.Errors})
+				}
+				t.Render()
+				fmt.Println()
+			} else {
+				log.Warn().Str("suite", res.suiteName).Msg("Failed to parse junit")
+			}
+		} else {
+			log.Warn().Str("suite", res.suiteName).Msg("Failed to retrieve the console output.")
 		}
 	} else {
 		log.Info().Str("suite", res.suiteName).Msgf("console.log output: \n%s", assetContent)

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -311,7 +311,11 @@ func (r *CloudRunner) logSuiteConsole(res result) {
 	// Display log only when at least it has started
 	assetContent, err := r.JobReader.GetJobAssetFileContent(context.Background(), res.job.ID, ConsoleLogAsset)
 	if err != nil {
-		log.Warn().Str("suite", res.suiteName).Msg("Failed to retrieve the console output.")
+		// log.Warn().Str("suite", res.suiteName).Msg("Failed to retrieve the console output.")
+		assetContent, err = r.JobReader.GetJobAssetFileContent(context.Background(), res.job.ID, "junit.xml")
+		if err == nil {
+			log.Info().Str("suite", res.suiteName).Msgf("junit.xml output: \n%s", assetContent)
+		}
 	} else {
 		log.Info().Str("suite", res.suiteName).Msgf("console.log output: \n%s", assetContent)
 	}

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -343,7 +343,7 @@ func (r *CloudRunner) logSuiteConsole(res result) {
 				fmt.Printf("\t%d) %s.%s\n\n", errCount, tc.ClassName, tc.Name)
 				headerColor.Println("\tError was:")
 				bodyColor.Printf("\t%s\n", tc.Error)
-				errCount += 1
+				errCount++
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed changes
`saucectl` currently fetches and prints a job's `console.log` when a suite fails. Espresso tests do not have a console.log, but they do have a junit.xml that is ripe for parsing.

So for failed espresso suites, fetch and parse the `junit.xml` file and pretty print the test output for the failed tests. Prints out a numbered list of errors:
![Screen Shot 2021-05-10 at 10 07 37 AM](https://user-images.githubusercontent.com/56001373/117690036-a0af4e00-b177-11eb-8f5a-4a2aae5982aa.png)

As well as a summary table:
![Screen Shot 2021-05-10 at 10 07 43 AM](https://user-images.githubusercontent.com/56001373/117690069-a9a01f80-b177-11eb-98ab-d8f6d197641c.png)


## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)