### PR TITLE
[DEVX-1113] init: Make errors more user-friendly

### DIFF
--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -136,9 +136,8 @@ func Run(cmd *cobra.Command, initCfg *initConfig) error {
 	initCfg.concurrency, err = ini.ccyReader.ReadAllowedCCY(context.Background())
 	if err != nil {
 		println()
-		color.HiRed("Unable to determine allowed concurrency.\n")
-		fmt.Printf("Defaulting to 1.\n")
-		fmt.Printf("Check your connectivity, and try again.\n")
+		color.HiRed("Unable to determine your exact allowed concurrency.\n")
+		color.HiBlue("Using 1 as default value.\n")
 		println()
 		initCfg.concurrency = 1
 	}
@@ -193,9 +192,8 @@ func batchMode(cmd *cobra.Command, initCfg *initConfig) error {
 	initCfg.concurrency, err = ini.ccyReader.ReadAllowedCCY(context.Background())
 	if err != nil {
 		println()
-		color.HiRed("Unable to determine allowed concurrency.\n")
-		fmt.Printf("Defaulting to 1.\n")
-		fmt.Printf("Check your connectivity, and try again.\n")
+		color.HiRed("Unable to determine your exact allowed concurrency.\n")
+		color.HiBlue("Using 1 as default value.\n")
 		println()
 		initCfg.concurrency = 1
 	}

--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -123,7 +123,7 @@ func Run(cmd *cobra.Command, initCfg *initConfig) error {
 	}
 
 	ini := newInitializer(stdio, creds, regio)
-	err = ini.checkCredentials()
+	err = ini.checkCredentials(regio)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/ini/initializer.go
+++ b/internal/cmd/ini/initializer.go
@@ -38,7 +38,6 @@ var androidDevicesPatterns = []string{
 var iOSDevicesPatterns = []string{"iPad .*", "iPhone .*"}
 
 var fallbackAndroidVirtualDevices = []vmd.VirtualDevice{
-	{Name: "Android Emulator", OSVersion: []string{"11.0", "10.0"}},
 	{Name: "Android GoogleAPI Emulator", OSVersion: []string{"11.0", "10.0"}},
 }
 

--- a/internal/cmd/ini/initializer.go
+++ b/internal/cmd/ini/initializer.go
@@ -159,7 +159,7 @@ func (ini *initializer) checkCredentials(region string) error {
 	if err != nil && strings.Contains(err.Error(), "context deadline exceeded") {
 		println()
 		color.HiRed("saucectl cannot reach Sauce Labs infrastructure.")
-		fmt.Printf("Check that you can access %s.\n", color.HiBlueString("https://api.%s.saucelabs.com", region))
+		fmt.Printf("Check your connection and that you can access %s.\n", color.HiBlueString("https://api.%s.saucelabs.com", region))
 		println()
 		return errors.New("unable to check credentials")
 	}
@@ -563,7 +563,7 @@ func (ini *initializer) initializeEspresso() (*initConfig, error) {
 		println()
 		color.HiRed("saucectl is unable to fetch the emulators list.")
 		fmt.Printf("You will be able to choose only in a subset of available emulators.\n")
-		fmt.Printf("Check your connectivity, and try again.\n")
+		fmt.Printf("To get the complete list, check your connection and try again.\n")
 		println()
 		virtualDevices = fallbackAndroidVirtualDevices
 	}

--- a/internal/cmd/ini/initializer.go
+++ b/internal/cmd/ini/initializer.go
@@ -37,6 +37,11 @@ var androidDevicesPatterns = []string{
 
 var iOSDevicesPatterns = []string{"iPad .*", "iPhone .*"}
 
+var fallbackAndroidVirtualDevices = []vmd.VirtualDevice{
+	{Name: "Android Emulator", OSVersion: []string{"11.0", "10.0"}},
+	{Name: "Android GoogleAPI Emulator", OSVersion: []string{"11.0", "10.0"}},
+}
+
 type initializer struct {
 	stdio        terminal.Stdio
 	infoReader   framework.MetadataService
@@ -555,7 +560,12 @@ func (ini *initializer) initializeEspresso() (*initConfig, error) {
 
 	virtualDevices, err := ini.vmdReader.GetVirtualDevices(context.Background(), vmd.AndroidEmulator)
 	if err != nil {
-		return &initConfig{}, err
+		println()
+		color.HiRed("saucectl is unable to fetch the emulators list.")
+		fmt.Printf("You will be able to choose only in a subset of available emulators.\n")
+		fmt.Printf("Check your connectivity, and try again.\n")
+		println()
+		virtualDevices = fallbackAndroidVirtualDevices
 	}
 
 	err = ini.askEmulator(cfg, virtualDevices)

--- a/internal/cmd/ini/initializer.go
+++ b/internal/cmd/ini/initializer.go
@@ -83,7 +83,7 @@ func newInitializer(stdio terminal.Stdio, creds credentials.Credentials, regio s
 func (ini *initializer) configure() (*initConfig, error) {
 	fName, err := ini.askFramework()
 	if err != nil {
-		return &initConfig{}, err
+		return &initConfig{}, fmt.Errorf("unable to fetch frameworks list")
 	}
 
 	switch fName {
@@ -142,7 +142,7 @@ func askRegion(stdio terminal.Stdio) (string, error) {
 	return r, nil
 }
 
-func (ini *initializer) checkCredentials() error {
+func (ini *initializer) checkCredentials(region string) error {
 	_, err := ini.infoReader.Frameworks(context.Background())
 	if err != nil && err.Error() == "unexpected status '401' from test-composer: Unauthorized\n" {
 		println()
@@ -150,6 +150,13 @@ func (ini *initializer) checkCredentials() error {
 		fmt.Printf("Use %s to update your account settings.\n", color.HiBlueString("saucectl configure"))
 		println()
 		return errors.New("invalid credentials")
+	}
+	if err != nil && strings.Contains(err.Error(), "context deadline exceeded") {
+		println()
+		color.HiRed("saucectl cannot reach Sauce Labs infrastructure.")
+		fmt.Printf("Check that you can access %s.\n", color.HiBlueString("https://api.%s.saucelabs.com", region))
+		println()
+		return errors.New("unable to check credentials")
 	}
 	return err
 }

--- a/internal/cmd/ini/initializer_test.go
+++ b/internal/cmd/ini/initializer_test.go
@@ -1405,7 +1405,7 @@ func Test_checkCredentials(t *testing.T) {
 					FrameworksFn: tt.frameworkFn,
 				},
 			}
-			if err := ini.checkCredentials(); !reflect.DeepEqual(err, tt.wantErr) {
+			if err := ini.checkCredentials("us-west-1"); !reflect.DeepEqual(err, tt.wantErr) {
 				t.Errorf("checkCredentials() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
## Proposed changes

Enhances user experiences when having connection related issues during `saucectl init`.

When backend is unreachable:
<img width="745" alt="Screen Shot 2021-07-27 at 8 17 39 AM" src="https://user-images.githubusercontent.com/11074879/127181010-e0c35dbd-9d6b-49c0-a86e-934d0ed8103f.png">


When connection lost after region selection:
<img width="746" alt="Screen Shot 2021-07-27 at 8 17 51 AM" src="https://user-images.githubusercontent.com/11074879/127181048-4a4c7672-0e1b-4770-8f54-4ea862c21c2a.png">
<img width="741" alt="Screen Shot 2021-07-27 at 8 18 04 AM" src="https://user-images.githubusercontent.com/11074879/127181061-12e8c9ef-0451-41e4-8d81-46977d837280.png">
<img width="738" alt="Screen Shot 2021-07-27 at 8 18 21 AM" src="https://user-images.githubusercontent.com/11074879/127181083-8823f111-1923-4244-95c7-e3d590ba5fac.png">



For Android virtual device list, add an hard-coded list, to avoid disrupting the UX due to low connectivity / slow connection.
Defaults to 1 when concurrency is unreachable (already present, mainly enhance the message).


## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->