### PR TITLE
[DEVX-1052] Allow the user to skip the config entirely

### DIFF
--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -83,6 +83,7 @@ func runEspresso(cmd *cobra.Command, flags espressoFlags, tc testcomposer.Client
 	p.Sauce.Metadata.ExpandEnv()
 	applyGlobalFlags(cmd, &p.Sauce, &p.Artifacts)
 	applyEspressoFlags(&p, flags)
+	espresso.SetDefaults(&p)
 
 	regio := region.FromString(p.Sauce.Region)
 	if regio == region.None {

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -163,7 +163,7 @@ func preRun() error {
 	}
 
 	// TODO Performing the "kind" check in the global run method is necessary for as long as we support the global
-	// `saucectl run`, rather then the framework specific `saucectl run {framework}`. After we drop the global run
+	// `saucectl run`, rather than the framework specific `saucectl run {framework}`. After we drop the global run
 	// support, the run command does not need to the determine the config type any longer, and each framework should
 	// perform this validation on its own.
 	d, err := config.Describe(gFlags.cfgFilePath)

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -75,6 +75,7 @@ func runXcuitest(cmd *cobra.Command, flags xcuitestFlags, tc testcomposer.Client
 	p.Sauce.Metadata.ExpandEnv()
 	applyGlobalFlags(cmd, &p.Sauce, &p.Artifacts)
 	applyXCUITestFlags(&p, flags)
+	xcuitest.SetDefaults(&p)
 
 	regio := region.FromString(p.Sauce.Region)
 	if regio == region.None {
@@ -82,7 +83,6 @@ func runXcuitest(cmd *cobra.Command, flags xcuitestFlags, tc testcomposer.Client
 		return 1, errors.New("no sauce region set")
 	}
 
-	xcuitest.SetDeviceDefaultValues(&p)
 	err = xcuitest.Validate(p)
 	if err != nil {
 		return 1, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,7 +110,7 @@ type Docker struct {
 type Npm struct {
 	Registry  string            `yaml:"registry,omitempty" json:"registry,omitempty"`
 	Packages  map[string]string `yaml:"packages,omitempty" json:"packages"`
-	StrictSSL bool             `yaml:"strictSSL,omitempty" json:"strictSSL"`
+	StrictSSL bool              `yaml:"strictSSL,omitempty" json:"strictSSL"`
 }
 
 // Defaults represents default suite settings.
@@ -139,6 +139,10 @@ func readYaml(cfgFilePath string) ([]byte, error) {
 // Describe returns a description of the given config that is cfgPath.
 func Describe(cfgPath string) (TypeDef, error) {
 	var d TypeDef
+
+	if cfgPath == "" {
+		return TypeDef{}, nil
+	}
 
 	yamlFile, err := readYaml(cfgPath)
 	if err != nil {

--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -62,6 +62,10 @@ const Android = "Android"
 func FromFile(cfgPath string) (Project, error) {
 	var p Project
 
+	if cfgPath == "" {
+		return Project{}, nil
+	}
+
 	f, err := os.Open(cfgPath)
 	if err != nil {
 		return Project{}, fmt.Errorf("failed to locate project config: %v", err)
@@ -80,22 +84,24 @@ func FromFile(cfgPath string) (Project, error) {
 		return p, config.ErrUnknownCfg
 	}
 
+	return p, nil
+}
+
+// SetDefaults applies config defaults in case the user has left them blank.
+func SetDefaults(p *Project) {
 	if p.Sauce.Concurrency < 1 {
-		// Default concurrency is 2
 		p.Sauce.Concurrency = 2
 	}
 
-	for sidx, suite := range p.Suites {
-		for didx := range suite.Devices {
+	for i, suite := range p.Suites {
+		for j := range suite.Devices {
 			// Android is the only choice.
-			p.Suites[sidx].Devices[didx].PlatformName = Android
+			p.Suites[i].Devices[j].PlatformName = Android
 		}
-		for eidx := range suite.Emulators {
-			p.Suites[sidx].Emulators[eidx].PlatformName = Android
+		for j := range suite.Emulators {
+			p.Suites[i].Emulators[j].PlatformName = Android
 		}
 	}
-
-	return p, nil
 }
 
 // Validate validates basic configuration of the project and returns an error if any of the settings contain illegal

--- a/internal/espresso/config_test.go
+++ b/internal/espresso/config_test.go
@@ -183,7 +183,6 @@ suites:
 				Devices: []config.Device{
 					{
 						Name:            "Device name",
-						PlatformName:    Android,
 						PlatformVersion: "8.1",
 						Options: config.DeviceOptions{
 							DeviceType: "TABLET",
@@ -193,7 +192,6 @@ suites:
 				Emulators: []config.Emulator{
 					{
 						Name:         "Google Pixel C GoogleAPI Emulator",
-						PlatformName: Android,
 						PlatformVersions: []string{
 							"8.1",
 						},

--- a/internal/testcafe/config.go
+++ b/internal/testcafe/config.go
@@ -87,6 +87,10 @@ type Testcafe struct {
 func FromFile(cfgPath string) (Project, error) {
 	var p Project
 
+	if cfgPath == "" {
+		return Project{}, nil
+	}
+
 	f, err := os.Open(cfgPath)
 	if err != nil {
 		return p, fmt.Errorf("failed to locate project config: %v", err)

--- a/internal/xcuitest/config_test.go
+++ b/internal/xcuitest/config_test.go
@@ -38,9 +38,9 @@ func TestValidate(t *testing.T) {
 				},
 				Suites: []Suite{
 					{
-						Name:    "iphone",
+						Name: "iphone",
 						Devices: []config.Device{
-							{ Name: "iPhone.*"},
+							{Name: "iPhone.*"},
 						},
 					},
 				},
@@ -56,9 +56,9 @@ func TestValidate(t *testing.T) {
 				},
 				Suites: []Suite{
 					{
-						Name:    "iphone",
+						Name: "iphone",
 						Devices: []config.Device{
-							{ Name: "iPhone.*"},
+							{Name: "iPhone.*"},
 						},
 					},
 				},
@@ -241,56 +241,71 @@ suites:
 	}
 }
 
-func TestSetDeviceDefaultValues(t *testing.T) {
-	p := Project{
-		Suites: []Suite{
-			{
-				Name: "test suite 1",
-				Devices: []config.Device{
-					{
-						Name: "iPhone 11",
-						Options: config.DeviceOptions{
-							DeviceType: "phone",
-						},
-					},
-					{
-						Name: "iPhone XR",
-						Options: config.DeviceOptions{
-							DeviceType: "tablet",
-						},
-					},
-				},
-			},
+func TestSetDefaults_Platform(t *testing.T) {
+	type args struct {
+		Device config.Device
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "no platform specified",
+			args: args{Device: config.Device{}},
+			want: "iOS",
+		},
+		{
+			name: "wrong platform specified",
+			args: args{Device: config.Device{PlatformName: "myOS"}},
+			want: "iOS",
 		},
 	}
 
-	SetDeviceDefaultValues(&p)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Project{Suites: []Suite{{
+				Devices: []config.Device{tt.args.Device},
+			}}}
 
-	expected := Project{
-		Suites: []Suite{
-			{
-				Name: "test suite 1",
-				Devices: []config.Device{
-					{
-						Name:         "iPhone 11",
-						PlatformName: "iOS",
-						Options: config.DeviceOptions{
-							DeviceType: "PHONE",
-						},
-					},
-					{
-						Name:         "iPhone XR",
-						PlatformName: "iOS",
-						Options: config.DeviceOptions{
-							DeviceType: "TABLET",
-						},
-					},
-				},
-			},
+			SetDefaults(&p)
+
+			got := p.Suites[0].Devices[0].PlatformName
+			if got != tt.want {
+				t.Errorf("SetDefaults() got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetDefaults_DeviceType(t *testing.T) {
+	type args struct {
+		Device config.Device
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "device type is always uppercase",
+			args: args{Device: config.Device{Options: config.DeviceOptions{DeviceType: "phone"}}},
+			want: "PHONE",
 		},
 	}
 
-	if !reflect.DeepEqual(p, expected) {
-		t.Errorf("expected: %v, got: %v", expected, p)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Project{Suites: []Suite{{
+				Devices: []config.Device{tt.args.Device},
+			}}}
+
+			SetDefaults(&p)
+
+			got := p.Suites[0].Devices[0].Options.DeviceType
+			if got != tt.want {
+				t.Errorf("SetDefaults() got: %v, want: %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Make the config entirely optional by allowing the user to specify an empty config path `-c ""`. Before this change, a config, albeit a very empty one, was still required, even when using the "cli driven" approach.
At the moment, this is only available for `espresso`, `testcafe` and `xcuitest`. The docs for this have not been updated, because the entire "cli driven" approach is still a WIP.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->