### PR TITLE
[DEVX-1061] Fix jobs count calculation when using sharding

### DIFF
--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -185,14 +185,15 @@ func (r *EspressoRunner) startJob(jobOpts chan<- job.StartOptions, s espresso.Su
 }
 
 func (r *EspressoRunner) calculateJobsCount(suites []espresso.Suite) int {
-	jobsCount := 0
+	total := 0
 	for _, s := range suites {
-		jobsCount += len(enumerateDevicesAndEmulators(s.Devices, s.Emulators))
+		jobs := len(enumerateDevicesAndEmulators(s.Devices, s.Emulators))
 		if s.TestOptions.NumShards > 0 {
-			jobsCount = jobsCount * s.TestOptions.NumShards
+			jobs *= s.TestOptions.NumShards
 		}
+		total += jobs
 	}
-	return jobsCount
+	return total
 }
 
 func (r *EspressoRunner) getSuiteNames() string {

--- a/internal/saucecloud/espresso_test.go
+++ b/internal/saucecloud/espresso_test.go
@@ -54,10 +54,26 @@ func TestEspressoRunner_CalculateJobCount(t *testing.T) {
 		},
 		{
 			name:  "should multiply jobs by NumShards if defined",
-			wants: 9,
+			wants: 18,
 			suites: []espresso.Suite{
 				{
-					Name: "valid espresso project",
+					Name: "first suite",
+					TestOptions: espresso.TestOptions{
+						NumShards: 3,
+					},
+					Emulators: []config.Emulator{
+						{
+							Name:             "Android GoogleApi Emulator",
+							PlatformVersions: []string{"11.0", "10.0"},
+						},
+						{
+							Name:             "Android Emulator",
+							PlatformVersions: []string{"11.0"},
+						},
+					},
+				},
+				{
+					Name: "second suite",
 					TestOptions: espresso.TestOptions{
 						NumShards: 3,
 					},


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Fix jobs count calculation when using sharding. Without the fix, the number of shards is multiplied with the total jobs count on each iteration (issue manifests itself when more than one suite is used and at least one of them uses sharding).

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->