### PR TITLE
Add warning when a newer version is available

### DIFF
--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -865,6 +865,6 @@ func checkForUpdates() {
 		return
 	}
 	if v != "" {
-		log.Warn().Msgf("An update of saucectl is available (%s)", v)
+		log.Warn().Msgf("A new version of saucectl is available (%s)", v)
 	}
 }

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -866,6 +866,6 @@ func checkForUpdates() {
 		return
 	}
 	if v != "" {
-		log.Info().Msgf("An update of saucectl is available (%s)", v)
+		log.Warn().Msgf("An update of saucectl is available (%s)", v)
 	}
 }

--- a/cli/command/run/cmd.go
+++ b/cli/command/run/cmd.go
@@ -862,7 +862,6 @@ func checkForUpdates() {
 
 	v, err := gh.HasUpdateAvailable()
 	if err != nil {
-		log.Error().Err(err).Msg("Check for update")
 		return
 	}
 	if v != "" {

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -6,3 +6,8 @@ var (
 	Version   = "v0.0.0+unknown"
 	GitCommit = "unknown-commit-sha"
 )
+
+// Checker represents an interface for checking saucectl updates.
+type Checker interface {
+	HasUpdateAvailable() (string, error)
+}

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/mod v0.4.2
 	gopkg.in/yaml.v2 v2.2.8
 	gotest.tools v2.2.0+incompatible
 	gotest.tools/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -334,6 +334,7 @@ golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -341,6 +342,8 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -386,6 +389,7 @@ golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1,0 +1,56 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/saucelabs/saucectl/cli/version"
+	"github.com/saucelabs/saucectl/internal/requesth"
+	"golang.org/x/mod/semver"
+	"net/http"
+)
+
+// Client represents the Github HTTP API client.
+type Client struct {
+	HTTPClient *http.Client
+	URL        string
+}
+
+type release struct {
+	Name    string `json:"name"`
+	TagName string `json:"tag_name"`
+}
+
+func (c *Client) HasUpdateAvailable() (string, error) {
+	req, err := requesth.New(http.MethodGet, fmt.Sprintf("%s/repos/saucelabs/saucectl/releases/latest", c.URL), nil)
+	if err != nil {
+		return "", err
+	}
+
+	r, err := c.executeRequest(req)
+	if err != nil {
+		return "", err
+	}
+
+	if isUpdateRequired(version.Version, r.TagName) {
+		return r.TagName, nil
+	}
+	return "", nil
+}
+
+func (c *Client) executeRequest(req *http.Request) (release, error){
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return release{}, nil
+	}
+	defer resp.Body.Close()
+
+	var r release
+	if err = json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return release{}, nil
+	}
+	return r, nil
+}
+
+func isUpdateRequired(current, remote string) bool {
+	return semver.Compare(current, remote) > 0
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -20,6 +20,7 @@ type release struct {
 	TagName string `json:"tag_name"`
 }
 
+// HasUpdateAvailable returns the version number of latest available update if there is one.
 func (c *Client) HasUpdateAvailable() (string, error) {
 	req, err := requesth.New(http.MethodGet, fmt.Sprintf("%s/repos/saucelabs/saucectl/releases/latest", c.URL), nil)
 	if err != nil {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -37,7 +37,7 @@ func (c *Client) HasUpdateAvailable() (string, error) {
 	return "", nil
 }
 
-func (c *Client) executeRequest(req *http.Request) (release, error){
+func (c *Client) executeRequest(req *http.Request) (release, error) {
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return release{}, nil
@@ -52,5 +52,5 @@ func (c *Client) executeRequest(req *http.Request) (release, error){
 }
 
 func isUpdateRequired(current, remote string) bool {
-	return semver.Compare(current, remote) > 0
+	return semver.Compare(current, remote) < 0
 }

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -1,0 +1,1 @@
+package github

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -1,1 +1,83 @@
 package github
+
+import (
+	"github.com/saucelabs/saucectl/cli/version"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGithub_isUpdateRequired(t *testing.T) {
+	testCases := []struct {
+		current string
+		remote  string
+		want    bool
+	}{
+		{current: "v0.1.0", remote: "v0.1.1", want: true},
+		{current: "v0.2.0", remote: "v0.1.1", want: false},
+		{current: "v0.1.0", remote: "v0.1.0", want: false},
+		{current: "v0.0.0+unknown", remote: "v0.1.0", want: true},
+	}
+	for _, tt := range testCases {
+		got := isUpdateRequired(tt.current, tt.remote)
+		if tt.want != got {
+			t.Errorf("%s <=> %s, want: %v, got: %v", tt.current, tt.remote, tt.want, got)
+		}
+	}
+}
+
+func TestClient_HasUpdateAvailable(t *testing.T) {
+	testCases := []struct {
+		body    []byte
+		current string
+		want    string
+		wantErr error
+	}{
+		{
+			body:    []byte(`{"tag_name": "v0.43.0", "name": "v0.43.0"}`),
+			current: "v0.1.0",
+			want:    "v0.43.0",
+			wantErr: nil,
+		},
+		{
+			body:    []byte(`{"tag_name": "v0.43.0", "name": "v0.43.0"}`),
+			current: "v0.44.0",
+			want:    "",
+			wantErr: nil,
+		},
+		{
+			body:    []byte(`{"tag_name": "v0.43.0", "name": "v0.43.0"}`),
+			current: "v0.0.0+unknown",
+			want:    "v0.43.0",
+			wantErr: nil,
+		},
+	}
+	for idx, tt := range testCases {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/repos/saucelabs/saucectl/releases/latest":
+				w.WriteHeader(200)
+				w.Write(tt.body)
+			default:
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}))
+		gh := Client{
+			HTTPClient: &http.Client{Timeout: 1 * time.Second},
+			URL:        ts.URL,
+		}
+
+		// Forcing current version
+		version.Version = tt.current
+		got, err := gh.HasUpdateAvailable()
+
+		if err != tt.wantErr {
+			t.Errorf("Case %d (err): want: %v, got: %v", idx, tt.wantErr, err)
+		}
+		if got != tt.want {
+			t.Errorf("Case %d: want: %v, got: %v", idx, tt.want, got)
+		}
+		ts.Close()
+	}
+}


### PR DESCRIPTION
## Proposed changes

Add a warning when a newer version of saucectl has been made available.
Timeout limited to `2s` to prevent having an impact on user tests (silently fails).

```
➭ ./saucectl  run
Running version v0.0.0+unknown
15:22:08 WRN An update of saucectl is available (v0.44.0)
15:22:08 INF Reading config file config=.sauce/config.yml
[...]
➭ 
```

```
➭ ./saucectl  run
Running version v0.43.0
15:26:14 WRN An update of saucectl is available (v0.44.0)
15:26:14 INF Reading config file config=.sauce/config.yml
[...]
➭
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->