### PR TITLE
Refactor espresso run command handling

### DIFF
--- a/cli/command/run/espresso.go
+++ b/cli/command/run/espresso.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/cli/command"
+	"github.com/saucelabs/saucectl/cli/version"
 	"github.com/saucelabs/saucectl/internal/appstore"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/credentials"
@@ -47,6 +48,10 @@ func NewEspressoCmd(cli *command.SauceCtlCli) *cobra.Command {
 
 // runEspressoCmd runs the espresso 'run' command.
 func runEspressoCmd(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, error) {
+	println("Running version", version.Version)
+	checkForUpdates()
+	go awaitGlobalTimeout()
+
 	creds := credentials.Get()
 	if !creds.IsValid() {
 		color.Red("\nSauceCTL requires a valid Sauce Labs account!\n\n")

--- a/cli/command/run/espresso.go
+++ b/cli/command/run/espresso.go
@@ -1,0 +1,171 @@
+package run
+
+import (
+	"errors"
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/cli/command"
+	"github.com/saucelabs/saucectl/internal/appstore"
+	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/espresso"
+	"github.com/saucelabs/saucectl/internal/rdc"
+	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/resto"
+	"github.com/saucelabs/saucectl/internal/saucecloud"
+	"github.com/saucelabs/saucectl/internal/sentry"
+	"github.com/saucelabs/saucectl/internal/testcomposer"
+	"github.com/spf13/cobra"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// NewEspressoCmd creates the 'run' command for espresso.
+func NewEspressoCmd(cli *command.SauceCtlCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:              "espresso",
+		Short:            "Run espresso tests",
+		Hidden:           true, // TODO reveal command once ready
+		TraverseChildren: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			exitCode, err := runEspressoCmd(cmd, cli, args)
+			if err != nil {
+				log.Err(err).Msg("failed to execute run command")
+				sentry.CaptureError(err, sentry.Scope{
+					Username:   credentials.Get().Username,
+					ConfigFile: cfgFilePath,
+				})
+			}
+			os.Exit(exitCode)
+		},
+	}
+
+	return cmd
+}
+
+// runEspressoCmd runs the espresso 'run' command.
+func runEspressoCmd(cmd *cobra.Command, cli *command.SauceCtlCli, args []string) (int, error) {
+	creds := credentials.Get()
+	if !creds.IsValid() {
+		color.Red("\nSauceCTL requires a valid Sauce Labs account!\n\n")
+		fmt.Println(`Set up your credentials by running:
+> saucectl configure`)
+		println()
+		return 1, fmt.Errorf("no credentials set")
+	}
+
+	if cfgLogDir == defaultLogFir {
+		pwd, _ := os.Getwd()
+		cfgLogDir = filepath.Join(pwd, "logs")
+	}
+	cli.LogDir = cfgLogDir
+	log.Info().Str("config", cfgFilePath).Msg("Reading config file")
+
+	d, err := config.Describe(cfgFilePath)
+	if err != nil {
+		return 1, err
+	}
+
+	tc := testcomposer.Client{
+		HTTPClient:  &http.Client{Timeout: testComposerTimeout},
+		URL:         "", // updated later once region is determined
+		Credentials: creds,
+	}
+
+	rs := resto.Client{
+		HTTPClient: &http.Client{Timeout: restoTimeout},
+		URL:        "", // updated later once region is determined
+		Username:   creds.Username,
+		AccessKey:  creds.AccessKey,
+	}
+
+	rc := rdc.Client{
+		HTTPClient: &http.Client{
+			Timeout: rdcTimeout,
+		},
+		Username:  creds.Username,
+		AccessKey: creds.AccessKey,
+	}
+
+	as := appstore.New("", creds.Username, creds.AccessKey, appStoreTimeout)
+
+	if d.Kind == config.KindEspresso && d.APIVersion == config.VersionV1Alpha {
+		return runEspresso(cmd, tc, rs, rc, as)
+	}
+
+	return 1, errors.New("unknown framework configuration")
+}
+
+func runEspresso(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, rc rdc.Client, as *appstore.AppStore) (int, error) {
+	p, err := espresso.FromFile(cfgFilePath)
+	if err != nil {
+		return 1, err
+	}
+	p.Sauce.Metadata.ExpandEnv()
+	applyDefaultValues(&p.Sauce)
+	overrideCliParameters(cmd, &p.Sauce)
+
+	// TODO - add dry-run mode
+	regio := region.FromString(p.Sauce.Region)
+	if regio == region.None {
+		log.Error().Str("region", regionFlag).Msg("Unable to determine sauce region.")
+		return 1, errors.New("no sauce region set")
+	}
+
+	err = espresso.Validate(p)
+	if err != nil {
+		return 1, err
+	}
+
+	if cmd.Flags().Lookup("suite").Changed {
+		if err := filterEspressoSuite(&p); err != nil {
+			return 1, err
+		}
+	}
+
+	tc.URL = regio.APIBaseURL()
+	rs.URL = regio.APIBaseURL()
+	as.URL = regio.APIBaseURL()
+	rc.URL = regio.APIBaseURL()
+
+	rs.ArtifactConfig = p.Artifacts.Download
+	rc.ArtifactConfig = p.Artifacts.Download
+
+	return runEspressoInCloud(p, regio, tc, rs, rc, as)
+}
+
+func runEspressoInCloud(p espresso.Project, regio region.Region, tc testcomposer.Client, rs resto.Client, rc rdc.Client, as *appstore.AppStore) (int, error) {
+	log.Info().Msg("Running Espresso in Sauce Labs")
+	printTestEnv("sauce")
+
+	r := saucecloud.EspressoRunner{
+		Project: p,
+		CloudRunner: saucecloud.CloudRunner{
+			ProjectUploader:       as,
+			JobStarter:            &tc,
+			JobReader:             &rs,
+			RDCJobReader:          &rc,
+			JobStopper:            &rs,
+			JobWriter:             &tc,
+			CCYReader:             &rs,
+			TunnelService:         &rs,
+			Region:                regio,
+			ShowConsoleLog:        false,
+			ArtifactDownloader:    &rs,
+			RDCArtifactDownloader: &rc,
+		},
+	}
+	return r.RunProject()
+}
+
+func filterEspressoSuite(c *espresso.Project) error {
+	for _, s := range c.Suites {
+		if s.Name == suiteName {
+			c.Suites = []espresso.Suite{s}
+			return nil
+		}
+	}
+	return fmt.Errorf("suite name '%s' is invalid", suiteName)
+}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Simple refactor to prepare for the CLI Driven Execution (no real functional changes). Cleaned up a few descriptions here and there as well along the way.
The new subcommand will remain hidden until it's officially ready.

This is how the help will look like with these changes:
```
~> saucectl help
Please refer to our examples for how to setup saucectl for your project:

- https://github.com/saucelabs/saucectl-cypress-example
- https://github.com/saucelabs/saucectl-espresso-example
- https://github.com/saucelabs/saucectl-playwright-example
- https://github.com/saucelabs/saucectl-puppeteer-example
- https://github.com/saucelabs/saucectl-testcafe-example
- https://github.com/saucelabs/saucectl-xcuitest-example

Usage:
  saucectl [command]

Available Commands:
  configure   Configure your Sauce Labs credentials
  help        Help about any command
  run         Runs tests on Sauce Labs
  signup      Signup for Sauce Labs

Flags:
  -h, --help      help for saucectl
      --verbose   turn on verbose logging
  -v, --version   print version

Use "saucectl [command] --help" for more information about a command.
```

```
~> saucectl run -h
Runs tests on Sauce Labs

Usage:
  saucectl run [flags]

Flags:
      --ccy int                Concurrency specifies how many suites are run at the same time. (default 2)
  -c, --config string          Specifies which config file to use (default ".sauce/config.yml")
      --dry-run                Simulate a test run without actually running any tests.
  -e, --env stringToString     Set environment variables, e.g. -e foo=bar. (default [])
  -h, --help                   help for run
  -l, --logDir string          log path (default "<cwd>/logs")
  -r, --region string          The sauce labs region. (default: us-west-1)
      --sauceignore string     Specifies the path to the .sauceignore file.
      --show-console-log       Shows suites console.log locally. By default console.log is only shown on failures.
      --suite string           Run specified test suite.
      --test-env string        Specifies the environment in which the tests should run. Choice: docker|sauce.
      --test-env-silent        Skips the test environment announcement.
  -t, --timeout duration       Global timeout that limits how long saucectl can run in total. Supports duration values like '10s', '30m' etc. (default: no timeout)
      --tunnel-id string       Sets the sauce-connect tunnel ID to be used for the run.
      --tunnel-parent string   Sets the sauce-connect tunnel parent to be used for the run.

Global Flags:
      --verbose   turn on verbose logging
```