### PR TITLE
fix: saucectl init: Define default pattern for Cypress

### DIFF
--- a/internal/cmd/ini/cypress.go
+++ b/internal/cmd/ini/cypress.go
@@ -27,10 +27,13 @@ func configureCypress(cfg *initConfig) interface{} {
 		},
 		Suites: []cypress.Suite{
 			{
-				Name:         fmt.Sprintf("cypress - %s - %s", firstNotEmpty(cfg.platformName, cfg.mode) , cfg.browserName),
+				Name:         fmt.Sprintf("cypress - %s - %s", firstNotEmpty(cfg.platformName, cfg.mode), cfg.browserName),
 				PlatformName: cfg.platformName,
 				Browser:      cfg.browserName,
 				Mode:         cfg.mode,
+				Config: cypress.SuiteConfig{
+					TestFiles: []string{"**/*.*"},
+				},
 			},
 		},
 		Artifacts: config.Artifacts{


### PR DESCRIPTION
## Proposed changes

Add a default pattern for `saucectl init` for Cypress.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->