### PR TITLE
[DEVX-1152] Filter out and warn if framework packages are defined in config.yml

### DIFF
--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -8,6 +9,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/docker"
 	"github.com/saucelabs/saucectl/internal/flags"
+	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/puppeteer"
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/saucelabs/saucectl/internal/resto"
@@ -85,12 +87,6 @@ func runPuppeteer(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client) (
 	puppeteer.SetDefaults(&p)
 	// Don't allow framework installation, it is provided by the runner
 
-	version, hasFramework := p.Npm.Packages["puppeteer"]
-	if hasFramework {
-		log.Warn().Msgf("Ignoring puppeteer@%s. Define the required puppeteer version with the puppeteer.version property in your config", version)
-		p.Npm.Packages = config.CleanNpmPackages(p.Npm.Packages, []string{"puppeteer"})
-	}
-
 	if err := puppeteer.Validate(&p); err != nil {
 		return 1, err
 	}
@@ -110,6 +106,8 @@ func runPuppeteerInDocker(p puppeteer.Project, testco testcomposer.Client, rs re
 	if err != nil {
 		return 1, err
 	}
+
+	cleanPuppeteerPackages(&p)
 	return cd.RunProject()
 }
 
@@ -126,4 +124,21 @@ func applyPuppeteerFlags(p *puppeteer.Project) error {
 	}
 
 	return nil
+}
+
+func cleanPuppeteerPackages(p *puppeteer.Project) {
+	// Don't allow framework installation, it is provided by the runner
+	ignoredPackages := []string{}
+	puppeteerVersion, hasPuppeteer := p.Npm.Packages["puppeteer"]
+	puppeteerCoreVersion, hasPuppeteerCore := p.Npm.Packages["puppeteer-core"]
+	if hasPuppeteer {
+		ignoredPackages = append(ignoredPackages, fmt.Sprintf("puppeteer@%s", puppeteerVersion))
+	}
+	if hasPuppeteerCore {
+		ignoredPackages = append(ignoredPackages, fmt.Sprintf("puppeteer-core@%s", puppeteerCoreVersion))
+	}
+	if hasPuppeteer || hasPuppeteerCore {
+		log.Warn().Msg(msg.IgnoredNpmPackagesMsg("puppeteer", p.Puppeteer.Version, ignoredPackages))
+		p.Npm.Packages = config.CleanNpmPackages(p.Npm.Packages, []string{"puppeteer", "puppeteer-core"})
+	}
 }

--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/docker"
 	"github.com/saucelabs/saucectl/internal/flags"
@@ -82,6 +83,14 @@ func runPuppeteer(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client) (
 		return 1, err
 	}
 	puppeteer.SetDefaults(&p)
+	// Don't allow framework installation, it is provided by the runner
+
+	version, hasFramework := p.Npm.Packages["puppeteer"]
+	if hasFramework {
+		log.Warn().Msgf("Ignoring puppeteer@%s. Define the required puppeteer version with the puppeteer.version property in your config", version)
+		p.Npm.Packages = config.CleanNpmPackages(p.Npm.Packages, []string{"puppeteer"})
+	}
+
 	if err := puppeteer.Validate(&p); err != nil {
 		return 1, err
 	}

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -113,6 +113,12 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, tc testcomposer.Clie
 	}
 	testcafe.SetDefaults(&p)
 
+	version, hasFramework := p.Npm.Packages["testcafe"]
+	if hasFramework {
+		log.Warn().Msgf("Ignoring testcafe@%s. Define the required testcafe version with the testcafe.version property in your config", version)
+		p.Npm.Packages = config.CleanNpmPackages(p.Npm.Packages, []string{"testcafe"})
+	}
+
 	if err := testcafe.Validate(&p); err != nil {
 		return 1, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,11 +3,12 @@ package config
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/viper"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/spf13/viper"
 
 	"gopkg.in/yaml.v2"
 )
@@ -204,6 +205,17 @@ func IsSupportedDeviceType(deviceType string) bool {
 		}
 	}
 	return false
+}
+
+// CleanNpmPackages removes any packages in denyList from packages
+func CleanNpmPackages(packages map[string]string, denyList []string) map[string]string {
+	for _, p := range denyList {
+		_, exists := packages[p]
+		if exists {
+			delete(packages, p)
+		}
+	}
+	return packages
 }
 
 // Unmarshal parses the file cfgPath into the given project struct.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,3 +10,24 @@ func TestStandardizeVersionFormat(t *testing.T) {
 	assert.Equal(t, "5.6.0", StandardizeVersionFormat("v5.6.0"))
 	assert.Equal(t, "5.6.0", StandardizeVersionFormat("5.6.0"))
 }
+
+func TestCleanNpmPackages(t *testing.T) {
+	packages := map[string]string{
+		"cypress": "7.7.0",
+		"mocha":   "1.2.3",
+	}
+
+	cleaned := CleanNpmPackages(packages, []string{"cypress"})
+	assert.NotContains(t, cleaned, "cypress")
+	assert.Contains(t, cleaned, "mocha")
+
+	packages = map[string]string{}
+
+	cleaned = CleanNpmPackages(packages, []string{"somepackage"})
+	assert.NotNil(t, cleaned)
+	assert.Len(t, cleaned, 0)
+
+	packages = nil
+	cleaned = CleanNpmPackages(packages, []string{})
+	assert.Nil(t, cleaned)
+}

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -2,6 +2,7 @@ package msg
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/fatih/color"
 )
@@ -127,4 +128,9 @@ func LogRootDirWarning() {
 func Error(msg string) {
 	red := color.New(color.FgRed).SprintFunc()
 	fmt.Printf("\n%s: %s\n\n", red("ERROR"), msg)
+}
+
+// IgnoredNpmPackagesMsg returns a warning message that framework npm packages are ignored.
+func IgnoredNpmPackagesMsg(framework string, installedVersion string, ignoredPackages []string) string {
+	return fmt.Sprintf("%s.version (%s) already defined in your config. Ignoring installation of npm packages: %s", framework, installedVersion, strings.Join(ignoredPackages, ", "))
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Adding the test framework to `npm.packages` is not just redundant since the framework version is pre-installed and defined in the `{{framework}}.version` property in the configuration, it can also cause errors at execution time (e.g. multiple incompatible versions of the test library).

Before execution, remove conflicting framework packages from the list of npm packages to install and print a warning.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
Fixes #403 