### PR TITLE
[DEVX-1156] Show the job's error msg if its status is error

### DIFF
--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -489,6 +489,7 @@ func (r *CloudRunner) logSuiteConsole(res result) {
 	headerColor.Print("\nErrors:\n\n")
 	bodyColor := color.New(color.FgHiRed)
 	errCount := 1
+	failCount := 1
 	for _, ts := range testsuites.TestSuites {
 		for _, tc := range ts.TestCases {
 			if tc.Error != "" {
@@ -496,6 +497,11 @@ func (r *CloudRunner) logSuiteConsole(res result) {
 				headerColor.Println("\tError was:")
 				bodyColor.Printf("\t%s\n", tc.Error)
 				errCount++
+			} else if tc.Failure != "" {
+				fmt.Printf("\n\t%d) %s.%s\n\n", failCount, tc.ClassName, tc.Name)
+				headerColor.Println("\tFailure was:")
+				bodyColor.Printf("\t%s\n", tc.Failure)
+				failCount++
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
* If a job has `status: "error"`, print the error message when reporting the job has finished.
* Make sure junit errors are printed for rdc jobs. rdc junit puts errors within the `failure` element, but vmd espresso jobs put them in `error`.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->