### PR TITLE
Capture CI info as part of properties

### DIFF
--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -28,7 +28,6 @@ func New() *Tracker {
 			OS: analytics.OSInfo{
 				Name: runtime.GOOS + " " + runtime.GOARCH,
 			},
-			Extra: map[string]interface{}{"ci": ci.GetProvider().Name},
 		},
 	})
 	if err != nil {
@@ -48,7 +47,7 @@ func (t *Tracker) Collect(subject string, props usage.Properties) {
 
 	p := analytics.NewProperties()
 	p.Set("subject_name", subject).Set("product_area", "DevX").
-		Set("product_sub_area", "SauceCTL")
+		Set("product_sub_area", "SauceCTL").Set("ci", ci.GetProvider().Name)
 
 	for k, v := range props {
 		p[k] = v


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
The way our segment sources/destinations are setup, it seems to be rather difficult to extract the `extra` info out of a context, unless it's part of the default fields, like OS.
Hence moving the CI field outside the context and into properties.