### PR TITLE
Extend espresso run with additional espresso specific flags

### DIFF
--- a/cli/flags/device.go
+++ b/cli/flags/device.go
@@ -1,0 +1,68 @@
+package flags
+
+import (
+	"encoding/csv"
+	"fmt"
+	"github.com/saucelabs/saucectl/internal/config"
+	"strconv"
+	"strings"
+)
+
+// Device represents the RDC device configuration.
+type Device struct {
+	config.Device
+	Changed bool
+}
+
+// String returns a string represenation of the device.
+func (d Device) String() string {
+	return fmt.Sprintf("%v", d.Device)
+}
+
+// Set sets the device to the values present in s.
+// The input has to be a comma separated string in the format of "key=value,key2=value2".
+// This method is called by cobra when CLI flags are parsed.
+func (d *Device) Set(s string) error {
+	d.Changed = true
+
+	rec, err := csv.NewReader(strings.NewReader(s)).Read()
+	if err != nil {
+		return err
+	}
+
+	for _, v := range rec {
+		vs := strings.Split(v, "=")
+		val := vs[1]
+		switch vs[0] {
+		case "id":
+			d.ID = val
+		case "name":
+			d.Name = val
+		case "platformName":
+			d.PlatformName = val
+		case "platformVersion":
+			d.PlatformVersion = val
+		case "carrierConnectivity":
+			b, err := strconv.ParseBool(val)
+			if err != nil {
+				return err
+			}
+			d.Options.CarrierConnectivity = b
+		case "deviceType":
+			d.Options.DeviceType = val
+		case "private":
+			b, err := strconv.ParseBool(val)
+			if err != nil {
+				return err
+			}
+			d.Options.Private = b
+		}
+	}
+
+	return nil
+}
+
+// Type returns the value type.
+func (d Device) Type() string {
+	return "device"
+}

--- a/cli/flags/device.go
+++ b/cli/flags/device.go
@@ -16,7 +16,10 @@ type Device struct {
 
 // String returns a string represenation of the device.
 func (d Device) String() string {
-	return fmt.Sprintf("%v", d.Device)
+	if !d.Changed {
+		return ""
+	}
+	return fmt.Sprintf("%+v", d.Device)
 }
 
 // Set sets the device to the values present in s.

--- a/cli/flags/emulator.go
+++ b/cli/flags/emulator.go
@@ -1,0 +1,54 @@
+package flags
+
+import (
+	"encoding/csv"
+	"fmt"
+	"github.com/saucelabs/saucectl/internal/config"
+	"strings"
+)
+
+// Emulator represents the emulator configuration.
+type Emulator struct {
+	config.Emulator
+	Changed bool
+}
+
+// String returns a string represenation of the emulator.
+func (e Emulator) String() string {
+	return fmt.Sprintf("%v", e.Emulator)
+}
+
+// Set sets the emulator to the values present in s.
+// The input has to be a comma separated string in the format of "key=value,key2=value2".
+// This method is called by cobra when CLI flags are parsed.
+func (e *Emulator) Set(s string) error {
+	e.Changed = true
+
+	rec, err := csv.NewReader(strings.NewReader(s)).Read()
+	if err != nil {
+		return err
+	}
+
+	// TODO consider defaulting this in a common place (between config and CLI flags)
+	e.PlatformName = "Android"
+
+	for _, v := range rec {
+		vs := strings.Split(v, "=")
+		val := vs[1]
+		switch vs[0] {
+		case "name":
+			e.Name = val
+		case "orientation":
+			e.Orientation = val
+		case "platformVersion":
+			e.PlatformVersions = []string{val}
+		}
+	}
+
+	return nil
+}
+
+// Type returns the value type.
+func (e Emulator) Type() string {
+	return "emulator"
+}

--- a/cli/flags/emulator.go
+++ b/cli/flags/emulator.go
@@ -15,7 +15,10 @@ type Emulator struct {
 
 // String returns a string represenation of the emulator.
 func (e Emulator) String() string {
-	return fmt.Sprintf("%v", e.Emulator)
+	if !e.Changed {
+		return ""
+	}
+	return fmt.Sprintf("%+v", e.Emulator)
 }
 
 // Set sets the emulator to the values present in s.

--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -33,8 +33,8 @@ type TestOptions struct {
 	Package    string   `yaml:"package,omitempty" json:"package"`
 	Size       string   `yaml:"size,omitempty" json:"size"`
 	Annotation string   `yaml:"annotation,omitempty" json:"annotation"`
-	ShardIndex *int     `yaml:"shardIndex,omitempty" json:"shardIndex"`
-	NumShards  *int     `yaml:"numShards,omitempty" json:"numShards"`
+	ShardIndex int     `yaml:"shardIndex,omitempty" json:"shardIndex"`
+	NumShards  int     `yaml:"numShards,omitempty" json:"numShards"`
 }
 
 // Suite represents the espresso test suite configuration.
@@ -115,9 +115,6 @@ func Validate(p Project) error {
 		}
 		if err := validateEmulators(suite.Name, suite.Emulators); err != nil {
 			return err
-		}
-		if suite.TestOptions.NumShards != nil && suite.TestOptions.ShardIndex == nil {
-			return fmt.Errorf("missing shardIndex")
 		}
 	}
 

--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -112,6 +112,18 @@ func enumerateDevicesAndEmulators(devices []config.Device, emulators []config.Em
 
 // startJob add the job to the list for the workers.
 func (r *EspressoRunner) startJob(jobOpts chan<- job.StartOptions, s espresso.Suite, appFileID, testAppFileID string, d deviceConfig) {
+	jto := job.TestOptions{
+		NotClass:   s.TestOptions.NotClass,
+		Class:      s.TestOptions.Class,
+		Annotation: s.TestOptions.Annotation,
+		Size:       s.TestOptions.Size,
+		Package:    s.TestOptions.Package,
+	}
+	if s.TestOptions.NumShards > 1 {
+		jto.NumShards = &s.TestOptions.NumShards
+		jto.ShardIndex = &s.TestOptions.ShardIndex
+	}
+
 	jobOpts <- job.StartOptions{
 		DisplayName:       s.Name,
 		ConfigFilePath:    r.Project.ConfigFilePath,
@@ -132,15 +144,7 @@ func (r *EspressoRunner) startJob(jobOpts chan<- job.StartOptions, s espresso.Su
 			Parent: r.Project.Sauce.Tunnel.Parent,
 		},
 		Experiments: r.Project.Sauce.Experiments,
-		TestOptions: job.TestOptions{
-			NotClass:   s.TestOptions.NotClass,
-			Class:      s.TestOptions.Class,
-			Annotation: s.TestOptions.Annotation,
-			Size:       s.TestOptions.Size,
-			Package:    s.TestOptions.Package,
-			NumShards:  s.TestOptions.NumShards,
-			ShardIndex: s.TestOptions.ShardIndex,
-		},
+		TestOptions: jto,
 
 		// RDC Specific flags
 		RealDevice:        d.isRealDevice,


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Extend espresso `run` with additional espresso specific flags.
This is not the final PR, as the presence of a config file is still required and additional work is needed in that area.