### PR TITLE
[MOBA-5500] Allow specifying tests to skip for XCUITest

### DIFF
--- a/.sauce/xcuitest.yml
+++ b/.sauce/xcuitest.yml
@@ -17,7 +17,10 @@ xcuitest:
 suites:
   - name: "saucy xcuitest"
     testOptions:
-      class: ["SwagLabsMobileAppUITests.LoginTests/testSuccessfulLogin"]
+      class:
+        - "SwagLabsMobileAppUITests.LoginTests/testSuccessfulLogin"
+      notClass:
+        - "SwagLabsMobileAppUITests.SwagLabsFlow/testCompleteFlow"
     devices:
       # If set, only device by ID will be queried.
       #- id: <rdc_device_id>

--- a/api/v1alpha/framework/xcuitest.schema.json
+++ b/api/v1alpha/framework/xcuitest.schema.json
@@ -70,7 +70,7 @@
                 "type": "array"
               },
               "notClass": {
-                "description": "Do not run the specified classes.",
+                "description": "Run all classes except those specified here.",
                 "type": "array"
               }
             },

--- a/api/v1alpha/framework/xcuitest.schema.json
+++ b/api/v1alpha/framework/xcuitest.schema.json
@@ -68,6 +68,10 @@
               "class": {
                 "description": "Only run the specified classes.",
                 "type": "array"
+              },
+              "notClass": {
+                "description": "Do not run the specified classes.",
+                "type": "array"
               }
             },
             "additionalProperties": false

--- a/api/v1alpha/generated/saucectl.schema.json
+++ b/api/v1alpha/generated/saucectl.schema.json
@@ -1183,7 +1183,7 @@
                       "type": "array"
                     },
                     "notClass": {
-                      "description": "Do not run the specified classes.",
+                      "description": "Run all classes except those specified here.",
                       "type": "array"
                     }
                   },

--- a/api/v1alpha/generated/saucectl.schema.json
+++ b/api/v1alpha/generated/saucectl.schema.json
@@ -1181,6 +1181,10 @@
                     "class": {
                       "description": "Only run the specified classes.",
                       "type": "array"
+                    },
+                    "notClass": {
+                      "description": "Do not run the specified classes.",
+                      "type": "array"
                     }
                   },
                   "additionalProperties": false

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -58,8 +58,8 @@ func NewEspressoCmd() *cobra.Command {
 	sc.StringSlice("otherApps", "espresso.otherApps", []string{}, "Specifies any additional apps that are installed alongside the main app")
 
 	// Test Options
-	sc.StringSlice("testOptions.class", "suite.testOptions.class", []string{}, "Include classes")
-	sc.StringSlice("testOptions.notClass", "suite.testOptions.notClass", []string{}, "Exclude classes")
+	sc.StringSlice("testOptions.class", "suite.testOptions.class", []string{}, "Only run the specified classes")
+	sc.StringSlice("testOptions.notClass", "suite.testOptions.notClass", []string{}, "Run all classes except those specified here")
 	sc.String("testOptions.package", "suite.testOptions.package", "", "Include package")
 	sc.String("testOptions.size", "suite.testOptions.size", "", "Include tests based on size")
 	sc.String("testOptions.annotation", "suite.testOptions.annotation", "", "Include tests based on the annotation")

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -56,7 +56,8 @@ func NewXCUITestCmd() *cobra.Command {
 	sc.StringSlice("otherApps", "xcuitest.otherApps", []string{}, "Specifies any additional apps that are installed alongside the main app")
 
 	// Test Options
-	sc.StringSlice("testOptions.class", "suite.testOptions.class", []string{}, "Include classes")
+	sc.StringSlice("testOptions.class", "suite.testOptions.class", []string{}, "Only run the specified classes")
+	sc.StringSlice("testOptions.notClass", "suite.testOptions.notClass", []string{}, "Run all classes except those specified here")
 
 	// Devices (no simulators)
 	cmd.Flags().Var(&lflags.Device, "device", "Specifies the device to use for testing")

--- a/internal/job/starter.go
+++ b/internal/job/starter.go
@@ -61,6 +61,7 @@ type StartOptions struct {
 	Experiments       map[string]string `json:"experiments,omitempty"`
 	TestOptions       TestOptions       `json:"testOptions,omitempty"`
 	TestsToRun        []string          `json:"testsToRun,omitempty"`
+	TestsToSkip       []string          `json:"testsToSkip,omitempty"`
 }
 
 // TunnelOptions represents the options that configure the usage of a tunnel when running tests in the Sauce Labs cloud.

--- a/internal/saucecloud/xcuitest.go
+++ b/internal/saucecloud/xcuitest.go
@@ -124,6 +124,7 @@ func (r *XcuitestRunner) startJob(jobOpts chan<- job.StartOptions, appFileID, te
 		},
 		Experiments: r.Project.Sauce.Experiments,
 		TestsToRun:  s.TestOptions.Class,
+		TestsToSkip: s.TestOptions.NotClass,
 
 		// RDC Specific flags
 		RealDevice:        true,

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -44,7 +44,8 @@ type Xcuitest struct {
 
 // TestOptions represents the xcuitest test filter options configuration.
 type TestOptions struct {
-	Class []string `yaml:"class,omitempty" json:"class"`
+	NotClass []string `yaml:"notClass,omitempty" json:"notClass"`
+	Class    []string `yaml:"class,omitempty" json:"class"`
 }
 
 // Suite represents the xcuitest test suite configuration.


### PR DESCRIPTION
## Proposed changes
Currently it's only possible to provide a lists of tests that should be run in an XCUITests (`tests_to_run` on the RDC API). There is now support for specifying a list of tests that should be ignored (`tests_to_skip`).

The usage in the config file is aligned with the existing names `class` and `notClass` (which is already available for Espresso)

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)