### PR TITLE
[DEVX-1015] Auto sharding for espresso

### DIFF
--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -65,14 +65,7 @@ func NewEspressoCmd() *cobra.Command {
 	f.StringVar(&lflags.TestOptions.Package, "testOptions.package", "", "Include package")
 	f.StringVar(&lflags.TestOptions.Size, "testOptions.size", "", "Include tests based on size")
 	f.StringVar(&lflags.TestOptions.Annotation, "testOptions.annotation", "", "Include tests based on the annotation")
-	var shardIndex, numShards int
-	f.IntVar(&numShards, "testOptions.numShards", 0, "Total number of shards")
-	f.IntVar(&shardIndex, "testOptions.shardIndex", -1, "The shard index for this particular run")
-
-	lflags.TestOptions.NumShards = &numShards
-	if shardIndex >= 0 {
-		lflags.TestOptions.ShardIndex = &shardIndex
-	}
+	f.IntVar(&lflags.TestOptions.NumShards, "testOptions.numShards", 0, "Total number of shards")
 
 	// Emulators and Devices
 	f.Var(&lflags.Emulator, "emulator", "Specifies the emulator to use for testing")

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -3,6 +3,8 @@ package run
 import (
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/appstore"
 	"github.com/saucelabs/saucectl/internal/config"
@@ -16,7 +18,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/sentry"
 	"github.com/saucelabs/saucectl/internal/testcomposer"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 type espressoFlags struct {
@@ -64,8 +65,14 @@ func NewEspressoCmd() *cobra.Command {
 	f.StringVar(&lflags.TestOptions.Package, "testOptions.package", "", "Include package")
 	f.StringVar(&lflags.TestOptions.Size, "testOptions.size", "", "Include tests based on size")
 	f.StringVar(&lflags.TestOptions.Annotation, "testOptions.annotation", "", "Include tests based on the annotation")
-	f.IntVar(&lflags.TestOptions.ShardIndex, "testOptions.shardIndex", 0, "The shard index for this particular run")
-	f.IntVar(&lflags.TestOptions.NumShards, "testOptions.numShards", 0, "Total number of shards")
+	var shardIndex, numShards int
+	f.IntVar(&numShards, "testOptions.numShards", 0, "Total number of shards")
+	f.IntVar(&shardIndex, "testOptions.shardIndex", -1, "The shard index for this particular run")
+
+	lflags.TestOptions.NumShards = &numShards
+	if shardIndex >= 0 {
+		lflags.TestOptions.ShardIndex = &shardIndex
+	}
 
 	// Emulators and Devices
 	f.Var(&lflags.Emulator, "emulator", "Specifies the emulator to use for testing")

--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -42,8 +42,8 @@ type TestOptions struct {
 	Package          string   `yaml:"package,omitempty" json:"package"`
 	Size             string   `yaml:"size,omitempty" json:"size"`
 	Annotation       string   `yaml:"annotation,omitempty" json:"annotation"`
-	ShardIndex       *int     `yaml:"shardIndex,omitempty" json:"shardIndex"`
-	NumShards        *int     `yaml:"numShards,omitempty" json:"numShards"`
+	ShardIndex       int      `json:"shardIndex"`
+	NumShards        int      `yaml:"numShards,omitempty" json:"numShards"`
 	ClearPackageData bool     `yaml:"clearPackageData,omitempty" json:"clearPackageData"`
 }
 

--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -42,8 +42,8 @@ type TestOptions struct {
 	Package          string   `yaml:"package,omitempty" json:"package"`
 	Size             string   `yaml:"size,omitempty" json:"size"`
 	Annotation       string   `yaml:"annotation,omitempty" json:"annotation"`
-	ShardIndex       int      `yaml:"shardIndex,omitempty" json:"shardIndex"`
-	NumShards        int      `yaml:"numShards,omitempty" json:"numShards"`
+	ShardIndex       *int     `yaml:"shardIndex,omitempty" json:"shardIndex"`
+	NumShards        *int     `yaml:"numShards,omitempty" json:"numShards"`
 	ClearPackageData bool     `yaml:"clearPackageData,omitempty" json:"clearPackageData"`
 }
 

--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -74,9 +74,20 @@ func (r *EspressoRunner) runSuites(appFileID string, testAppFileID string) bool 
 	jobsCount := r.calculateJobsCount(r.Project.Suites)
 	go func() {
 		for _, s := range r.Project.Suites {
-			for _, c := range enumerateDevicesAndEmulators(s.Devices, s.Emulators) {
-				log.Debug().Str("suite", s.Name).Str("device", fmt.Sprintf("%v", c)).Msg("Starting job")
-				r.startJob(jobOpts, s, appFileID, testAppFileID, c)
+			// Automatically apply ShardIndex if not specified
+			if s.TestOptions.NumShards != nil && s.TestOptions.ShardIndex == nil {
+				for i := 0; i <= *s.TestOptions.NumShards; i++ {
+					s.TestOptions.ShardIndex = &i
+					for _, c := range enumerateDevicesAndEmulators(s.Devices, s.Emulators) {
+						log.Debug().Str("suite", s.Name).Str("device", fmt.Sprintf("%v", c)).Msg("Starting job")
+						r.startJob(jobOpts, s, appFileID, testAppFileID, c)
+					}
+				}
+			} else {
+				for _, c := range enumerateDevicesAndEmulators(s.Devices, s.Emulators) {
+					log.Debug().Str("suite", s.Name).Str("device", fmt.Sprintf("%v", c)).Msg("Starting job")
+					r.startJob(jobOpts, s, appFileID, testAppFileID, c)
+				}
 			}
 		}
 		close(jobOpts)
@@ -133,9 +144,9 @@ func (r *EspressoRunner) startJob(jobOpts chan<- job.StartOptions, s espresso.Su
 		Size:       s.TestOptions.Size,
 		Package:    s.TestOptions.Package,
 	}
-	if s.TestOptions.NumShards > 1 {
-		jto.NumShards = &s.TestOptions.NumShards
-		jto.ShardIndex = &s.TestOptions.ShardIndex
+	if *s.TestOptions.NumShards > 1 {
+		jto.NumShards = s.TestOptions.NumShards
+		jto.ShardIndex = s.TestOptions.ShardIndex
 	}
 	if s.TestOptions.ClearPackageData {
 		jto.ClearPackageData = &s.TestOptions.ClearPackageData
@@ -175,6 +186,9 @@ func (r *EspressoRunner) calculateJobsCount(suites []espresso.Suite) int {
 	jobsCount := 0
 	for _, s := range suites {
 		jobsCount += len(enumerateDevicesAndEmulators(s.Devices, s.Emulators))
+		if s.TestOptions.NumShards != nil && s.TestOptions.ShardIndex == nil {
+			jobsCount = jobsCount * *s.TestOptions.NumShards
+		}
 	}
 	return jobsCount
 }

--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -145,9 +145,11 @@ func (r *EspressoRunner) startJob(jobOpts chan<- job.StartOptions, s espresso.Su
 		Size:       s.TestOptions.Size,
 		Package:    s.TestOptions.Package,
 	}
-	if *s.TestOptions.NumShards > 1 {
+	displayName := s.Name
+	if s.TestOptions.NumShards != nil && *s.TestOptions.NumShards > 0 {
 		jto.NumShards = s.TestOptions.NumShards
 		jto.ShardIndex = s.TestOptions.ShardIndex
+		displayName = fmt.Sprintf("%s shard #%d of %d", displayName, *jto.ShardIndex, *jto.NumShards)
 	}
 	if s.TestOptions.ClearPackageData {
 		jto.ClearPackageData = &s.TestOptions.ClearPackageData
@@ -165,7 +167,7 @@ func (r *EspressoRunner) startJob(jobOpts chan<- job.StartOptions, s espresso.Su
 		DeviceID:          d.ID,
 		DeviceName:        d.name,
 		DeviceOrientation: d.orientation,
-		Name:              s.Name,
+		Name:              displayName,
 		Build:             r.Project.Sauce.Metadata.Build,
 		Tags:              r.Project.Sauce.Metadata.Tags,
 		Tunnel: job.TunnelOptions{

--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -76,8 +76,9 @@ func (r *EspressoRunner) runSuites(appFileID string, testAppFileID string) bool 
 		for _, s := range r.Project.Suites {
 			// Automatically apply ShardIndex if not specified
 			if s.TestOptions.NumShards != nil && s.TestOptions.ShardIndex == nil {
-				for i := 0; i <= *s.TestOptions.NumShards; i++ {
-					s.TestOptions.ShardIndex = &i
+				for i := 0; i < *s.TestOptions.NumShards; i++ {
+					sindex := i
+					s.TestOptions.ShardIndex = &sindex
 					for _, c := range enumerateDevicesAndEmulators(s.Devices, s.Emulators) {
 						log.Debug().Str("suite", s.Name).Str("device", fmt.Sprintf("%v", c)).Msg("Starting job")
 						r.startJob(jobOpts, s, appFileID, testAppFileID, c)

--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -149,7 +149,7 @@ func (r *EspressoRunner) startJob(jobOpts chan<- job.StartOptions, s espresso.Su
 	if s.TestOptions.NumShards != nil && *s.TestOptions.NumShards > 0 {
 		jto.NumShards = s.TestOptions.NumShards
 		jto.ShardIndex = s.TestOptions.ShardIndex
-		displayName = fmt.Sprintf("%s shard #%d of %d", displayName, *jto.ShardIndex, *jto.NumShards)
+		displayName = fmt.Sprintf("%s shard #%d", displayName, *jto.ShardIndex)
 	}
 	if s.TestOptions.ClearPackageData {
 		jto.ClearPackageData = &s.TestOptions.ClearPackageData

--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -148,7 +148,7 @@ func (r *EspressoRunner) startJob(jobOpts chan<- job.StartOptions, s espresso.Su
 	if s.TestOptions.NumShards > 0 {
 		jto.NumShards = &s.TestOptions.NumShards
 		jto.ShardIndex = &s.TestOptions.ShardIndex
-		displayName = fmt.Sprintf("%s shard #%d", displayName, *jto.ShardIndex)
+		displayName = fmt.Sprintf("%s (shard %d/%d)", displayName, *jto.ShardIndex+1, *jto.NumShards)
 	}
 	if s.TestOptions.ClearPackageData {
 		jto.ClearPackageData = &s.TestOptions.ClearPackageData

--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -155,7 +155,7 @@ func (r *EspressoRunner) startJob(jobOpts chan<- job.StartOptions, s espresso.Su
 	}
 
 	jobOpts <- job.StartOptions{
-		DisplayName:       s.Name,
+		DisplayName:       displayName,
 		ConfigFilePath:    r.Project.ConfigFilePath,
 		App:               fmt.Sprintf("storage:%s", appFileID),
 		Suite:             fmt.Sprintf("storage:%s", testAppFileID),

--- a/internal/saucecloud/espresso_test.go
+++ b/internal/saucecloud/espresso_test.go
@@ -27,10 +27,6 @@ func TestEspresso_GetSuiteNames(t *testing.T) {
 	assert.Equal(t, "suite1, suite2, suite3", runner.getSuiteNames())
 }
 
-func createIntPointer(val int) *int {
-	return &val
-}
-
 func TestEspressoRunner_CalculateJobCount(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -57,36 +53,13 @@ func TestEspressoRunner_CalculateJobCount(t *testing.T) {
 			wants: 3,
 		},
 		{
-			name:  "should ignore NumShards if ShardIndex is defined",
-			wants: 3,
-			suites: []espresso.Suite{
-				{
-					Name: "valid espresso project",
-					TestOptions: espresso.TestOptions{
-						NumShards:  createIntPointer(3),
-						ShardIndex: createIntPointer(1),
-					},
-					Emulators: []config.Emulator{
-						{
-							Name:             "Android GoogleApi Emulator",
-							PlatformVersions: []string{"11.0", "10.0"},
-						},
-						{
-							Name:             "Android Emulator",
-							PlatformVersions: []string{"11.0"},
-						},
-					},
-				},
-			},
-		},
-		{
 			name:  "should multiply jobs by NumShards if defined",
 			wants: 9,
 			suites: []espresso.Suite{
 				{
 					Name: "valid espresso project",
 					TestOptions: espresso.TestOptions{
-						NumShards: createIntPointer(3),
+						NumShards: 3,
 					},
 					Emulators: []config.Emulator{
 						{


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
~~Make `shardIndex` optional~~ Remove `shardIndex` and instead if `numShards` is defined, create sharded jobs with `shardIndex` automatically set.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
The auto sharding will happen across all devices and emulators defined for a suite. e.g. if `numShards` is 2 and there are 2 devices (say, d1 and d2) and 2 emulators (say, e1 and e2) defined, 8 jobs will be created:

d1 (shard 1 of 2)
d1 (shard 2 of 2)

d2 (shard 1 of 2)
d2 (shard 2 of 2)

e1 (shard 1 of 2)
e1 (shard 2 of 2)

e2 (shard 1 of 2)
e2 (shard 2 of 2)

Not totally sure this is the desired behaviour though.