### PR TITLE
[DEVX-1133] Remove specific docker env injection

### DIFF
--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -135,25 +135,22 @@ func SetDefaults(p *Project) {
 		if s.Config.Env == nil {
 			s.Config.Env = map[string]string{}
 		}
+
+
+		// Apply global env vars onto suite.
+		for k, v := range p.Env {
+			s.Config.Env[k] = v
+		}
+
+		// Expand env vars.
 		for envK, envV := range s.Config.Env {
 			s.Config.Env[envK] = os.ExpandEnv(envV)
 
-			// Remove CYPRESS_ prefix as we directly pass it in Cypress.
+			// Add an entry without CYPRESS_ prefix as we directly pass it in Cypress.
 			if strings.HasPrefix(envK, "CYPRESS_") {
 				newKey := strings.TrimPrefix(envK, "CYPRESS_")
-				s.Config.Env[newKey] = s.Config.Env[envV]
+				s.Config.Env[newKey] = s.Config.Env[envK]
 			}
-		}
-	}
-
-	// Apply global env vars onto every suite.
-	for k, v := range p.Env {
-		for ks := range p.Suites {
-			s := &p.Suites[ks]
-			if s.Config.Env == nil {
-				s.Config.Env = map[string]string{}
-			}
-			s.Config.Env[k] = os.ExpandEnv(v)
 		}
 	}
 }

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -137,6 +137,12 @@ func SetDefaults(p *Project) {
 		}
 		for envK, envV := range s.Config.Env {
 			s.Config.Env[envK] = os.ExpandEnv(envV)
+
+			// Remove CYPRESS_ prefix as we directly pass it in Cypress.
+			if strings.HasPrefix(envK, "CYPRESS_") {
+				newKey := strings.TrimPrefix(envK, "CYPRESS_")
+				s.Config.Env[newKey] = s.Config.Env[envV]
+			}
 		}
 	}
 

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -183,12 +183,12 @@ func (r *ContainerRunner) startContainer(options containerStartOptions) (string,
 	return containerID, nil
 }
 
-func (r *ContainerRunner) run(containerID, suiteName string, cmd []string, env map[string]string, timeout time.Duration) (output string, jobInfo jobInfo, passed bool, timedOut bool, err error) {
+func (r *ContainerRunner) run(containerID, suiteName string, cmd []string, timeout time.Duration) (output string, jobInfo jobInfo, passed bool, timedOut bool, err error) {
 	c := make(chan bool)
 
 	var exitCode int
 	go func(c chan bool) {
-		exitCode, output, err = r.docker.ExecuteAttach(r.Ctx, containerID, cmd, env)
+		exitCode, output, err = r.docker.ExecuteAttach(r.Ctx, containerID, cmd)
 		c <- true
 	}(c)
 
@@ -257,7 +257,7 @@ func (r *ContainerRunner) readJobInfo(containerID string) (jobInfo, error) {
 func (r *ContainerRunner) beforeExec(containerID, suiteName string, tasks []string) error {
 	for _, task := range tasks {
 		log.Info().Str("task", task).Str("suite", suiteName).Msg("Running BeforeExec")
-		exitCode, _, err := r.docker.ExecuteAttach(r.Ctx, containerID, strings.Fields(task), nil)
+		exitCode, _, err := r.docker.ExecuteAttach(r.Ctx, containerID, strings.Fields(task))
 		if err != nil {
 			return err
 		}
@@ -419,7 +419,7 @@ func (r *ContainerRunner) runSuite(options containerStartOptions) (containerID s
 
 	output, jobInfo, passed, timedOut, err = r.run(containerID, options.SuiteName,
 		[]string{"npm", "test", "--", "-r", r.containerConfig.sauceRunnerConfigPath, "-s", options.SuiteName},
-		options.Environment, options.Timeout)
+		options.Timeout)
 
 	jobID := jobIDFromURL(jobIDFromURL(jobInfo.JobDetailsURL))
 	if jobID != "" {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -369,20 +369,11 @@ func (handler *Handler) CopyFromContainer(ctx context.Context, srcContainerID st
 }
 
 // Execute runs the test in the Docker container and attaches to its stdout
-func (handler *Handler) Execute(ctx context.Context, srcContainerID string, cmd []string, env map[string]string) (*types.IDResponse, *types.HijackedResponse, error) {
+func (handler *Handler) Execute(ctx context.Context, srcContainerID string, cmd []string) (*types.IDResponse, *types.HijackedResponse, error) {
 	execConfig := types.ExecConfig{
 		Cmd:          cmd,
 		AttachStdout: true,
 		AttachStderr: true,
-	}
-
-	// Set env vars for a particular suite
-	if len(env) > 0 {
-		envVars := []string{}
-		for k, v := range env {
-			envVars = append(envVars, k+"="+v)
-		}
-		execConfig.Env = envVars
 	}
 
 	createResp, err := handler.client.ContainerExecCreate(ctx, srcContainerID, execConfig)
@@ -398,11 +389,11 @@ func (handler *Handler) Execute(ctx context.Context, srcContainerID string, cmd 
 }
 
 // ExecuteAttach runs the cmd test in the Docker container and catch the given stream to a string.
-func (handler *Handler) ExecuteAttach(ctx context.Context, containerID string, cmd []string, env map[string]string) (int, string, error) {
+func (handler *Handler) ExecuteAttach(ctx context.Context, containerID string, cmd []string) (int, string, error) {
 	var in io.ReadCloser
 	var out bytes.Buffer
 
-	createResp, attachResp, err := handler.Execute(ctx, containerID, cmd, env)
+	createResp, attachResp, err := handler.Execute(ctx, containerID, cmd)
 	if err != nil {
 		return 1, "", err
 	}

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -135,7 +135,7 @@ func TestExecuteInContainer(t *testing.T) {
 		client: &mockDocker,
 	}
 
-	IDResponse, hijackedResponse, err := handler.Execute(context.Background(), "dummy-container-id", []string{"npm", "dummy-command"}, map[string]string{})
+	IDResponse, hijackedResponse, err := handler.Execute(context.Background(), "dummy-container-id", []string{"npm", "dummy-command"})
 	assert.Nil(t, err)
 	assert.NotNil(t, hijackedResponse)
 	assert.Equal(t, IDResponse.ID, "dummy-id")


### PR DESCRIPTION
## Proposed changes

As reported by https://github.com/saucelabs/saucectl/issues/280, there is a small discrepancy between Docker and Sauce regarding environment vars.

In both cases, env variables are being read from `sauce-runner.json` by the runner and set before invoking Cypress process (or any other framework).
In addition to that, when running in docker move, those variables are being injected before the invocation of the runner.

Summary:
|  | CYPRESS_VAR1 | VAR2 |
| --- | --- | --- |
| Cypress in Docker | Visible as VAR1 | Visible as VAR2 | 
| Cypress in Sauce | Invisible | Visible as VAR2 | 

To avoid that discrepancy, removing the docker-specific implementation seems better.

It will also require an update of docs, stating that variables are directly set in Cypres, and does not require any `CYPRESS_` prefix.

**Note:** 
To avoid any breaking change, if `CYPRESS_X` is detected, it will create a copy as `X` in environment before invoking the runner.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
