### PR TITLE
[DEVX-1088] Check cypress following cypress.json file

### DIFF
--- a/internal/cypress/config_test.go
+++ b/internal/cypress/config_test.go
@@ -1,7 +1,9 @@
 package cypress
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/fs"
 	"reflect"
 	"testing"
 )
@@ -61,6 +63,148 @@ func TestFilterSuites(t *testing.T) {
 				assert.Equal(t, tc.expErr, err.Error())
 			}
 			assert.True(t, reflect.DeepEqual(*tc.config, tc.expConfig))
+		})
+	}
+}
+
+func TestValidateCypressConfiguration(t *testing.T) {
+	tests := []struct {
+		creator     func(t *testing.T) *fs.Dir
+		name        string
+		errFileName string
+		wantErr     string
+	}{
+		{
+			name: "Valid empty config",
+			creator: func(t *testing.T) *fs.Dir {
+				dir := fs.NewDir(t, "test-case", fs.WithMode(0755),
+					fs.WithFile("cypress.json", "{}", fs.WithMode(0644)),
+					fs.WithDir("cypress", fs.WithMode(0755),
+						fs.WithDir("integration", fs.WithMode(0755))))
+				return dir
+			},
+			wantErr: "",
+		},
+		{
+			name: "Valid config with custom integration folder",
+			creator: func(t *testing.T) *fs.Dir {
+				dir := fs.NewDir(t, "test-case", fs.WithMode(0755),
+					fs.WithFile("cypress.json", `{"integrationFolder":"e2e/integration"}`, fs.WithMode(0644)),
+					fs.WithDir("e2e", fs.WithMode(0755),
+						fs.WithDir("integration", fs.WithMode(0755))))
+				return dir
+			},
+			wantErr: "",
+		},
+		{
+			name: "Valid config with custom integration/fixtures folders, plugins/support files",
+			creator: func(t *testing.T) *fs.Dir {
+				dir := fs.NewDir(t, "test-case", fs.WithMode(0755),
+					fs.WithFile("cypress.json", `{"integrationFolder":"e2e/integration", "fixturesFolder": "e2e/fixtures", "pluginsFile": "e2e/plugins-custom/index.js", "supportFile": "e2e/support-custom/index.js"}`, fs.WithMode(0644)),
+					fs.WithDir("e2e", fs.WithMode(0755),
+						fs.WithDir("integration", fs.WithMode(0755)),
+						fs.WithDir("fixtures", fs.WithMode(0755)),
+						fs.WithDir("plugins-custom", fs.WithMode(0755),
+							fs.WithFile("index.js", "", fs.WithMode(0644))),
+						fs.WithDir("support-custom", fs.WithMode(0755),
+							fs.WithFile("index.js", "", fs.WithMode(0644)))))
+				return dir
+			},
+			wantErr: "",
+		},
+		{
+			name: "Invalid file",
+			creator: func(t *testing.T) *fs.Dir {
+				dir := fs.NewDir(t, "test-case", fs.WithMode(0755),
+					fs.WithFile("cypress.json", `{"integrationFo}`, fs.WithMode(0644)))
+				return dir
+			},
+			wantErr:     "unexpected EOF",
+		},
+		{
+			name: "Un-existing integrationFolder",
+			creator: func(t *testing.T) *fs.Dir {
+				dir := fs.NewDir(t, "test-case", fs.WithMode(0755),
+					fs.WithFile("cypress.json", `{"integrationFolder":"e2e/integration-absent", "fixturesFolder": "e2e/fixtures", "pluginsFile": "e2e/plugins-custom/index.js", "supportFile": "e2e/support-custom/index.js"}`, fs.WithMode(0644)),
+					fs.WithDir("e2e", fs.WithMode(0755),
+						fs.WithDir("integration", fs.WithMode(0755)),
+						fs.WithDir("fixtures", fs.WithMode(0755)),
+						fs.WithDir("plugins-custom", fs.WithMode(0755),
+							fs.WithFile("index.js", "", fs.WithMode(0644))),
+						fs.WithDir("support-custom", fs.WithMode(0755),
+							fs.WithFile("index.js", "", fs.WithMode(0644)))))
+				return dir
+			},
+			errFileName: "e2e/integration-absent",
+			wantErr:     "stat %s: no such file or directory",
+		},
+		{
+			name: "Un-existing fixture folder",
+			creator: func(t *testing.T) *fs.Dir {
+				dir := fs.NewDir(t, "test-case", fs.WithMode(0755),
+					fs.WithFile("cypress.json", `{"integrationFolder":"e2e/integration", "fixturesFolder": "e2e/fixtures-absent", "pluginsFile": "e2e/plugins-custom/index.js", "supportFile": "e2e/support-custom/index.js"}`, fs.WithMode(0644)),
+					fs.WithDir("e2e", fs.WithMode(0755),
+						fs.WithDir("integration", fs.WithMode(0755)),
+						fs.WithDir("fixtures", fs.WithMode(0755)),
+						fs.WithDir("plugins-custom", fs.WithMode(0755),
+							fs.WithFile("index.js", "", fs.WithMode(0644))),
+						fs.WithDir("support-custom", fs.WithMode(0755),
+							fs.WithFile("index.js", "", fs.WithMode(0644)))))
+				return dir
+			},
+			errFileName: "e2e/fixtures-absent",
+			wantErr:     "stat %s: no such file or directory",
+		},
+		{
+			name: "Un-existing plugins file",
+			creator: func(t *testing.T) *fs.Dir {
+				dir := fs.NewDir(t, "test-case", fs.WithMode(0755),
+					fs.WithFile("cypress.json", `{"integrationFolder":"e2e/integration", "fixturesFolder": "e2e/fixtures", "pluginsFile": "e2e/plugins-custom/index-fake.js", "supportFile": "e2e/support-custom/index.js"}`, fs.WithMode(0644)),
+					fs.WithDir("e2e", fs.WithMode(0755),
+						fs.WithDir("integration", fs.WithMode(0755)),
+						fs.WithDir("fixtures", fs.WithMode(0755)),
+						fs.WithDir("plugins-custom", fs.WithMode(0755),
+							fs.WithFile("index.js", "", fs.WithMode(0644))),
+						fs.WithDir("support-custom", fs.WithMode(0755),
+							fs.WithFile("index.js", "", fs.WithMode(0644)))))
+				return dir
+			},
+			errFileName: "e2e/plugins-custom/index-fake.js",
+			wantErr:     "stat %s: no such file or directory",
+		},
+		{
+			name: "Un-existing support file",
+			creator: func(t *testing.T) *fs.Dir {
+				dir := fs.NewDir(t, "test-case", fs.WithMode(0755),
+					fs.WithFile("cypress.json", `{"integrationFolder":"e2e/integration", "fixturesFolder": "e2e/fixtures", "pluginsFile": "e2e/plugins-custom/index.js", "supportFile": "e2e/support-custom/index-fake.js"}`, fs.WithMode(0644)),
+					fs.WithDir("e2e", fs.WithMode(0755),
+						fs.WithDir("integration", fs.WithMode(0755)),
+						fs.WithDir("fixtures", fs.WithMode(0755)),
+						fs.WithDir("plugins-custom", fs.WithMode(0755),
+							fs.WithFile("index.js", "", fs.WithMode(0644))),
+						fs.WithDir("support-custom", fs.WithMode(0755),
+							fs.WithFile("index.js", "", fs.WithMode(0644)))))
+				return dir
+			},
+			errFileName: "e2e/support-custom/index-fake.js",
+			wantErr:     "stat %s: no such file or directory",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := tt.creator(t)
+			defer d.Remove()
+			err := ValidateCypressConfiguration(d.Join("cypress.json"))
+
+			if tt.wantErr != "" {
+				expectedErr := tt.wantErr
+				if tt.errFileName != "" {
+					expectedErr = fmt.Sprintf(tt.wantErr, d.Join(tt.errFileName))
+				}
+				assert.EqualError(t, err, expectedErr, "ValidateCypressConfiguration() error = %v, wantErr %v", err, expectedErr)
+			} else {
+				assert.Nil(t, err, "ValidateCypressConfiguration() error = %v, wanted no-error", err)
+			}
 		})
 	}
 }

--- a/internal/cypress/native.go
+++ b/internal/cypress/native.go
@@ -1,0 +1,26 @@
+package cypress
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// Config represents the cypress.json native configuration file.
+type Config struct {
+	FixturesFolder    string `json:"fixturesFolder,omitempty"`
+	IntegrationFolder string `json:"integrationFolder,omitempty"`
+	PluginsFile       string `json:"pluginsFile,omitempty"`
+	SupportFile       string `json:"supportFile,omitempty"`
+}
+
+// ConfigFromFile loads cypress configuration into Config structure.
+func ConfigFromFile(fileName string) (Config, error) {
+	var c Config
+
+	fd, err := os.Open(fileName)
+	if err != nil {
+		return c, err
+	}
+	err = json.NewDecoder(fd).Decode(&c)
+	return c, err
+}

--- a/internal/cypress/native_test.go
+++ b/internal/cypress/native_test.go
@@ -1,0 +1,53 @@
+package cypress
+
+import (
+	"gotest.tools/v3/fs"
+	"reflect"
+	"testing"
+)
+
+func TestConfigFromFile(t *testing.T) {
+	type args struct {
+		fileName string
+	}
+	tests := []struct {
+		name        string
+		fileContent string
+		want        Config
+		wantErr     bool
+	}{
+		{
+			name: "Valid File - Empty",
+			fileContent: `{}`,
+			want: Config{},
+			wantErr: false,
+		},
+		{
+			name: "Valid File - Integration folder",
+			fileContent: `{"integrationFolder":"./e2e/integration"}`,
+			want: Config{IntegrationFolder: "./e2e/integration"},
+			wantErr: false,
+		},
+		{
+			name: "Invalid File",
+			fileContent: `{"integrationFolder":"./e2e/integration}`,
+			want: Config{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := fs.NewDir(t, "cypress-config", fs.WithMode(0755),
+				fs.WithFile("cypress.json", tt.fileContent, fs.WithMode(0644)))
+			defer dir.Remove()
+			got, err := ConfigFromFile(dir.Join("cypress.json"))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConfigFromFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ConfigFromFile() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

Resolves https://github.com/saucelabs/saucectl/issues/377

Instead of checking presence of `cypress` folder close to `cypress.json`, check using content of that file.
Allow for non-native configuration of `cypress`.

With config containing `"integrationFolder": "e2e/integration"`:


Previously:
```
{16:31}~/Projects/saucectl-cypress-example(master ✗) ➭ saucectl run
Running version 0.55.1
16:31:51 ERR failed to execute run command error="unable to locate the cypress folder in ."
{16:31}~/Projects/saucectl-cypress-example(master ✗) ➭ 
```

Now it's passing !


## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->