### PR TITLE
[DEVX-1180] Add usage tracking

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
       - -X github.com/saucelabs/saucectl/internal/version.Version={{.Version}}
       - -X github.com/saucelabs/saucectl/internal/version.GitCommit={{.Commit}}
       - -X github.com/saucelabs/saucectl/internal/setup.SentryDSN={{.Env.SENTRY_DSN}}
+      - -X github.com/saucelabs/saucectl/internal/setup.SegmentWriteKey={{.Env.SEGMENT_WRITE_KEY}}
 brews:
   - tap:
       owner: saucelabs

--- a/go.mod
+++ b/go.mod
@@ -29,11 +29,14 @@ require (
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/rs/zerolog v1.18.0
 	github.com/ryanuber/go-glob v1.0.0
+	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
+	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	golang.org/x/mod v0.4.2
+	gopkg.in/segmentio/analytics-go.v3 v3.1.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
 	gotest.tools/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -437,6 +437,8 @@ github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkB
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 h1:ZuhckGJ10ulaKkdvJtiAqsLTiPrLaXSdnVgXJKJkTxE=
+github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -501,6 +503,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c h1:3lbZUMbMiGUW/LMkfsEABsc5zNT9+b1CvsJx47JzJ8g=
+github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
@@ -849,6 +853,8 @@ gopkg.in/ini.v1 v1.62.0 h1:duBzk771uxoUuOlyRLkHsygud9+5lrlGjdFBb4mSKDU=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/segmentio/analytics-go.v3 v3.1.0 h1:UzxH1uaGZRpMKDhJyBz0pexz6yUoBU3x8bJsRk/HV6U=
+gopkg.in/segmentio/analytics-go.v3 v3.1.0/go.mod h1:4QqqlTlSSpVlWA9/9nDcPw+FkM2yv1NQoYjUbL9/JAw=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=

--- a/internal/ci/ci.go
+++ b/internal/ci/ci.go
@@ -1,0 +1,83 @@
+package ci
+
+import "os"
+
+// Provider represents a CI Provider.
+type Provider struct {
+	// Name of the Provider.
+	Name string
+
+	// The environment variable by which the Provider is detected.
+	Envar string
+}
+
+var (
+	// AppVeyor represents https://www.appveyor.com/
+	AppVeyor = Provider{Name: "AppVeyor", Envar: "APPVEYOR_BUILD_NUMBER"}
+	// AWS represents https://aws.amazon.com/codebuild/
+	AWS = Provider{Name: "AWS CodeBuild", Envar: "CODEBUILD_INITIATOR"}
+	// Azure represents https://azure.microsoft.com/en-us/services/devops/
+	Azure = Provider{Name: "Azure DevOps", Envar: "Agent_BuildDirectory"}
+	// Bamboo represents https://www.atlassian.com/software/bamboo
+	Bamboo = Provider{Name: "Bamboo", Envar: "bamboo_buildNumber"}
+	// Bitbucket represents https://bitbucket.org/product/features/pipelines
+	Bitbucket = Provider{Name: "Bitbucket", Envar: "BITBUCKET_BUILD_NUMBER"}
+	// Buildkite represents https://buildkite.com/
+	Buildkite = Provider{Name: "Buildkite", Envar: "BUILDKITE"}
+	// Buddy represents https://buddy.works/
+	Buddy = Provider{Name: "Buddy", Envar: "BUDDY"}
+	// Circle represents https://circleci.com/
+	Circle = Provider{Name: "CircleCI", Envar: "CIRCLECI"}
+	// CodeShip represents https://www.cloudbees.com/products/codeship
+	CodeShip = Provider{Name: "CloudBees CodeShip", Envar: "CI_NAME"}
+	// Drone represents https://www.drone.io/
+	Drone = Provider{Name: "Drone", Envar: "DRONE_BUILD_NUMBER"}
+	// GitHub represents https://github.com/
+	GitHub = Provider{Name: "GitHub", Envar: "GITHUB_RUN_ID"}
+	// GitLab represents https://about.gitlab.com/
+	GitLab = Provider{Name: "GitLab", Envar: "CI_PIPELINE_ID"}
+	// Jenkins represents https://www.jenkins.io/
+	Jenkins = Provider{Name: "Jenkins", Envar: "BUILD_NUMBER"}
+	// Semaphore represents https://semaphoreci.com/
+	Semaphore = Provider{Name: "Semaphore", Envar: "SEMAPHORE_EXECUTABLE_UUID"}
+	// Travis represents https://www.travis-ci.com/
+	Travis = Provider{Name: "Travis CI", Envar: "TRAVIS_BUILD_ID"}
+	// TeamCity represents https://www.jetbrains.com/teamcity/
+	TeamCity = Provider{Name: "TeamCity", Envar: "TEAMCITY_VERSION"}
+
+	// None represents a non-CI environment.
+	None = Provider{}
+)
+
+// Providers contains a list of all supported providers.
+var Providers = []Provider{
+	AppVeyor,
+	AWS,
+	Azure,
+	Bamboo,
+	Bitbucket,
+	Buildkite,
+	Buddy,
+	Circle,
+	CodeShip,
+	Drone,
+	GitHub,
+	GitLab,
+	Jenkins,
+	Semaphore,
+	Travis,
+	TeamCity,
+}
+
+// GetProvider returns a CI Provider if this code is executed in a known CI environment.
+// Returns None if it's not a CI environment or if the CI Provider could not be detected.
+func GetProvider() Provider {
+	for _, p := range Providers {
+		_, ok := os.LookupEnv(p.Envar)
+		if ok {
+			return p
+		}
+	}
+
+	return None
+}

--- a/internal/cmd/configure/cmd.go
+++ b/internal/cmd/configure/cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/msg"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/saucelabs/saucectl/internal/sentry"
 	"github.com/spf13/cobra"
 	"os"
@@ -30,6 +31,13 @@ func Command() *cobra.Command {
 		Long:    configureLong,
 		Example: configureExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			tracker := segment.New()
+
+			defer func() {
+				tracker.Collect("Configure", nil)
+				_ = tracker.Close()
+			}()
+
 			if err := Run(); err != nil {
 				log.Err(err).Msg("failed to execute configure command")
 				sentry.CaptureError(err, sentry.Scope{

--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"os"
 	"time"
 
@@ -72,6 +73,13 @@ func Command() *cobra.Command {
 		Long:    initLong,
 		Example: initExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			tracker := segment.New()
+
+			defer func() {
+				tracker.Collect("Init", nil)
+				_ = tracker.Close()
+			}()
+
 			log.Info().Msg("Start Init Command")
 			err := Run(cmd, initCfg)
 			if err != nil {

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -112,8 +112,8 @@ func runCypress(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as 
 
 	defer func() {
 		props := usage.Properties{}
-		props.SetFramework("cypress").SetFVersion(p.Cypress.Version).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
-			SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
+		props.SetFramework("cypress").SetFVersion(p.Cypress.Version).SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).
+			SetArtifacts(p.Artifacts).SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/appstore"
@@ -13,10 +14,13 @@ import (
 	"github.com/saucelabs/saucectl/internal/flags"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/report/captor"
 	"github.com/saucelabs/saucectl/internal/resto"
 	"github.com/saucelabs/saucectl/internal/saucecloud"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/saucelabs/saucectl/internal/sentry"
 	"github.com/saucelabs/saucectl/internal/testcomposer"
+	"github.com/saucelabs/saucectl/internal/usage"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -103,6 +107,16 @@ func runCypress(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as 
 	as.URL = regio.APIBaseURL()
 
 	rs.ArtifactConfig = p.Artifacts.Download
+
+	tracker := segment.New()
+
+	defer func() {
+		props := usage.Properties{}
+		props.SetFramework("cypress").SetFVersion(p.Cypress.Version).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
+			SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
+		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
+		_ = tracker.Close()
+	}()
 
 	dockerProject, sauceProject := cypress.SplitSuites(p)
 	if len(dockerProject.Suites) != 0 {

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -1,7 +1,11 @@
 package run
 
 import (
+	"github.com/saucelabs/saucectl/internal/report/captor"
+	"github.com/saucelabs/saucectl/internal/segment"
+	"github.com/saucelabs/saucectl/internal/usage"
 	"os"
+	"strings"
 
 	"github.com/spf13/pflag"
 
@@ -104,6 +108,16 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, tc testcompose
 
 	rs.ArtifactConfig = p.Artifacts.Download
 	rc.ArtifactConfig = p.Artifacts.Download
+
+	tracker := segment.New()
+
+	defer func() {
+		props := usage.Properties{}
+		props.SetFramework("espresso").SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).SetNumSuites(len(p.Suites)).
+			SetJobs(captor.Default.TestResults)
+		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
+		_ = tracker.Close()
+	}()
 
 	return runEspressoInCloud(p, regio, tc, rs, rc, as)
 }

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -113,8 +113,8 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, tc testcompose
 
 	defer func() {
 		props := usage.Properties{}
-		props.SetFramework("espresso").SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).SetNumSuites(len(p.Suites)).
-			SetJobs(captor.Default.TestResults)
+		props.SetFramework("espresso").SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
+			SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/appstore"
@@ -13,10 +14,13 @@ import (
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/playwright"
 	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/report/captor"
 	"github.com/saucelabs/saucectl/internal/resto"
 	"github.com/saucelabs/saucectl/internal/saucecloud"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/saucelabs/saucectl/internal/sentry"
 	"github.com/saucelabs/saucectl/internal/testcomposer"
+	"github.com/saucelabs/saucectl/internal/usage"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -108,6 +112,16 @@ func runPlaywright(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, 
 	as.URL = regio.APIBaseURL()
 
 	rs.ArtifactConfig = p.Artifacts.Download
+
+	tracker := segment.New()
+
+	defer func() {
+		props := usage.Properties{}
+		props.SetFramework("playwright").SetFVersion(p.Playwright.Version).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
+			SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
+		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
+		_ = tracker.Close()
+	}()
 
 	dockerProject, sauceProject := playwright.SplitSuites(p)
 	if len(dockerProject.Suites) != 0 {

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -117,8 +117,8 @@ func runPlaywright(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, 
 
 	defer func() {
 		props := usage.Properties{}
-		props.SetFramework("playwright").SetFVersion(p.Playwright.Version).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
-			SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
+		props.SetFramework("playwright").SetFVersion(p.Playwright.Version).SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).
+			SetArtifacts(p.Artifacts).SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()

--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/config"
@@ -12,9 +13,12 @@ import (
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/puppeteer"
 	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/report/captor"
 	"github.com/saucelabs/saucectl/internal/resto"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/saucelabs/saucectl/internal/sentry"
 	"github.com/saucelabs/saucectl/internal/testcomposer"
+	"github.com/saucelabs/saucectl/internal/usage"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -94,6 +98,16 @@ func runPuppeteer(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client) (
 	regio := region.FromString(p.Sauce.Region)
 	rs.URL = regio.APIBaseURL()
 	tc.URL = regio.APIBaseURL()
+
+	tracker := segment.New()
+
+	defer func() {
+		props := usage.Properties{}
+		props.SetFramework("puppeteer").SetFVersion(p.Puppeteer.Version).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
+			SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
+		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
+		_ = tracker.Close()
+	}()
 
 	return runPuppeteerInDocker(p, tc, rs)
 }

--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -103,8 +103,8 @@ func runPuppeteer(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client) (
 
 	defer func() {
 		props := usage.Properties{}
-		props.SetFramework("puppeteer").SetFVersion(p.Puppeteer.Version).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
-			SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
+		props.SetFramework("puppeteer").SetFVersion(p.Puppeteer.Version).SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).
+			SetArtifacts(p.Artifacts).SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/playwright"
 	"github.com/saucelabs/saucectl/internal/puppeteer"
 	"github.com/saucelabs/saucectl/internal/report"
+	"github.com/saucelabs/saucectl/internal/report/captor"
 	"github.com/saucelabs/saucectl/internal/report/table"
 	"github.com/saucelabs/saucectl/internal/testcafe"
 	"github.com/saucelabs/saucectl/internal/version"
@@ -19,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -281,9 +283,11 @@ func checkForUpdates() {
 }
 
 func createReporters(c config.Reporters) []report.Reporter {
-	reps := []report.Reporter{&table.Reporter{
-		Dst: os.Stdout,
-	}}
+	reps := []report.Reporter{
+		&captor.Default,
+		&table.Reporter{
+			Dst: os.Stdout,
+		}}
 
 	if c.JUnit.Enabled {
 		reps = append(reps, &junit.Reporter{
@@ -292,4 +296,17 @@ func createReporters(c config.Reporters) []report.Reporter {
 	}
 
 	return reps
+}
+
+// fullCommandName returns the full command name by concatenating the command names of any parents,
+// except the name of the CLI itself.
+func fullCommandName(cmd *cobra.Command) string {
+	name := ""
+
+	for cmd.Name() != "saucectl" {
+		name = fmt.Sprintf("%s %s", cmd.Name(), name)
+		cmd = cmd.Parent()
+	}
+
+	return strings.TrimSpace(name)
 }

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -304,6 +304,8 @@ func fullCommandName(cmd *cobra.Command) string {
 	name := ""
 
 	for cmd.Name() != "saucectl" {
+		// Prepending, because we are looking up names from the bottom up: cypress < run < saucectl
+		// which ends up correctly as 'run cypress' (sans saucectl).
 		name = fmt.Sprintf("%s %s", cmd.Name(), name)
 		cmd = cmd.Parent()
 	}

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -134,8 +134,8 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, tc testcomposer.Clie
 
 	defer func() {
 		props := usage.Properties{}
-		props.SetFramework("testcafe").SetFVersion(p.Testcafe.Version).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
-			SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
+		props.SetFramework("testcafe").SetFVersion(p.Testcafe.Version).SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).
+			SetArtifacts(p.Artifacts).SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -1,7 +1,11 @@
 package run
 
 import (
+	"github.com/saucelabs/saucectl/internal/report/captor"
+	"github.com/saucelabs/saucectl/internal/segment"
+	"github.com/saucelabs/saucectl/internal/usage"
 	"os"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/appstore"
@@ -95,6 +99,16 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, tc testcomposer.Cl
 
 	rs.ArtifactConfig = p.Artifacts.Download
 	rc.ArtifactConfig = p.Artifacts.Download
+
+	tracker := segment.New()
+
+	defer func() {
+		props := usage.Properties{}
+		props.SetFramework("xcuitest").SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).SetNumSuites(len(p.Suites)).
+			SetJobs(captor.Default.TestResults)
+		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
+		_ = tracker.Close()
+	}()
 
 	return runXcuitestInCloud(p, regio, tc, rs, rc, as)
 }

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -104,8 +104,8 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, tc testcomposer.Cl
 
 	defer func() {
 		props := usage.Properties{}
-		props.SetFramework("xcuitest").SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).SetNumSuites(len(p.Suites)).
-			SetJobs(captor.Default.TestResults)
+		props.SetFramework("xcuitest").SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
+			SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults)
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,9 +13,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// ErrUnknownCfg is thrown when the provided config doesn't match anything known, be it in "kind" or the version of it.
-var ErrUnknownCfg = errors.New("unknown framework configuration")
-
 // Metadata describes job metadata
 type Metadata struct {
 	Tags  []string `yaml:"tags" json:"tags,omitempty"`
@@ -93,7 +90,7 @@ type Reporters struct {
 
 // Tunnel represents a sauce labs tunnel.
 type Tunnel struct {
-	ID     string `yaml:"id,omitempty" json:"id"`
+	ID     string `yaml:"id,omitempty" json:"id,omitempty"`
 	Parent string `yaml:"parent,omitempty" json:"parent,omitempty"`
 }
 
@@ -114,8 +111,8 @@ const (
 
 // Docker represents docker settings.
 type Docker struct {
-	FileTransfer DockerFileMode `yaml:"fileTransfer,omitempty" json:"fileTransfer"`
-	Image        string         `yaml:"image,omitempty" json:"image"`
+	FileTransfer DockerFileMode `yaml:"fileTransfer,omitempty" json:"fileTransfer,omitempty"`
+	Image        string         `yaml:"image,omitempty" json:"image,omitempty"`
 }
 
 // Npm represents the npm settings

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -365,7 +365,9 @@ func (r *ContainerRunner) collectResults(artifactCfg config.ArtifactDownload, re
 				Platform:  "Docker",
 				URL:       res.jobInfo.JobDetailsURL,
 				Artifacts: artifacts,
+				Origin:    "docker",
 			}
+
 			for _, rep := range r.Reporters {
 				rep.Add(tr)
 			}

--- a/internal/docker/cypress.go
+++ b/internal/docker/cypress.go
@@ -2,12 +2,11 @@ package docker
 
 import (
 	"context"
-	"github.com/saucelabs/saucectl/internal/report"
-
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/download"
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/job"
+	"github.com/saucelabs/saucectl/internal/report"
 )
 
 // CypressRunner represents the docker implementation of a test runner.

--- a/internal/report/captor/captor.go
+++ b/internal/report/captor/captor.go
@@ -1,0 +1,44 @@
+package captor
+
+import (
+	"github.com/saucelabs/saucectl/internal/report"
+	"sync"
+)
+
+// Default is the default, global instance of Reporter. Use judiciously.
+var Default = Reporter{}
+
+// Reporter is a simple implementation for report.Reporter, a no-output reporter for capturing test results.
+type Reporter struct {
+	TestResults []report.TestResult
+	lock        sync.Mutex
+}
+
+// Add adds the test result.
+func (r *Reporter) Add(t report.TestResult) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.TestResults = append(r.TestResults, t)
+}
+
+// GetAll returns all added test results, unless they've been purged via Reset().
+func (r *Reporter) GetAll() []report.TestResult {
+	return r.TestResults
+}
+
+// Render does nothing.
+func (r *Reporter) Render() {
+	//	no op
+}
+
+// Reset resets the reporter to its initial state. This action will delete all test results.
+func (r *Reporter) Reset() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.TestResults = make([]report.TestResult, 0)
+}
+
+// ArtifactRequirements returns a list of artifact types are this reporter requires to create a proper report.
+func (r *Reporter) ArtifactRequirements() []report.ArtifactType {
+	return nil
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -4,14 +4,15 @@ import "time"
 
 // TestResult represents the test result.
 type TestResult struct {
-	Name       string
-	Duration   time.Duration
-	Passed     bool
-	Browser    string
-	Platform   string
-	DeviceName string
-	URL        string
-	Artifacts  []Artifact
+	Name       string        `json:"name"`
+	Duration   time.Duration `json:"duration"`
+	Passed     bool          `json:"passed"`
+	Browser    string        `json:"browser"`
+	Platform   string        `json:"platform"`
+	DeviceName string        `json:"deviceName"`
+	URL        string        `json:"url"`
+	Artifacts  []Artifact    `json:"-"`
+	Origin     string        `json:"origin"`
 }
 
 // ArtifactType represents the type of assets (e.g. a junit report). Semantically similar to Content-Type.

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -139,6 +139,7 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 				DeviceName: res.job.BaseConfig.DeviceName,
 				URL:        fmt.Sprintf("%s/tests/%s", r.Region.AppBaseURL(), res.job.ID),
 				Artifacts:  artifacts,
+				Origin:     "sauce",
 			}
 
 			for _, rep := range r.Reporters {

--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -1,0 +1,77 @@
+package segment
+
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/ci"
+	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/setup"
+	"github.com/saucelabs/saucectl/internal/usage"
+	"github.com/saucelabs/saucectl/internal/version"
+	"gopkg.in/segmentio/analytics-go.v3"
+	"runtime"
+)
+
+type Tracker struct {
+	client analytics.Client
+}
+
+func New() *Tracker {
+	client, err := analytics.NewWithConfig(setup.SegmentWriteKey, analytics.Config{
+		BatchSize: 1,
+		DefaultContext: &analytics.Context{
+			App: analytics.AppInfo{
+				Name:    "saucectl",
+				Version: version.Version,
+			},
+			OS: analytics.OSInfo{
+				Name: runtime.GOOS + " " + runtime.GOARCH,
+			},
+			Extra: map[string]interface{}{"ci": ci.GetProvider().Name},
+		},
+	})
+	if err != nil {
+		// Usage is not crucial to the execution of saucectl, so proceed without notifying or blocking the user.
+		log.Debug().Err(err).Msg("Failed to create segment client")
+		return &Tracker{}
+	}
+
+	return &Tracker{client: client}
+}
+
+func (t *Tracker) Collect(subject string, props usage.Properties) {
+	if t.client == nil {
+		return
+	}
+
+	p := analytics.NewProperties()
+	p.Set("subject_name", subject).Set("product_area", "DevX").
+		Set("product_sub_area", "SauceCTL")
+
+	for k, v := range props {
+		p[k] = v
+	}
+
+	userId := credentials.Get().Username
+	if userId == "" {
+		userId = "saucectlanon"
+	}
+
+	if err := t.client.Enqueue(analytics.Track{
+		UserId:     userId,
+		Event:      "Command Executed",
+		Properties: p,
+
+		Integrations: map[string]interface{}{
+			"All":       false,
+			"Mixpanel":  true,
+			"Snowflake": true,
+		},
+	}); err != nil {
+		// Usage is not crucial to the execution of saucectl, so proceed without notifying or blocking the user.
+		log.Debug().Err(err).Msg("Failed to collect usage metrics")
+	}
+}
+
+func (t *Tracker) Close() error {
+	return t.client.Close()
+}

--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -11,10 +11,12 @@ import (
 	"runtime"
 )
 
+// Tracker is the segment implemention for usage.Tracker.
 type Tracker struct {
 	client analytics.Client
 }
 
+// New creates a new instance of Tracker.
 func New() *Tracker {
 	client, err := analytics.NewWithConfig(setup.SegmentWriteKey, analytics.Config{
 		BatchSize: 1,
@@ -38,6 +40,7 @@ func New() *Tracker {
 	return &Tracker{client: client}
 }
 
+// Collect reports the usage of subject along with its attached metadata that is props.
 func (t *Tracker) Collect(subject string, props usage.Properties) {
 	if t.client == nil {
 		return
@@ -51,13 +54,13 @@ func (t *Tracker) Collect(subject string, props usage.Properties) {
 		p[k] = v
 	}
 
-	userId := credentials.Get().Username
-	if userId == "" {
-		userId = "saucectlanon"
+	userID := credentials.Get().Username
+	if userID == "" {
+		userID = "saucectlanon"
 	}
 
 	if err := t.client.Enqueue(analytics.Track{
-		UserId:     userId,
+		UserId:     userID,
 		Event:      "Command Executed",
 		Properties: p,
 
@@ -72,6 +75,7 @@ func (t *Tracker) Collect(subject string, props usage.Properties) {
 	}
 }
 
+// Close closes the underlying client.
 func (t *Tracker) Close() error {
 	return t.client.Close()
 }

--- a/internal/setup/segment.go
+++ b/internal/setup/segment.go
@@ -1,0 +1,8 @@
+package setup
+
+// These values are overridden via ldflags.
+
+// SegmentWriteKey is the access key (referred to as "write key" by segment) for segment.
+var (
+	SegmentWriteKey = ""
+)

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -44,7 +44,7 @@ func (p Properties) SetFlags(flags *pflag.FlagSet) Properties {
 		ff = append(ff, flag.Name)
 	})
 
-	p["flags"] = flags
+	p["flags"] = ff
 
 	return p
 }

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -1,0 +1,75 @@
+package usage
+
+import (
+	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/report"
+	"io"
+)
+
+type Properties map[string]interface{}
+
+func (p Properties) Set(key string, val interface{}) Properties {
+	p[key] = val
+	return p
+}
+
+func (p Properties) SetArtifacts(art config.Artifacts) Properties {
+	p["artifact_download_match"] = art.Download.Match
+	p["artifact_download_when"] = art.Download.When
+	return p
+}
+
+func (p Properties) SetDocker(d config.Docker) Properties {
+	p["docker_img"] = d.Image
+	p["docker_transfer"] = d.FileTransfer
+	return p
+}
+
+// SetFramework sets the test framework.
+func (p Properties) SetFramework(f string) Properties {
+	p["framework"] = f
+	return p
+}
+
+// SetFVersion sets the test framework version.
+func (p Properties) SetFVersion(f string) Properties {
+	p["framework_version"] = f
+	return p
+}
+
+func (p Properties) SetFlags(flags map[string]interface{}) Properties {
+	p["flags"] = flags
+	return p
+}
+
+func (p Properties) SetJobs(jobs []report.TestResult) Properties {
+	p["jobs"] = jobs
+
+	return p
+}
+
+func (p Properties) SetNPM(npm config.Npm) Properties {
+	p["npm_registry"] = npm.Registry
+	p["npm_packages"] = npm.Packages
+	return p
+}
+
+func (p Properties) SetNumSuites(n int) Properties {
+	p["num_suites"] = n
+	return p
+}
+
+func (p Properties) SetSauceConfig(c config.SauceConfig) Properties {
+	p["concurrency"] = c.Concurrency
+	p["region"] = c.Region
+	p["tunnel"] = c.Tunnel.ID
+	p["tunnel_owner"] = c.Tunnel.Parent
+	p["retries"] = c.Retries
+
+	return p
+}
+
+type Tracker interface {
+	io.Closer
+	Collect(subject string, props Properties)
+}

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -3,62 +3,73 @@ package usage
 import (
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/report"
+	"github.com/spf13/pflag"
 	"io"
 )
 
+// Properties is a scoped data transfer object for usage reporting and contains usage event related data.
 type Properties map[string]interface{}
 
-func (p Properties) Set(key string, val interface{}) Properties {
-	p[key] = val
-	return p
-}
-
+// SetArtifacts reports artifact usage.
 func (p Properties) SetArtifacts(art config.Artifacts) Properties {
 	p["artifact_download_match"] = art.Download.Match
 	p["artifact_download_when"] = art.Download.When
 	return p
 }
 
+// SetDocker reports the docker container setup.
 func (p Properties) SetDocker(d config.Docker) Properties {
 	p["docker_img"] = d.Image
 	p["docker_transfer"] = d.FileTransfer
 	return p
 }
 
-// SetFramework sets the test framework.
+// SetFramework reports the framework.
 func (p Properties) SetFramework(f string) Properties {
 	p["framework"] = f
 	return p
 }
 
-// SetFVersion sets the test framework version.
+// SetFVersion reports the framework version.
 func (p Properties) SetFVersion(f string) Properties {
 	p["framework_version"] = f
 	return p
 }
 
-func (p Properties) SetFlags(flags map[string]interface{}) Properties {
+// SetFlags reports CLI flags.
+func (p Properties) SetFlags(flags *pflag.FlagSet) Properties {
+	var ff []string
+
+	flags.Visit(func(flag *pflag.Flag) {
+		ff = append(ff, flag.Name)
+	})
+
 	p["flags"] = flags
+
 	return p
 }
 
+// SetJobs reports job (aka test results).
 func (p Properties) SetJobs(jobs []report.TestResult) Properties {
 	p["jobs"] = jobs
 
 	return p
 }
 
+// SetNPM reports the npm usage.
 func (p Properties) SetNPM(npm config.Npm) Properties {
 	p["npm_registry"] = npm.Registry
 	p["npm_packages"] = npm.Packages
 	return p
 }
 
+// SetNumSuites reports the number of configured suites.
 func (p Properties) SetNumSuites(n int) Properties {
 	p["num_suites"] = n
 	return p
 }
 
+// SetSauceConfig reports key fields of the sauce config.
 func (p Properties) SetSauceConfig(c config.SauceConfig) Properties {
 	p["concurrency"] = c.Concurrency
 	p["region"] = c.Region
@@ -69,6 +80,7 @@ func (p Properties) SetSauceConfig(c config.SauceConfig) Properties {
 	return p
 }
 
+// Tracker is an interface for providing usage tracking.
 type Tracker interface {
 	io.Closer
 	Collect(subject string, props Properties)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Add usage tracking.

This tracks usage across the following commands:
- saucectl init
- saucectl configure
- saucectl run (incl. the framework specific subcommands)