### PR TITLE
Collect only npm package names

### DIFF
--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -59,7 +59,13 @@ func (p Properties) SetJobs(jobs []report.TestResult) Properties {
 // SetNPM reports the npm usage.
 func (p Properties) SetNPM(npm config.Npm) Properties {
 	p["npm_registry"] = npm.Registry
-	p["npm_packages"] = npm.Packages
+
+	var pkgs []string
+	for k := range npm.Packages {
+		pkgs = append(pkgs, k)
+	}
+	p["npm_packages"] = pkgs
+
 	return p
 }
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Prior to this change, we collected the nested object of NPM packages + versions.
Not all downstream tools support "complex" objects like that, making it harder to analyze.
Also, we don't really care about the versions. Thus no reason to collect.
This change simplifies the object into an array.
