### PR TITLE
Remove support for metadata.name

### DIFF
--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -4,7 +4,6 @@ sauce:
   region: us-west-1
   concurrency: 10
   metadata:
-    name: Testing Cypress Support
     tags:
       - e2e
     build: "$BUILD_ID"

--- a/.sauce/espresso.yml
+++ b/.sauce/espresso.yml
@@ -4,10 +4,9 @@ sauce:
   region: us-west-1
   concurrency: 10
   metadata:
-    name: Testing Espresso Support
     tags:
       - e2e
-  build: "$BUILD_ID"
+    build: "$BUILD_ID"
 espresso:
   app: ./tests/e2e/espresso/calc.apk
   testApp: ./tests/e2e/espresso/calc-success.apk

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -4,7 +4,6 @@ sauce:
   region: us-west-1
   concurrency: 10
   metadata:
-    name: Testing Playwright Support
     tags:
       - e2e
     build: "$BUILD_ID"

--- a/.sauce/puppeteer.yml
+++ b/.sauce/puppeteer.yml
@@ -4,7 +4,6 @@ sauce:
   region: us-west-1
   concurrency: 10
   metadata:
-    name: Testing Puppeteer Support
     tags:
       - e2e
     build: "$BUILD_ID"

--- a/.sauce/testcafe.yml
+++ b/.sauce/testcafe.yml
@@ -4,7 +4,6 @@ sauce:
   region: us-west-1
   concurrency: 10
   metadata:
-    name: Testing Testcafe Support
     tags:
       - e2e
     build: "$BUILD_ID"

--- a/.sauce/xcuitest.yml
+++ b/.sauce/xcuitest.yml
@@ -4,7 +4,6 @@ sauce:
   region: us-west-1
   concurrency: 1
   metadata:
-    name: Testing XCUITEST Support
     tags:
       - e2e
       - release team

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,6 @@ import (
 
 // Metadata describes job metadata
 type Metadata struct {
-	Name  string   `yaml:"name" json:"name"`
 	Tags  []string `yaml:"tags" json:"tags,omitempty"`
 	Build string   `yaml:"build" json:"build"`
 }
@@ -172,7 +171,6 @@ func Describe(cfgPath string) (TypeDef, error) {
 
 // ExpandEnv expands environment variables inside metadata fields.
 func (m *Metadata) ExpandEnv() {
-	m.Name = os.ExpandEnv(m.Name)
 	m.Build = os.ExpandEnv(m.Build)
 	for i, v := range m.Tags {
 		m.Tags[i] = os.ExpandEnv(v)

--- a/internal/config/example_test.go
+++ b/internal/config/example_test.go
@@ -11,7 +11,6 @@ func ExampleMetadata_ExpandEnv() {
 	os.Setenv("tbuild", "Bob")
 
 	m := Metadata{
-		Name:  "Test $tname",
 		Tags:  []string{"$ttag"},
 		Build: "Build $tbuild",
 	}

--- a/internal/config/example_test.go
+++ b/internal/config/example_test.go
@@ -18,5 +18,5 @@ func ExampleMetadata_ExpandEnv() {
 	m.ExpandEnv()
 
 	fmt.Println(m)
-	// Output: {Test Envy [xp1] Build Bob}
+	// Output: {[xp1] Build Bob}
 }

--- a/internal/saucecloud/cypress.go
+++ b/internal/saucecloud/cypress.go
@@ -83,7 +83,7 @@ func (r *CypressRunner) runSuites(fileID string) bool {
 				BrowserName:      s.Browser,
 				BrowserVersion:   s.BrowserVersion,
 				PlatformName:     s.PlatformName,
-				Name:             r.Project.Sauce.Metadata.Name + " - " + s.Name,
+				Name:             s.Name,
 				Build:            r.Project.Sauce.Metadata.Build,
 				Tags:             r.Project.Sauce.Metadata.Tags,
 				Tunnel: job.TunnelOptions{

--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -150,7 +150,7 @@ func (r *EspressoRunner) startJob(jobOpts chan<- job.StartOptions, s espresso.Su
 		DeviceID:          d.ID,
 		DeviceName:        d.name,
 		DeviceOrientation: d.orientation,
-		Name:              r.Project.Sauce.Metadata.Name + " - " + s.Name,
+		Name:              s.Name,
 		Build:             r.Project.Sauce.Metadata.Build,
 		Tags:              r.Project.Sauce.Metadata.Tags,
 		Tunnel: job.TunnelOptions{

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -61,6 +61,8 @@ func (r *PlaywrightRunner) runSuites(fileID string) bool {
 	}
 	defer close(results)
 
+	// TODO fix jobnames. Don't need to hyphenate empty metadata name fields
+
 	// Submit suites to work on.
 	go func() {
 		for _, s := range r.Project.Suites {
@@ -78,7 +80,7 @@ func (r *PlaywrightRunner) runSuites(fileID string) bool {
 				BrowserName:      s.Params.BrowserName,
 				BrowserVersion:   "",
 				PlatformName:     s.PlatformName,
-				Name:             r.Project.Sauce.Metadata.Name + " - " + s.Name,
+				Name:             s.Name,
 				Build:            r.Project.Sauce.Metadata.Build,
 				Tags:             r.Project.Sauce.Metadata.Tags,
 				Tunnel: job.TunnelOptions{

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -61,8 +61,6 @@ func (r *PlaywrightRunner) runSuites(fileID string) bool {
 	}
 	defer close(results)
 
-	// TODO fix jobnames. Don't need to hyphenate empty metadata name fields
-
 	// Submit suites to work on.
 	go func() {
 		for _, s := range r.Project.Suites {

--- a/internal/saucecloud/testcafe.go
+++ b/internal/saucecloud/testcafe.go
@@ -79,7 +79,7 @@ func (r *TestcafeRunner) runSuites(fileID string) bool {
 							PlatformName:     d.PlatformName,
 							PlatformVersion:  pv,
 							DeviceName:       d.Name,
-							Name:             fmt.Sprintf("%s - %s", r.Project.Sauce.Metadata.Name, s.Name),
+							Name:             s.Name,
 							Build:            r.Project.Sauce.Metadata.Build,
 							Tags:             r.Project.Sauce.Metadata.Tags,
 							Tunnel: job.TunnelOptions{
@@ -103,7 +103,7 @@ func (r *TestcafeRunner) runSuites(fileID string) bool {
 					BrowserName:      s.BrowserName,
 					BrowserVersion:   s.BrowserVersion,
 					PlatformName:     s.PlatformName,
-					Name:             fmt.Sprintf("%s - %s", r.Project.Sauce.Metadata.Name, s.Name),
+					Name:             s.Name,
 					Build:            r.Project.Sauce.Metadata.Build,
 					Tags:             r.Project.Sauce.Metadata.Tags,
 					Tunnel: job.TunnelOptions{

--- a/internal/saucecloud/xcuitest.go
+++ b/internal/saucecloud/xcuitest.go
@@ -104,7 +104,7 @@ func (r *XcuitestRunner) startJob(jobOpts chan<- job.StartOptions, appFileID, te
 		PlatformVersion:  d.PlatformVersion,
 		DeviceName:       d.Name,
 		DeviceID:         d.ID,
-		Name:             r.Project.Sauce.Metadata.Name + " - " + s.Name,
+		Name:             s.Name,
 		Build:            r.Project.Sauce.Metadata.Build,
 		Tags:             r.Project.Sauce.Metadata.Tags,
 		Tunnel: job.TunnelOptions{


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Remove support for `metadata.name`. Job name == suite name.