### PR TITLE
[DEVX-1188] Flag clarity

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -55,6 +55,7 @@ var (
 	appsClient  appstore.AppStore
 	rdcClient   rdc.Client
 
+	// ErrEmptySuiteName is thrown when a flag is specified that has a dependency on the --name flag.
 	ErrEmptySuiteName = errors.New("adhoc suite parameters can only be used with a new adhoc suite by setting --name")
 )
 

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -55,7 +55,7 @@ var (
 	appsClient  appstore.AppStore
 	rdcClient   rdc.Client
 
-	ErrEmptySuiteName = errors.New("adhoc suite parameters can only be used with a new adhoc suite via --name")
+	ErrEmptySuiteName = errors.New("adhoc suite parameters can only be used with a new adhoc suite by setting --name")
 )
 
 // gFlags contains all global flags that are set when 'run' is invoked.

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -54,6 +54,8 @@ var (
 	restoClient resto.Client
 	appsClient  appstore.AppStore
 	rdcClient   rdc.Client
+
+	ErrEmptySuiteName = errors.New("adhoc suite parameters can only be used with a new adhoc suite via --name")
 )
 
 // gFlags contains all global flags that are set when 'run' is invoked.

--- a/internal/flags/device.go
+++ b/internal/flags/device.go
@@ -2,8 +2,10 @@ package flags
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/msg"
 	"strconv"
 	"strings"
 )
@@ -35,6 +37,12 @@ func (d *Device) Set(s string) error {
 
 	for _, v := range rec {
 		vs := strings.Split(v, "=")
+
+		if len(vs) < 2 {
+			msg.Error("--device must be specified using a key-value format, e.g. \"--device name=iPhone,private=true\"")
+			return errors.New("wrong input format; must be of key-value")
+		}
+
 		val := vs[1]
 		switch vs[0] {
 		case "id":

--- a/internal/flags/emulator.go
+++ b/internal/flags/emulator.go
@@ -2,8 +2,10 @@ package flags
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/msg"
 	"strings"
 )
 
@@ -37,6 +39,12 @@ func (e *Emulator) Set(s string) error {
 
 	for _, v := range rec {
 		vs := strings.Split(v, "=")
+
+		if len(vs) < 2 {
+			msg.Error("--emulator must be specified using a key-value format, e.g. \"--emulator name=Android Emulator,platformVersion=11.0\"")
+			return errors.New("wrong input format; must be of key-value")
+		}
+
 		val := vs[1]
 		switch vs[0] {
 		case "name":

--- a/internal/flags/simulator.go
+++ b/internal/flags/simulator.go
@@ -2,8 +2,10 @@ package flags
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/msg"
 	"strings"
 )
 
@@ -37,6 +39,12 @@ func (e *Simulator) Set(s string) error {
 
 	for _, v := range rec {
 		vs := strings.Split(v, "=")
+
+		if len(vs) < 2 {
+			msg.Error("--simulator must be specified using a key-value format, e.g. \"--simulator name=iPhone X Simulator,platformVersion=14.0\"")
+			return errors.New("wrong input format; must be of key-value")
+		}
+
 		val := vs[1]
 		switch vs[0] {
 		case "name":

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -122,3 +122,9 @@ func LogRootDirWarning() {
 	fmt.Printf("\n%s: %s\n\n", red("WARNING"), "'rootDir' is not defined. Using the current working directory instead "+
 		"(equivalent to 'rootDir: .'). Please set 'rootDir' explicitly in your config!")
 }
+
+// Error prints out the given message, prefixed with a color coded 'ERROR: ' segment.
+func Error(msg string) {
+	red := color.New(color.FgRed).SprintFunc()
+	fmt.Printf("\n%s: %s\n\n", red("ERROR"), msg)
+}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Improve the UX of the CLI Driven approach by making flag usage more clear. And including examples as part of the help printout.
This PR only covers xcuitest and espresso, as the two most prominent frameworks where the CLI Driven approach is used.

```
~> saucectl run espresso -h
Unlike 'saucectl run', this command allows you to bypass the config file partially or entirely by configuring an adhoc suite (--name) via flags.

Usage:
  saucectl run espresso [flags]

Examples:
saucectl run espresso -c "" --name "My Suite" --app app.apk --testApp testApp.apk --otherApps=a.apk,b.apk --device name="Google Pixel.*",platformVersion=14.0,carrierConnectivity=false,deviceType=PHONE,private=false --emulator name="Android Emulator",platformVersion=8.0

Flags:
      --app string                         Specifies the app under test
      --device device                      Specifies the device to use for testing. Requires --name to be set.
      --emulator emulator                  Specifies the emulator to use for testing. Requires --name to be set.
  -h, --help                               help for espresso
      --name string                        Sets the name of the job as it will appear on Sauce Labs
      --otherApps strings                  Specifies any additional apps that are installed alongside the main app
      --testApp string                     Specifies the test app
      --testOptions.annotation string      Include tests based on the annotation. Requires --name to be set.
      --testOptions.class strings          Only run the specified classes. Requires --name to be set.
      --testOptions.notAnnotation string   Run all tests except those with this annotation. Requires --name to be set.
      --testOptions.notClass strings       Run all classes except those specified here. Requires --name to be set.
      --testOptions.numShards int          Total number of shards. Requires --name to be set.
      --testOptions.package string         Include package. Requires --name to be set.
      --testOptions.size string            Include tests based on size. Requires --name to be set.
      --testOptions.useTestOrchestrator    Set the instrumentation to start with Test Orchestrator. Requires --name to be set.
[...]
```

```
~> saucectl run xcuitest -h
Unlike 'saucectl run', this command allows you to bypass the config file partially or entirely by configuring an adhoc suite (--name) via flags.

Usage:
  saucectl run xcuitest [flags]

Examples:
saucectl run xcuitest -c "" --name "My Suite" --app app.ipa --testApp testApp.ipa --otherApps=a.ipa,b.ipa --device name="iPhone.*",platformVersion=14.0,carrierConnectivity=false,deviceType=PHONE,private=false

Flags:
      --app string                     Specifies the app under test
      --device device                  Specifies the device to use for testing. Requires --name to be set.
  -h, --help                           help for xcuitest
      --name string                    Creates a new adhoc suite with this name. Suites defined in the config will be ignored.
      --otherApps strings              Specifies any additional apps that are installed alongside the main app
      --testApp string                 Specifies the test app
      --testOptions.class strings      Only run the specified classes. Requires --name to be set.
      --testOptions.notClass strings   Run all classes except those specified here. Requires --name to be set.

```


```
saucectl run xcuitest -c "" --testOptions.class "ooops"
11:04:53 ERR failed to execute run command error="adhoc suite parameters can only be used with a new adhoc suite by setting --name"
```