### PR TITLE
Cypress Test Sharding

### DIFF
--- a/api/v1alpha/framework/cypress.schema.json
+++ b/api/v1alpha/framework/cypress.schema.json
@@ -150,6 +150,13 @@
           "mode": {
             "$ref": "../subschema/common.schema.json#/definitions/mode"
           },
+          "shard": {
+            "description": "When sharding is configured, saucectl automatically splits the tests (e.g. by spec) so that they can easily run in parallel.",
+            "enum": [
+              "",
+              "spec"
+            ]
+          },
           "timeout": {
             "$ref": "../subschema/common.schema.json#/definitions/timeout"
           }

--- a/api/v1alpha/generated/saucectl.schema.json
+++ b/api/v1alpha/generated/saucectl.schema.json
@@ -371,6 +371,13 @@
                     "sauce"
                   ]
                 },
+                "shard": {
+                  "description": "When sharding is configured, saucectl automatically splits the tests (e.g. by spec) so that they can easily run in parallel.",
+                  "enum": [
+                    "",
+                    "spec"
+                  ]
+                },
                 "timeout": {
                   "description": "Instructs how long (in ms, s, m, or h) saucectl should wait for a suite to complete.",
                   "type": "string",

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/hcsshim v0.8.9 // indirect
 	github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8
+	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/briandowns/spinner v1.11.1
 	github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/briandowns/spinner v1.11.1 h1:OixPqDEcX3juo5AjQZAnFPbeUA0jvkp2qzB5gOZJ/L0=

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -75,6 +75,7 @@ func NewCypressCmd() *cobra.Command {
 
 	// Misc
 	sc.String("rootDir", "rootDir", ".", "Control what files are available in the context of a test run, unless explicitly excluded by .sauceignore")
+	sc.String("shard", "suite.shard", "", "Controls whether or not (and how) tests are sharded across multiple machines")
 
 	// NPM
 	sc.String("npm.registry", "npm.registry", "", "Specify the npm registry URL")

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -3,6 +3,8 @@ package cypress
 import (
 	"errors"
 	"fmt"
+	"github.com/bmatcuk/doublestar/v4"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,6 +60,7 @@ type Suite struct {
 	ScreenResolution string        `yaml:"screenResolution,omitempty" json:"screenResolution"`
 	Mode             string        `yaml:"mode,omitempty" json:"-"`
 	Timeout          time.Duration `yaml:"timeout,omitempty" json:"timeout"`
+	Shard            string        `yaml:"shard,omitempty" json:"-"`
 }
 
 // SuiteConfig represents the cypress config overrides.
@@ -177,53 +180,50 @@ func checkAvailability(path string, mustBeDirectory bool) error {
 	return nil
 }
 
-// ValidateCypressConfiguration validates that Cypress config has required folders.
-func ValidateCypressConfiguration(rootDir string, cypressCfgFile, sauceIgnoreFile string) error {
+// loadCypressConfiguration reads the cypress.json file and performs basic validation.
+func loadCypressConfiguration(rootDir string, cypressCfgFile, sauceIgnoreFile string) (Config, error) {
 	isIgnored, err := isCypressCfgIgnored(sauceIgnoreFile, cypressCfgFile)
 	if err != nil {
-		return err
+		return Config{}, err
 	}
 	if isIgnored {
-		return fmt.Errorf("your .sauceignore configuration seems to include statements that match crucial cypress configuration files (e.g. cypress.json). In order to run your test successfully, please adjust your .sauceignore configuration")
+		return Config{}, fmt.Errorf("your .sauceignore configuration seems to include statements that match crucial cypress configuration files (e.g. cypress.json). In order to run your test successfully, please adjust your .sauceignore configuration")
 	}
 
 	cypressCfgPath := filepath.Join(rootDir, cypressCfgFile)
-	if _, err := os.Stat(cypressCfgPath); err != nil {
-		return fmt.Errorf("unable to locate the cypress config file at %s", cypressCfgPath)
+	cfg, err := configFromFile(cypressCfgPath)
+	if err != nil {
+		return Config{}, err
+	}
+
+	if cfg.IntegrationFolder == "" {
+		cfg.IntegrationFolder = "cypress/integration"
 	}
 
 	configDir := filepath.Dir(cypressCfgPath)
-	cfg, err := configFromFile(cypressCfgPath)
-	if err != nil {
-		return err
-	}
-
-	integrationFolder := "cypress/integration"
-	if cfg.IntegrationFolder != "" {
-		integrationFolder = cfg.IntegrationFolder
-	}
-	if err = checkAvailability(filepath.Join(configDir, integrationFolder), true); err != nil {
-		return err
+	if err = checkAvailability(filepath.Join(configDir, cfg.IntegrationFolder), true); err != nil {
+		return Config{}, err
 	}
 
 	if cfg.FixturesFolder != "" {
 		if err = checkAvailability(filepath.Join(configDir, cfg.FixturesFolder), true); err != nil {
-			return err
+			return Config{}, err
 		}
 	}
 
 	if cfg.SupportFile != "" {
 		if err = checkAvailability(filepath.Join(configDir, cfg.SupportFile), false); err != nil {
-			return err
+			return Config{}, err
 		}
 	}
 
 	if cfg.PluginsFile != "" {
 		if err = checkAvailability(filepath.Join(configDir, cfg.PluginsFile), false); err != nil {
-			return err
+			return Config{}, err
 		}
 	}
-	return nil
+
+	return cfg, nil
 }
 
 func isCypressCfgIgnored(sauceIgnoreFile, cypressCfgFile string) (bool, error) {
@@ -246,10 +246,6 @@ func Validate(p *Project) error {
 
 	if p.Cypress.Version == "" {
 		return errors.New("missing framework version. Check available versions here: https://docs.staging.saucelabs.net/testrunner-toolkit#supported-frameworks-and-browsers")
-	}
-	// Validate cypress configuration
-	if err := ValidateCypressConfiguration(p.RootDir, p.Cypress.ConfigFile, p.Sauce.Sauceignore); err != nil {
-		return err
 	}
 
 	// Validate docker.
@@ -297,7 +293,14 @@ func Validate(p *Project) error {
 		}
 	}
 
-	return nil
+	cfg, err := loadCypressConfiguration(p.RootDir, p.Cypress.ConfigFile, p.Sauce.Sauceignore)
+	if err != nil {
+		return err
+	}
+
+	p.Suites, err = shardSuites(cfg, p.Suites)
+
+	return err
 }
 
 // SplitSuites divided Suites to dockerSuites and sauceSuites
@@ -318,6 +321,58 @@ func SplitSuites(p Project) (Project, Project) {
 	sauceProject.Suites = sauceSuites
 
 	return dockerProject, sauceProject
+}
+
+func shardSuites(cfg Config, suites []Suite) ([]Suite, error) {
+	absIntFolder := cfg.AbsIntegrationFolder()
+
+	var shardedSuites []Suite
+	for _, s := range suites {
+		// Use the original suite if there is nothing to shard.
+		if s.Shard != "spec" {
+			shardedSuites = append(shardedSuites, s)
+			continue
+		}
+
+		if err := filepath.WalkDir(absIntFolder, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if d.IsDir() {
+				return nil
+			}
+
+			// Normalize path separators, since the target execution environment may not support backslashes.
+			pathSlashes := filepath.ToSlash(path)
+
+			for _, pattern := range s.Config.TestFiles {
+				patternSlashes := filepath.ToSlash(pattern)
+				ok, err := doublestar.Match(patternSlashes, pathSlashes)
+				if err != nil {
+					return fmt.Errorf("test file pattern '%s' is not supported: %s", patternSlashes, err)
+				}
+
+				if ok {
+					rel, err := filepath.Rel(absIntFolder, path)
+					if err != nil {
+						return err
+					}
+					rel = filepath.ToSlash(rel)
+					replica := s
+					replica.Name = fmt.Sprintf("%s - %s", s.Name, rel)
+					replica.Config.TestFiles = []string{rel}
+					shardedSuites = append(shardedSuites, replica)
+				}
+			}
+
+			return nil
+		}); err != nil {
+			return shardedSuites, err
+		}
+	}
+
+	return shardedSuites, nil
 }
 
 // FilterSuites filters out suites in the project that don't match the given suite name.

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -193,7 +193,7 @@ func ValidateCypressConfiguration(rootDir string, cypressCfgFile, sauceIgnoreFil
 	}
 
 	configDir := filepath.Dir(cypressCfgPath)
-	cfg, err := ConfigFromFile(cypressCfgPath)
+	cfg, err := configFromFile(cypressCfgPath)
 	if err != nil {
 		return err
 	}

--- a/internal/cypress/config_test.go
+++ b/internal/cypress/config_test.go
@@ -68,7 +68,7 @@ func TestFilterSuites(t *testing.T) {
 	}
 }
 
-func TestValidateCypressConfiguration(t *testing.T) {
+func Test_loadCypressConfiguration(t *testing.T) {
 	tests := []struct {
 		creator     func(t *testing.T) *fs.Dir
 		name        string
@@ -195,7 +195,7 @@ func TestValidateCypressConfiguration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := tt.creator(t)
 			defer d.Remove()
-			err := ValidateCypressConfiguration(d.Path(), "cypress.json", ".sauceignore")
+			_, err := loadCypressConfiguration(d.Path(), "cypress.json", ".sauceignore")
 
 			if tt.wantErr != "" {
 				expectedErr := tt.wantErr

--- a/internal/cypress/native.go
+++ b/internal/cypress/native.go
@@ -2,15 +2,25 @@ package cypress
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // Config represents the cypress.json native configuration file.
 type Config struct {
+	// Path is the location of the config file itself.
+	Path string `yaml:"-" json:"-"`
+
 	FixturesFolder    string `json:"fixturesFolder,omitempty"`
 	IntegrationFolder string `json:"integrationFolder,omitempty"`
 	PluginsFile       string `json:"pluginsFile,omitempty"`
 	SupportFile       string `json:"supportFile,omitempty"`
+}
+
+// AbsIntegrationFolder returns the absolute path to Config.IntegrationFolder.
+func (c Config) AbsIntegrationFolder() string {
+	return filepath.Join(filepath.Join(filepath.Dir(c.Path), c.IntegrationFolder))
 }
 
 // configFromFile loads cypress configuration into Config structure.
@@ -19,8 +29,9 @@ func configFromFile(fileName string) (Config, error) {
 
 	fd, err := os.Open(fileName)
 	if err != nil {
-		return c, err
+		return c, fmt.Errorf("unable to locate the cypress config file at: %s", fileName)
 	}
 	err = json.NewDecoder(fd).Decode(&c)
+	c.Path = fileName
 	return c, err
 }

--- a/internal/cypress/native.go
+++ b/internal/cypress/native.go
@@ -13,8 +13,8 @@ type Config struct {
 	SupportFile       string `json:"supportFile,omitempty"`
 }
 
-// ConfigFromFile loads cypress configuration into Config structure.
-func ConfigFromFile(fileName string) (Config, error) {
+// configFromFile loads cypress configuration into Config structure.
+func configFromFile(fileName string) (Config, error) {
 	var c Config
 
 	fd, err := os.Open(fileName)

--- a/internal/cypress/native_test.go
+++ b/internal/cypress/native_test.go
@@ -40,13 +40,13 @@ func TestConfigFromFile(t *testing.T) {
 			dir := fs.NewDir(t, "cypress-config", fs.WithMode(0755),
 				fs.WithFile("cypress.json", tt.fileContent, fs.WithMode(0644)))
 			defer dir.Remove()
-			got, err := ConfigFromFile(dir.Join("cypress.json"))
+			got, err := configFromFile(dir.Join("cypress.json"))
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ConfigFromFile() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("configFromFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ConfigFromFile() got = %v, want %v", got, tt.want)
+				t.Errorf("configFromFile() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/cypress/native_test.go
+++ b/internal/cypress/native_test.go
@@ -1,9 +1,11 @@
 package cypress
 
 import (
-	"gotest.tools/v3/fs"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	"gotest.tools/v3/fs"
 )
 
 func TestConfigFromFile(t *testing.T) {
@@ -17,22 +19,22 @@ func TestConfigFromFile(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name: "Valid File - Empty",
+			name:        "Valid File - Empty",
 			fileContent: `{}`,
-			want: Config{},
-			wantErr: false,
+			want:        Config{},
+			wantErr:     false,
 		},
 		{
-			name: "Valid File - Integration folder",
+			name:        "Valid File - Integration folder",
 			fileContent: `{"integrationFolder":"./e2e/integration"}`,
-			want: Config{IntegrationFolder: "./e2e/integration"},
-			wantErr: false,
+			want:        Config{IntegrationFolder: "./e2e/integration"},
+			wantErr:     false,
 		},
 		{
-			name: "Invalid File",
+			name:        "Invalid File",
 			fileContent: `{"integrationFolder":"./e2e/integration}`,
-			want: Config{},
-			wantErr: true,
+			want:        Config{},
+			wantErr:     true,
 		},
 	}
 	for _, tt := range tests {
@@ -40,6 +42,9 @@ func TestConfigFromFile(t *testing.T) {
 			dir := fs.NewDir(t, "cypress-config", fs.WithMode(0755),
 				fs.WithFile("cypress.json", tt.fileContent, fs.WithMode(0644)))
 			defer dir.Remove()
+
+			tt.want.Path = filepath.Join(dir.Path(), "cypress.json")
+
 			got, err := configFromFile(dir.Join("cypress.json"))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("configFromFile() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Shard tests automatically by spec, if desired. This will launch as many jobs as there are spec files.

**shard by spec:**
```
       Name                                     Duration    Status    Browser      Platform
───────────────────────────────────────────────────────────────────────────────────────────────
  ✔    all tests - examples/actions.spec.js          47s    passed    chrome 94    Windows 10
  ✔    all tests - examples/actions3.spec.js         47s    passed    chrome 94    Windows 10
  ✔    all tests - examples/actions2.spec.js         47s    passed    chrome 94    Windows 10
───────────────────────────────────────────────────────────────────────────────────────────────
  ✔    All tests have passed                         48s
```

**no sharding:**
```
       Name                              Duration    Status    Browser      Platform
────────────────────────────────────────────────────────────────────────────────────────
  ✔    all tests                            1m17s    passed    chrome 94    Windows 10
────────────────────────────────────────────────────────────────────────────────────────
  ✔    All tests have passed                1m17s
```