### PR TITLE
[DEVX-1070] Use espresso with viper

### DIFF
--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -11,18 +11,22 @@ import (
 	"github.com/saucelabs/saucectl/internal/sentry"
 	"github.com/saucelabs/saucectl/internal/testcomposer"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"os"
 )
 
 // NewPuppeteerCmd creates the 'run' command for Puppeteer.
 func NewPuppeteerCmd() *cobra.Command {
+	sc := flags.SnakeCharmer{Fmap: map[string]*pflag.Flag{}}
+
 	cmd := &cobra.Command{
 		Use:              "puppeteer",
 		Short:            "Run puppeteer tests",
 		Hidden:           true, // TODO reveal command once ready
 		TraverseChildren: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			sc.BindAll()
 			return preRun()
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -41,7 +45,7 @@ func NewPuppeteerCmd() *cobra.Command {
 		},
 	}
 
-	sc := flags.SnakeCharmer{Fset: cmd.Flags()}
+	sc.Fset = cmd.Flags()
 
 	sc.String("name", "suite.name", "", "Set the name of the job as it will appear on Sauce Labs")
 
@@ -76,7 +80,7 @@ func runPuppeteer(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client) (
 	if err := puppeteer.Validate(&p); err != nil {
 		return 1, err
 	}
-	
+
 	regio := region.FromString(p.Sauce.Region)
 	rs.URL = regio.APIBaseURL()
 	tc.URL = regio.APIBaseURL()

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"syscall"
 	"time"
 
@@ -178,16 +177,6 @@ func preRun() error {
 		return err
 	}
 	typeDef = d
-
-	// Prepare viper for all subcommands.
-	if gFlags.cfgFilePath != "" {
-		name := strings.TrimSuffix(filepath.Base(gFlags.cfgFilePath), filepath.Ext(gFlags.cfgFilePath)) // config name without extension
-		viper.SetConfigName(name)
-		viper.AddConfigPath(filepath.Dir(gFlags.cfgFilePath))
-		if err := viper.ReadInConfig(); err != nil {
-			return fmt.Errorf("failed to locate project config: %v", err)
-		}
-	}
 
 	tcClient = testcomposer.Client{
 		HTTPClient:  &http.Client{Timeout: testComposerTimeout},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"github.com/spf13/viper"
 	"os"
 	"path/filepath"
 	"strings"
@@ -192,4 +193,20 @@ func IsSupportedDeviceType(deviceType string) bool {
 		}
 	}
 	return false
+}
+
+// Unmarshal parses the file cfgPath into the given project struct.
+func Unmarshal(cfgPath string, project interface{}) error {
+	if cfgPath == "" {
+		return nil
+	}
+
+	name := strings.TrimSuffix(filepath.Base(cfgPath), filepath.Ext(cfgPath)) // config name without extension
+	viper.SetConfigName(name)
+	viper.AddConfigPath(filepath.Dir(cfgPath))
+	if err := viper.ReadInConfig(); err != nil {
+		return fmt.Errorf("failed to locate project config: %v", err)
+	}
+
+	return viper.Unmarshal(&project)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,15 +197,13 @@ func IsSupportedDeviceType(deviceType string) bool {
 
 // Unmarshal parses the file cfgPath into the given project struct.
 func Unmarshal(cfgPath string, project interface{}) error {
-	if cfgPath == "" {
-		return nil
-	}
-
-	name := strings.TrimSuffix(filepath.Base(cfgPath), filepath.Ext(cfgPath)) // config name without extension
-	viper.SetConfigName(name)
-	viper.AddConfigPath(filepath.Dir(cfgPath))
-	if err := viper.ReadInConfig(); err != nil {
-		return fmt.Errorf("failed to locate project config: %v", err)
+	if cfgPath != "" {
+		name := strings.TrimSuffix(filepath.Base(cfgPath), filepath.Ext(cfgPath)) // config name without extension
+		viper.SetConfigName(name)
+		viper.AddConfigPath(filepath.Dir(cfgPath))
+		if err := viper.ReadInConfig(); err != nil {
+			return fmt.Errorf("failed to locate project config: %v", err)
+		}
 	}
 
 	return viper.Unmarshal(&project)

--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -22,7 +22,7 @@ var (
 
 // Project represents the espresso project configuration.
 type Project struct {
-	config.TypeDef `yaml:",inline"`
+	config.TypeDef `yaml:",inline" mapstructure:",squash"`
 	ConfigFilePath string             `yaml:"-" json:"-"`
 	Sauce          config.SauceConfig `yaml:"sauce,omitempty" json:"sauce"`
 	Espresso       Espresso           `yaml:"espresso,omitempty" json:"espresso"`
@@ -72,7 +72,7 @@ func FromFile(cfgPath string) (Project, error) {
 
 	p.Espresso.App = os.ExpandEnv(p.Espresso.App)
 	p.Espresso.TestApp = os.ExpandEnv(p.Espresso.TestApp)
-	
+
 	return p, nil
 }
 

--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/saucelabs/saucectl/internal/region"
-	"github.com/spf13/viper"
 	"os"
 	"strings"
 
@@ -65,7 +64,7 @@ const Android = "Android"
 func FromFile(cfgPath string) (Project, error) {
 	var p Project
 
-	if err := viper.Unmarshal(&p); err != nil {
+	if err := config.Unmarshal(cfgPath, &p); err != nil {
 		return p, err
 	}
 	p.ConfigFilePath = cfgPath

--- a/internal/flags/binder.go
+++ b/internal/flags/binder.go
@@ -10,29 +10,48 @@ import (
 // It's a convenience wrapper around cobra and viper, allowing the user to declare and bind flags at the same time.
 type SnakeCharmer struct {
 	Fset *pflag.FlagSet
+	Fmap map[string]*pflag.Flag
+}
+
+func (s *SnakeCharmer) BindAll() {
+	for fieldName, flag := range s.Fmap {
+		if err := viper.BindPFlag(fieldName, flag); err != nil {
+			log.Fatal().Msgf("Failed to bind flags and config fields: %v", err)
+		}
+	}
 }
 
 // Bool defines a bool flag with specified flagName, default value, usage string and then binds it to fieldName.
 func (s *SnakeCharmer) Bool(flagName, fieldName string, value bool, usage string) {
 	s.Fset.Bool(flagName, value, usage)
-	s.mustBind(flagName, fieldName)
+	s.addBind(flagName, fieldName)
+}
+
+// Int defines an int flag with specified flagName, default value, usage string and then binds it to fieldName.
+func (s *SnakeCharmer) Int(flagName, fieldName string, value int, usage string) {
+	s.Fset.Int(flagName, value, usage)
+	s.addBind(flagName, fieldName)
 }
 
 // String defines a string flag with specified flagName, default value, usage string and then binds it to fieldName.
 func (s *SnakeCharmer) String(flagName, fieldName, value, usage string) {
 	s.Fset.String(flagName, value, usage)
-	s.mustBind(flagName, fieldName)
+	s.addBind(flagName, fieldName)
+}
+
+// StringSlice defines a []string flag with specified flagName, default value, usage string and then binds it to fieldName.
+func (s *SnakeCharmer) StringSlice(flagName, fieldName string, value []string, usage string) {
+	s.Fset.StringSlice(flagName, value, usage)
+	s.addBind(flagName, fieldName)
 }
 
 // StringToString defines a map[string]string flag with specified flagName, default value, usage string and then binds
 // it to fieldName.
 func (s *SnakeCharmer) StringToString(flagName, fieldName string, value map[string]string, usage string) {
 	s.Fset.StringToString(flagName, value, usage)
-	s.mustBind(flagName, fieldName)
+	s.addBind(flagName, fieldName)
 }
 
-func (s *SnakeCharmer) mustBind(flagName, fieldName string) {
-	if err := viper.BindPFlag(fieldName, s.Fset.Lookup(flagName)); err != nil {
-		log.Fatal().Msgf("Failed to bind flags and config fields: %v", err)
-	}
+func (s *SnakeCharmer) addBind(flagName, fieldName string) {
+	s.Fmap[fieldName] = s.Fset.Lookup(flagName)
 }

--- a/internal/flags/binder.go
+++ b/internal/flags/binder.go
@@ -8,11 +8,20 @@ import (
 
 // SnakeCharmer because Cobra and Viper. Get it?
 // It's a convenience wrapper around cobra and viper, allowing the user to declare and bind flags at the same time.
+//
+// Example:
+//	sc := flags.SnakeCharmer{Fmap: map[string]*pflag.Flag{}}
+//	sc.Fset = cmd.Flags()
+//	sc.String("name", "suite.name", "", "Set the name of the job as it will appear on Sauce Labs")
+//  sc.BindAll()
+//
 type SnakeCharmer struct {
 	Fset *pflag.FlagSet
+	// Fmap maps field names (key) to flags (value).
 	Fmap map[string]*pflag.Flag
 }
 
+// BindAll binds all previously added flags to their respective fields.
 func (s *SnakeCharmer) BindAll() {
 	for fieldName, flag := range s.Fmap {
 		if err := viper.BindPFlag(fieldName, flag); err != nil {

--- a/internal/puppeteer/config.go
+++ b/internal/puppeteer/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/region"
-	"github.com/spf13/viper"
 	"os"
 )
 
@@ -54,7 +53,7 @@ type Puppeteer struct {
 func FromFile(cfgPath string) (Project, error) {
 	var p Project
 
-	if err := viper.Unmarshal(&p); err != nil {
+	if err := config.Unmarshal(cfgPath, &p); err != nil {
 		return p, err
 	}
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Add viper config/flag binding to espresso.

Due to the fact that you cannot bind flags with the same name multiple times (e.g. `--name` has the same semantic use in saucectl, but used more than once for different subcommands) as a rebinding overwrites the previous one, I had to move the early-binding (command creation time) to a late-binding (command execution time).

The alternative would have been to use multiple viper instances, but that proved to be more brittle and would have required more maintenance going forward.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->