### PR TITLE
[DEVX-1218] Fix wrong test total duration

### DIFF
--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/rs/zerolog/log"
-
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/download"
 	"github.com/saucelabs/saucectl/internal/framework"
@@ -23,6 +22,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/jsonio"
 	"github.com/saucelabs/saucectl/internal/progress"
 	"github.com/saucelabs/saucectl/internal/report"
+	"github.com/saucelabs/saucectl/internal/report/table"
 	"github.com/saucelabs/saucectl/internal/sauceignore"
 )
 
@@ -41,6 +41,8 @@ type ContainerRunner struct {
 	Reporters []report.Reporter
 
 	interrupted bool
+	startTime   time.Time
+	endTime     time.Time
 }
 
 // containerStartOptions represent data required to start a new container.
@@ -275,6 +277,7 @@ func (r *ContainerRunner) createWorkerPool(ccy int) (chan containerStartOptions,
 
 	log.Info().Int("concurrency", ccy).Msg("Launching workers.")
 
+	r.startTime = time.Now()
 	for i := 0; i < ccy; i++ {
 		go r.runJobs(jobOpts, results)
 	}
@@ -377,8 +380,12 @@ func (r *ContainerRunner) collectResults(artifactCfg config.ArtifactDownload, re
 		r.logSuite(res)
 	}
 	close(done)
+	r.endTime = time.Now()
 
 	for _, rep := range r.Reporters {
+		if rpt, ok := rep.(*table.Reporter); ok {
+			rpt.TotalDuration = r.endTime.Sub(r.startTime)
+		}
 		rep.Render()
 	}
 

--- a/internal/report/captor/captor.go
+++ b/internal/report/captor/captor.go
@@ -2,7 +2,6 @@ package captor
 
 import (
 	"sync"
-	"time"
 
 	"github.com/saucelabs/saucectl/internal/report"
 )
@@ -12,9 +11,8 @@ var Default = Reporter{}
 
 // Reporter is a simple implementation for report.Reporter, a no-output reporter for capturing test results.
 type Reporter struct {
-	TestResults   []report.TestResult
-	lock          sync.Mutex
-	TotalDuration time.Duration
+	TestResults []report.TestResult
+	lock        sync.Mutex
 }
 
 // Add adds the test result.

--- a/internal/report/captor/captor.go
+++ b/internal/report/captor/captor.go
@@ -1,8 +1,10 @@
 package captor
 
 import (
-	"github.com/saucelabs/saucectl/internal/report"
 	"sync"
+	"time"
+
+	"github.com/saucelabs/saucectl/internal/report"
 )
 
 // Default is the default, global instance of Reporter. Use judiciously.
@@ -10,8 +12,9 @@ var Default = Reporter{}
 
 // Reporter is a simple implementation for report.Reporter, a no-output reporter for capturing test results.
 type Reporter struct {
-	TestResults []report.TestResult
-	lock        sync.Mutex
+	TestResults   []report.TestResult
+	lock          sync.Mutex
+	TotalDuration time.Duration
 }
 
 // Add adds the test result.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -6,7 +6,7 @@ import "time"
 type TestResult struct {
 	Name       string        `json:"name"`
 	Duration   time.Duration `json:"duration"`
-	StartTime  time.Time     `json:"sstartTime"`
+	StartTime  time.Time     `json:"startTime"`
 	EndTime    time.Time     `json:"endTime"`
 	Passed     bool          `json:"passed"`
 	Browser    string        `json:"browser"`

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -6,6 +6,8 @@ import "time"
 type TestResult struct {
 	Name       string        `json:"name"`
 	Duration   time.Duration `json:"duration"`
+	StartTime  time.Time     `json:"sstartTime"`
+	EndTime    time.Time     `json:"endTime"`
 	Passed     bool          `json:"passed"`
 	Browser    string        `json:"browser"`
 	Platform   string        `json:"platform"`

--- a/internal/report/table/table.go
+++ b/internal/report/table/table.go
@@ -150,16 +150,13 @@ func statusSymbol(passed bool) string {
 }
 
 func calDuration(results []report.TestResult) time.Duration {
-	if len(results) == 0 {
-		return 0
-	}
-	start := results[0].StartTime
-	end := results[0].EndTime
+	start := time.Now()
+	end := start
 	for _, r := range results {
-		if start.After(r.StartTime) {
+		if r.StartTime.Before(start) {
 			start = r.StartTime
 		}
-		if end.Before(r.EndTime) {
+		if r.EndTime.After(end) {
 			end = r.EndTime
 		}
 	}

--- a/internal/report/table/table.go
+++ b/internal/report/table/table.go
@@ -53,10 +53,9 @@ var defaultTableStyle = table.Style{
 
 // Reporter is a table writer implementation for report.Reporter.
 type Reporter struct {
-	TestResults   []report.TestResult
-	Dst           io.Writer
-	lock          sync.Mutex
-	TotalDuration time.Duration
+	TestResults []report.TestResult
+	Dst         io.Writer
+	lock        sync.Mutex
 }
 
 // Add adds the test result to the summary table.
@@ -107,7 +106,7 @@ func (r *Reporter) Render() {
 			statusText(ts.Passed), ts.Browser, ts.Platform, ts.DeviceName})
 	}
 
-	t.AppendFooter(footer(errors, len(r.TestResults), r.TotalDuration))
+	t.AppendFooter(footer(errors, len(r.TestResults), calDuration(r.TestResults)))
 
 	_, _ = fmt.Fprintln(r.Dst)
 	t.Render()
@@ -148,4 +147,22 @@ func statusSymbol(passed bool) string {
 	}
 
 	return color.GreenString("✔")
+}
+
+func calDuration(results []report.TestResult) time.Duration {
+	if len(results) == 0 {
+		return 0
+	}
+	start := results[0].StartTime
+	end := results[0].EndTime
+	for _, r := range results {
+		if start.After(r.StartTime) {
+			start = r.StartTime
+		}
+		if end.Before(r.EndTime) {
+			end = r.EndTime
+		}
+	}
+
+	return end.Sub(start)
 }

--- a/internal/report/table/table.go
+++ b/internal/report/table/table.go
@@ -53,9 +53,10 @@ var defaultTableStyle = table.Style{
 
 // Reporter is a table writer implementation for report.Reporter.
 type Reporter struct {
-	TestResults []report.TestResult
-	Dst         io.Writer
-	lock        sync.Mutex
+	TestResults   []report.TestResult
+	Dst           io.Writer
+	lock          sync.Mutex
+	TotalDuration time.Duration
 }
 
 // Add adds the test result to the summary table.
@@ -106,7 +107,7 @@ func (r *Reporter) Render() {
 			statusText(ts.Passed), ts.Browser, ts.Platform, ts.DeviceName})
 	}
 
-	t.AppendFooter(footer(errors, len(r.TestResults), totalDur))
+	t.AppendFooter(footer(errors, len(r.TestResults), r.TotalDuration))
 
 	_, _ = fmt.Fprintln(r.Dst)
 	t.Render()

--- a/internal/report/table/table_test.go
+++ b/internal/report/table/table_test.go
@@ -2,15 +2,17 @@ package table
 
 import (
 	"bytes"
-	"github.com/saucelabs/saucectl/internal/report"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/saucelabs/saucectl/internal/report"
 )
 
 func TestReporter_Render(t *testing.T) {
 	type fields struct {
-		TestResults []report.TestResult
+		TestResults   []report.TestResult
+		TotalDuration time.Duration
 	}
 	tests := []struct {
 		name   string
@@ -20,6 +22,7 @@ func TestReporter_Render(t *testing.T) {
 		{
 			name: "all pass",
 			fields: fields{
+				TotalDuration: 34479 * time.Millisecond,
 				TestResults: []report.TestResult{
 					{
 						Name:     "Firefox",
@@ -37,19 +40,19 @@ func TestReporter_Render(t *testing.T) {
 					},
 				},
 			},
-			want:
-			`
+			want: `
        Name                              Duration    Status    Browser    Platform    
 ──────────────────────────────────────────────────────────────────────────────────────
   ✔    Firefox                                34s    passed    Firefox    Windows 10  
   ✔    Chrome                                  5s    passed    Chrome     Windows 10  
 ──────────────────────────────────────────────────────────────────────────────────────
-  ✔    All tests have passed                  39s                                     
+  ✔    All tests have passed                  34s                                     
 `,
 		},
 		{
 			name: "with failure",
 			fields: fields{
+				TotalDuration: 205931 * time.Millisecond,
 				TestResults: []report.TestResult{
 					{
 						Name:     "Firefox",
@@ -67,8 +70,7 @@ func TestReporter_Render(t *testing.T) {
 					},
 				},
 			},
-			want:
-			`
+			want: `
        Name                               Duration    Status    Browser    Platform    
 ───────────────────────────────────────────────────────────────────────────────────────
   ✔    Firefox                                 34s    passed    Firefox    Windows 10  
@@ -83,8 +85,9 @@ func TestReporter_Render(t *testing.T) {
 			var buffy bytes.Buffer
 
 			r := &Reporter{
-				TestResults: tt.fields.TestResults,
-				Dst:         &buffy,
+				TestResults:   tt.fields.TestResults,
+				Dst:           &buffy,
+				TotalDuration: tt.fields.TotalDuration,
 			}
 			r.Render()
 

--- a/internal/report/table/table_test.go
+++ b/internal/report/table/table_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestReporter_Render(t *testing.T) {
 	type fields struct {
-		TestResults   []report.TestResult
-		TotalDuration time.Duration
+		TestResults []report.TestResult
 	}
+	startTime := time.Now()
 	tests := []struct {
 		name   string
 		fields fields
@@ -22,21 +22,24 @@ func TestReporter_Render(t *testing.T) {
 		{
 			name: "all pass",
 			fields: fields{
-				TotalDuration: 34479 * time.Millisecond,
 				TestResults: []report.TestResult{
 					{
-						Name:     "Firefox",
-						Duration: 34479 * time.Millisecond,
-						Passed:   true,
-						Browser:  "Firefox",
-						Platform: "Windows 10",
+						Name:      "Firefox",
+						Duration:  34479 * time.Millisecond,
+						StartTime: startTime,
+						EndTime:   startTime.Add(34479 * time.Millisecond),
+						Passed:    true,
+						Browser:   "Firefox",
+						Platform:  "Windows 10",
 					},
 					{
-						Name:     "Chrome",
-						Duration: 5123 * time.Millisecond,
-						Passed:   true,
-						Browser:  "Chrome",
-						Platform: "Windows 10",
+						Name:      "Chrome",
+						Duration:  5123 * time.Millisecond,
+						StartTime: startTime,
+						EndTime:   startTime.Add(5123 * time.Millisecond),
+						Passed:    true,
+						Browser:   "Chrome",
+						Platform:  "Windows 10",
 					},
 				},
 			},
@@ -52,21 +55,24 @@ func TestReporter_Render(t *testing.T) {
 		{
 			name: "with failure",
 			fields: fields{
-				TotalDuration: 205931 * time.Millisecond,
 				TestResults: []report.TestResult{
 					{
-						Name:     "Firefox",
-						Duration: 34479 * time.Millisecond,
-						Passed:   true,
-						Browser:  "Firefox",
-						Platform: "Windows 10",
+						Name:      "Firefox",
+						Duration:  34479 * time.Millisecond,
+						StartTime: startTime,
+						EndTime:   startTime.Add(34479 * time.Millisecond),
+						Passed:    true,
+						Browser:   "Firefox",
+						Platform:  "Windows 10",
 					},
 					{
-						Name:     "Chrome",
-						Duration: 171452 * time.Millisecond,
-						Passed:   false,
-						Browser:  "Chrome",
-						Platform: "Windows 10",
+						Name:      "Chrome",
+						Duration:  171452 * time.Millisecond,
+						StartTime: startTime,
+						EndTime:   startTime.Add(171452 * time.Millisecond),
+						Passed:    false,
+						Browser:   "Chrome",
+						Platform:  "Windows 10",
 					},
 				},
 			},
@@ -76,7 +82,7 @@ func TestReporter_Render(t *testing.T) {
   ✔    Firefox                                 34s    passed    Firefox    Windows 10  
   ✖    Chrome                                2m51s    failed    Chrome     Windows 10  
 ───────────────────────────────────────────────────────────────────────────────────────
-  ✖    1 of 2 suites have failed (50%)       3m25s                                     
+  ✖    1 of 2 suites have failed (50%)       2m51s                                     
 `,
 		},
 	}
@@ -85,9 +91,8 @@ func TestReporter_Render(t *testing.T) {
 			var buffy bytes.Buffer
 
 			r := &Reporter{
-				TestResults:   tt.fields.TestResults,
-				Dst:           &buffy,
-				TotalDuration: tt.fields.TotalDuration,
+				TestResults: tt.fields.TestResults,
+				Dst:         &buffy,
 			}
 			r.Render()
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Only calculate test duration from the start to the end instead of only adding duration.

Given 2 suites and 2ccy.
Docker:
```
       Name                                Duration    Status    Browser                 Platform
───────────────────────────────────────────────────────────────────────────────────────────────────
  ✔    Chrome using global mode setting         50s    passed    chrome 92.0.4515.159    Docker
  ✔    Firefox in sauce                         51s    passed    firefox 91.0.2          Docker
───────────────────────────────────────────────────────────────────────────────────────────────────
  ✔    All tests have passed                    51s
```
Sauce:
```
       Name                                Duration    Status    Browser       Platform
───────────────────────────────────────────────────────────────────────────────────────────
  ✔    Chrome using global mode setting        1m3s    passed    chrome 93     Windows 10
  ✔    Firefox in sauce                        1m3s    passed    firefox 92    Windows 10
───────────────────────────────────────────────────────────────────────────────────────────
  ✔    All tests have passed                   1m4s
```
====

Given 4 suites and 2 ccy.
Docker:
```
       Name                                Duration    Status    Browser                 Platform
───────────────────────────────────────────────────────────────────────────────────────────────────
  ✔    Chrome using global mode setting         56s    passed    chrome 92.0.4515.159    Docker
  ✔    Firefox in sauce                         57s    passed    firefox 91.0.2          Docker
  ✔    Firefox in sauce3                        47s    passed    firefox 91.0.2          Docker
  ✔    Firefox in sauce2                        49s    passed    firefox 91.0.2          Docker
───────────────────────────────────────────────────────────────────────────────────────────────────
  ✔    All tests have passed                  1m46s
```

Sauce:
```
       Name                                Duration    Status    Browser       Platform
───────────────────────────────────────────────────────────────────────────────────────────
  ✔    Firefox in sauce                         50s    passed    firefox 92    Windows 10
  ✔    Chrome using global mode setting        1m3s    passed    chrome 93     Windows 10
  ✔    Firefox in sauce2                       1m2s    passed    firefox 92    Windows 10
  ✔    Firefox in sauce3                       1m3s    passed    firefox 92    Windows 10
───────────────────────────────────────────────────────────────────────────────────────────
  ✔    All tests have passed                   2m7s
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->