### PR TITLE
Check if an artifact has already been uploaded

### DIFF
--- a/internal/appstore/appstore.go
+++ b/internal/appstore/appstore.go
@@ -178,6 +178,7 @@ func calculateBundleHash(filename string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer fs.close()
 	hsh := md5.New()
 	if _, err := io.Copy(hsh, fs); err != nil {
 		return "", err

--- a/internal/appstore/appstore.go
+++ b/internal/appstore/appstore.go
@@ -178,7 +178,7 @@ func calculateBundleHash(filename string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer fs.close()
+	defer fs.Close()
 	hsh := md5.New()
 	if _, err := io.Copy(hsh, fs); err != nil {
 		return "", err

--- a/internal/appstore/appstore.go
+++ b/internal/appstore/appstore.go
@@ -137,8 +137,8 @@ func createRequest(url, username, accesskey string, body *bytes.Buffer, contentT
 	return req, nil
 }
 
-// Locate looks for a file having the same signature.
-func (s *AppStore) Locate(filename string) (storage.ArtifactMeta, error) {
+// Find looks for a file having the same signature.
+func (s *AppStore) Find(filename string) (storage.ArtifactMeta, error) {
 	if filename == "" {
 		return storage.ArtifactMeta{}, nil
 	}

--- a/internal/appstore/appstore_test.go
+++ b/internal/appstore/appstore_test.go
@@ -1,0 +1,50 @@
+package appstore
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestAppStore_Upload(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		completeQuery := fmt.Sprintf("%s?%s", r.URL.Path, r.URL.RawQuery)
+		switch completeQuery {
+		case "/v1/storage/list?":
+			w.WriteHeader(200)
+			w.Write([]byte(`{"items": [{"id":"matching-id", "etag": "matching-hash"}], "links": {"next": "?page=2"}}`))
+		case "/v1/storage/list?page=2":
+			w.WriteHeader(200)
+			w.Write([]byte(`{"items": [{"id":"matching-id-next", "etag": "matching-hash-next"}]}`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	testCases := []struct {
+		look    string
+		want    string
+		wantErr error
+	}{
+		{look: "not-found-hash", want: "", wantErr: nil},
+		{look: "matching-hash", want: "matching-id", wantErr: nil},
+		{look: "matching-hash-next", want: "matching-id-next", wantErr: nil},
+		{look: "", want: "", wantErr: nil},
+	}
+
+	as := New(ts.URL, "fake-username", "fake-access-key", 15*time.Second)
+	for _, tt := range testCases {
+		artifact, err := as.Locate(tt.look)
+
+		if !reflect.DeepEqual(err, tt.wantErr) {
+			t.Errorf("Error: want: %v, got: %v", tt.wantErr, err)
+		}
+		if artifact.ID != tt.want {
+			t.Errorf("StorageID: want: %v, got: %v", tt.want, artifact.ID)
+		}
+	}
+}

--- a/internal/appstore/appstore_test.go
+++ b/internal/appstore/appstore_test.go
@@ -53,7 +53,7 @@ func TestAppStore_Upload(t *testing.T) {
 
 	as := New(ts.URL, "fake-username", "fake-access-key", 15*time.Second)
 	for _, tt := range testCases {
-		artifact, err := as.Locate(tt.look)
+		artifact, err := as.Find(tt.look)
 
 		if !reflect.DeepEqual(err, tt.wantErr) {
 			t.Errorf("Error: want: %v, got: %v", tt.wantErr, err)

--- a/internal/mocks/storage.go
+++ b/internal/mocks/storage.go
@@ -20,7 +20,7 @@ func (fpu *FakeProjectUploader) Upload(name string) (storage.ArtifactMeta, error
 	return storage.ArtifactMeta{}, errors.New("failed-upload")
 }
 
-// Locate mock function
+// Find mock function
 func (fpu *FakeProjectUploader) Find(hash string) (storage.ArtifactMeta, error) {
 	return storage.ArtifactMeta{}, nil
 }

--- a/internal/mocks/storage.go
+++ b/internal/mocks/storage.go
@@ -19,3 +19,8 @@ func (fpu *FakeProjectUploader) Upload(name string) (storage.ArtifactMeta, error
 	}
 	return storage.ArtifactMeta{}, errors.New("failed-upload")
 }
+
+// Locate mock function
+func (fpu *FakeProjectUploader) Locate(hash string) (storage.ArtifactMeta, error) {
+	return storage.ArtifactMeta{}, nil
+}

--- a/internal/mocks/storage.go
+++ b/internal/mocks/storage.go
@@ -21,6 +21,6 @@ func (fpu *FakeProjectUploader) Upload(name string) (storage.ArtifactMeta, error
 }
 
 // Locate mock function
-func (fpu *FakeProjectUploader) Locate(hash string) (storage.ArtifactMeta, error) {
+func (fpu *FakeProjectUploader) Find(hash string) (storage.ArtifactMeta, error) {
 	return storage.ArtifactMeta{}, nil
 }

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -318,7 +318,7 @@ var (
 
 func (r *CloudRunner) uploadProject(filename string, pType uploadType) (string, error) {
 	log.Info().Msgf("Checking if %s has already been uploaded previously", filename)
-	if storageID, _ := r.checkIfFileExists(filename); storageID != "" {
+	if storageID, _ := r.checkIfFileAlreadyUploaded(filename); storageID != "" {
 		log.Info().Msgf("Skipping upload, using storage:%s", storageID)
 		return storageID, nil
 	}
@@ -339,8 +339,8 @@ func (r *CloudRunner) uploadProject(filename string, pType uploadType) (string, 
 	return resp.ID, nil
 }
 
-func (r *CloudRunner) checkIfFileExists(fileName string) (string, error) {
-	resp, err := r.ProjectUploader.Locate(fileName)
+func (r *CloudRunner) checkIfFileAlreadyUploaded(fileName string) (storageID string, err error) {
+	resp, err := r.ProjectUploader.Find(fileName)
 	if err != nil {
 		return "", err
 	}

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -2,7 +2,6 @@ package saucecloud
 
 import (
 	"context"
-	"crypto/md5"
 	"errors"
 	"fmt"
 	"io"
@@ -317,19 +316,6 @@ var (
 	projectUpload uploadType = "project"
 )
 
-func (r *CloudRunner) calculateBundleHash(filename string) (string, error) {
-	fs, err := os.Open(filename)
-	if err != nil {
-		return "", err
-	}
-	hsh := md5.New()
-	if _, err := io.Copy(hsh, fs); err != nil {
-		return "", err
-	}
-	hash := fmt.Sprintf("%x", hsh.Sum(nil))
-	return hash, nil
-}
-
 func (r *CloudRunner) uploadProject(filename string, pType uploadType) (string, error) {
 	log.Info().Msgf("Checking if %s has already been uploaded previously", filename)
 	if storageID, _ := r.checkIfFileExists(filename); storageID != "" {
@@ -354,11 +340,7 @@ func (r *CloudRunner) uploadProject(filename string, pType uploadType) (string, 
 }
 
 func (r *CloudRunner) checkIfFileExists(fileName string) (string, error) {
-	hash, err := r.calculateBundleHash(fileName)
-	if err != nil {
-		return "", err
-	}
-	resp, err := r.ProjectUploader.Locate(hash)
+	resp, err := r.ProjectUploader.Locate(fileName)
 	if err != nil {
 		return "", err
 	}

--- a/internal/storage/project.go
+++ b/internal/storage/project.go
@@ -3,6 +3,7 @@ package storage
 // ProjectUploader is the interface for uploading bundled project files, later to be used in the Sauce Cloud.
 type ProjectUploader interface {
 	Upload(name string) (ArtifactMeta, error)
+	Locate(hash string) (ArtifactMeta, error)
 }
 
 // ArtifactMeta represents metadata of the uploaded file.

--- a/internal/storage/project.go
+++ b/internal/storage/project.go
@@ -3,7 +3,7 @@ package storage
 // ProjectUploader is the interface for uploading bundled project files, later to be used in the Sauce Cloud.
 type ProjectUploader interface {
 	Upload(name string) (ArtifactMeta, error)
-	Locate(hash string) (ArtifactMeta, error)
+	Locate(name string) (ArtifactMeta, error)
 }
 
 // ArtifactMeta represents metadata of the uploaded file.

--- a/internal/storage/project.go
+++ b/internal/storage/project.go
@@ -3,7 +3,7 @@ package storage
 // ProjectUploader is the interface for uploading bundled project files, later to be used in the Sauce Cloud.
 type ProjectUploader interface {
 	Upload(name string) (ArtifactMeta, error)
-	Locate(name string) (ArtifactMeta, error)
+	Find(name string) (ArtifactMeta, error)
 }
 
 // ArtifactMeta represents metadata of the uploaded file.


### PR DESCRIPTION
## Proposed changes

In order to save time of uploading, check if an artifact has already been uploaded.
Use storage API to check if there is a candidate file having the same hash (assumed to be identical).


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->