### PR TITLE
[DEVX-1347] Add a flag to disable collecting segment metrics

### DIFF
--- a/internal/cmd/configure/cmd.go
+++ b/internal/cmd/configure/cmd.go
@@ -32,7 +32,7 @@ func Command() *cobra.Command {
 		Long:    configureLong,
 		Example: configureExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New(false)
+			tracker := segment.New(true)
 
 			defer func() {
 				tracker.Collect("Configure", nil)

--- a/internal/cmd/configure/cmd.go
+++ b/internal/cmd/configure/cmd.go
@@ -16,12 +16,13 @@ import (
 )
 
 var (
-	configureUse     = "configure"
-	configureShort   = "Configure your Sauce Labs credentials"
-	configureLong    = `Persist locally your Sauce Labs credentials`
-	configureExample = "saucectl configure"
-	cliUsername      = ""
-	cliAccessKey     = ""
+	configureUse           = "configure"
+	configureShort         = "Configure your Sauce Labs credentials"
+	configureLong          = `Persist locally your Sauce Labs credentials`
+	configureExample       = "saucectl configure"
+	cliUsername            = ""
+	cliAccessKey           = ""
+	cliDisableUsageMetrics = false
 )
 
 // Command creates the `configure` command
@@ -32,7 +33,7 @@ func Command() *cobra.Command {
 		Long:    configureLong,
 		Example: configureExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New(nil)
+			tracker := segment.New(!cliDisableUsageMetrics)
 
 			defer func() {
 				tracker.Collect("Configure", nil)
@@ -50,6 +51,7 @@ func Command() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&cliUsername, "username", "u", "", "username, available on your sauce labs account")
 	cmd.Flags().StringVarP(&cliAccessKey, "accessKey", "a", "", "accessKey, available on your sauce labs account")
+	cmd.Flags().BoolVar(&cliDisableUsageMetrics, "disable-usage-metrics", false, "Disable usage metrics collection.")
 	return cmd
 }
 

--- a/internal/cmd/configure/cmd.go
+++ b/internal/cmd/configure/cmd.go
@@ -3,6 +3,9 @@ package configure
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/credentials"
@@ -10,8 +13,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/saucelabs/saucectl/internal/sentry"
 	"github.com/spf13/cobra"
-	"os"
-	"strings"
 )
 
 var (
@@ -31,7 +32,7 @@ func Command() *cobra.Command {
 		Long:    configureLong,
 		Example: configureExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New()
+			tracker := segment.New(false)
 
 			defer func() {
 				tracker.Collect("Configure", nil)

--- a/internal/cmd/configure/cmd.go
+++ b/internal/cmd/configure/cmd.go
@@ -32,7 +32,7 @@ func Command() *cobra.Command {
 		Long:    configureLong,
 		Example: configureExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New(true)
+			tracker := segment.New(nil)
 
 			defer func() {
 				tracker.Collect("Configure", nil)

--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -74,7 +74,7 @@ func Command() *cobra.Command {
 		Long:    initLong,
 		Example: initExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New(false)
+			tracker := segment.New(true)
 
 			defer func() {
 				tracker.Collect("Init", nil)

--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/saucelabs/saucectl/internal/segment"
 	"os"
 	"time"
+
+	"github.com/saucelabs/saucectl/internal/segment"
 
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/espresso"
@@ -73,7 +74,7 @@ func Command() *cobra.Command {
 		Long:    initLong,
 		Example: initExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New()
+			tracker := segment.New(false)
 
 			defer func() {
 				tracker.Collect("Init", nil)

--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -37,25 +37,26 @@ var (
 type initConfig struct {
 	batchMode bool
 
-	frameworkName    string
-	frameworkVersion string
-	cypressJSON      string
-	app              string
-	testApp          string
-	otherApps        []string
-	platformName     string
-	mode             string
-	browserName      string
-	region           string
-	artifactWhen     config.When
-	artifactWhenStr  string
-	device           config.Device
-	emulator         config.Emulator
-	deviceFlag       flags.Device
-	emulatorFlag     flags.Emulator
-	concurrency      int
-	username         string
-	accessKey        string
+	frameworkName       string
+	frameworkVersion    string
+	cypressJSON         string
+	app                 string
+	testApp             string
+	otherApps           []string
+	platformName        string
+	mode                string
+	browserName         string
+	region              string
+	artifactWhen        config.When
+	artifactWhenStr     string
+	device              config.Device
+	emulator            config.Emulator
+	deviceFlag          flags.Device
+	emulatorFlag        flags.Emulator
+	concurrency         int
+	username            string
+	accessKey           string
+	disableUsageMetrics bool
 }
 
 var (
@@ -74,7 +75,7 @@ func Command() *cobra.Command {
 		Long:    initLong,
 		Example: initExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New(nil)
+			tracker := segment.New(!initCfg.disableUsageMetrics)
 
 			defer func() {
 				tracker.Collect("Init", nil)
@@ -104,6 +105,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&initCfg.artifactWhenStr, "artifacts.download.when", "fail", "defines when to download artifacts")
 	cmd.Flags().Var(&initCfg.emulatorFlag, "emulator", "Specifies the emulator to use for testing")
 	cmd.Flags().Var(&initCfg.deviceFlag, "device", "Specifies the device to use for testing")
+	cmd.Flags().BoolVar(&initCfg.disableUsageMetrics, "disable-usage-metrics", false, "Disable usage metrics collection.")
 	return cmd
 }
 

--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -74,7 +74,7 @@ func Command() *cobra.Command {
 		Long:    initLong,
 		Example: initExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New(true)
+			tracker := segment.New(nil)
 
 			defer func() {
 				tracker.Collect("Init", nil)

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -111,7 +111,7 @@ func runCypress(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as 
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New()
+	tracker := segment.New(gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -111,7 +111,7 @@ func runCypress(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as 
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New(gFlags.disableUsageMetrics)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -111,8 +111,7 @@ func runCypress(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as 
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	enabled := !gFlags.disableUsageMetrics
-	tracker := segment.New(&enabled)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -111,7 +111,8 @@ func runCypress(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as 
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	enabled := !gFlags.disableUsageMetrics
+	tracker := segment.New(&enabled)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -109,7 +109,8 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, tc testcompose
 	rs.ArtifactConfig = p.Artifacts.Download
 	rc.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	enabled := !gFlags.disableUsageMetrics
+	tracker := segment.New(&enabled)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -109,7 +109,7 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, tc testcompose
 	rs.ArtifactConfig = p.Artifacts.Download
 	rc.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New(gFlags.disableUsageMetrics)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -109,8 +109,7 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, tc testcompose
 	rs.ArtifactConfig = p.Artifacts.Download
 	rc.ArtifactConfig = p.Artifacts.Download
 
-	enabled := !gFlags.disableUsageMetrics
-	tracker := segment.New(&enabled)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -109,7 +109,7 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, tc testcompose
 	rs.ArtifactConfig = p.Artifacts.Download
 	rc.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New()
+	tracker := segment.New(gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -119,8 +119,7 @@ func runPlaywright(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, 
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	enabled := !gFlags.disableUsageMetrics
-	tracker := segment.New(&enabled)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -119,7 +119,8 @@ func runPlaywright(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, 
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	enabled := !gFlags.disableUsageMetrics
+	tracker := segment.New(&enabled)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -119,7 +119,7 @@ func runPlaywright(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, 
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New(gFlags.disableUsageMetrics)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -119,7 +119,7 @@ func runPlaywright(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, 
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New()
+	tracker := segment.New(gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -100,7 +100,7 @@ func runPuppeteer(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client) (
 	rs.URL = regio.APIBaseURL()
 	tc.URL = regio.APIBaseURL()
 
-	tracker := segment.New(gFlags.disableUsageMetrics)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -100,8 +100,7 @@ func runPuppeteer(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client) (
 	rs.URL = regio.APIBaseURL()
 	tc.URL = regio.APIBaseURL()
 
-	enabled := !gFlags.disableUsageMetrics
-	tracker := segment.New(&enabled)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -100,7 +100,8 @@ func runPuppeteer(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client) (
 	rs.URL = regio.APIBaseURL()
 	tc.URL = regio.APIBaseURL()
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	enabled := !gFlags.disableUsageMetrics
+	tracker := segment.New(&enabled)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -100,7 +100,7 @@ func runPuppeteer(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client) (
 	rs.URL = regio.APIBaseURL()
 	tc.URL = regio.APIBaseURL()
 
-	tracker := segment.New()
+	tracker := segment.New(gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -135,7 +135,7 @@ func Command() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&gFlags.sauceAPI, "sauce-api", "", "Overrides the region specific sauce API URL. (e.g. https://api.us-west-1.saucelabs.com)")
 	cmd.PersistentFlags().StringVar(&gFlags.selectedSuite, "select-suite", "", "Run specified test suite.")
 	cmd.PersistentFlags().BoolVar(&gFlags.testEnvSilent, "test-env-silent", false, "Skips the test environment announcement.")
-	cmd.PersistentFlags().BoolVar(&gFlags.disableUsageMetrics, "disable-usage-metrics", false, "Disable usage metrics collections.")
+	cmd.PersistentFlags().BoolVar(&gFlags.disableUsageMetrics, "disable-usage-metrics", false, "Disable usage metrics collection.")
 	_ = cmd.PersistentFlags().MarkHidden("sauce-api")
 	_ = cmd.PersistentFlags().MarkHidden("runner-version")
 	_ = cmd.PersistentFlags().MarkHidden("experiment")

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -66,11 +66,12 @@ var (
 var gFlags = globalFlags{}
 
 type globalFlags struct {
-	cfgFilePath   string
-	globalTimeout time.Duration
-	sauceAPI      string
-	selectedSuite string
-	testEnvSilent bool
+	cfgFilePath         string
+	globalTimeout       time.Duration
+	sauceAPI            string
+	selectedSuite       string
+	testEnvSilent       bool
+	disableUsageMetrics bool
 }
 
 // Command creates the `run` command
@@ -134,6 +135,7 @@ func Command() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&gFlags.sauceAPI, "sauce-api", "", "Overrides the region specific sauce API URL. (e.g. https://api.us-west-1.saucelabs.com)")
 	cmd.PersistentFlags().StringVar(&gFlags.selectedSuite, "select-suite", "", "Run specified test suite.")
 	cmd.PersistentFlags().BoolVar(&gFlags.testEnvSilent, "test-env-silent", false, "Skips the test environment announcement.")
+	cmd.PersistentFlags().BoolVar(&gFlags.disableUsageMetrics, "disable-usage-metrics", false, "Disable usage metrics collections.")
 	_ = cmd.PersistentFlags().MarkHidden("sauce-api")
 	_ = cmd.PersistentFlags().MarkHidden("runner-version")
 	_ = cmd.PersistentFlags().MarkHidden("experiment")

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -70,7 +70,6 @@ type globalFlags struct {
 	globalTimeout       time.Duration
 	sauceAPI            string
 	selectedSuite       string
-	testEnvSilent       bool
 	disableUsageMetrics bool
 }
 

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -70,6 +70,7 @@ type globalFlags struct {
 	globalTimeout       time.Duration
 	sauceAPI            string
 	selectedSuite       string
+	testEnvSilent       bool
 	disableUsageMetrics bool
 }
 

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -140,7 +140,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, tc testcomposer.Clie
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New()
+	tracker := segment.New(gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -140,7 +140,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, tc testcomposer.Clie
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New(gFlags.disableUsageMetrics)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -140,8 +140,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, tc testcomposer.Clie
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	enabled := !gFlags.disableUsageMetrics
-	tracker := segment.New(&enabled)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -140,7 +140,8 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, tc testcomposer.Clie
 
 	rs.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	enabled := !gFlags.disableUsageMetrics
+	tracker := segment.New(&enabled)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -101,7 +101,8 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, tc testcomposer.Cl
 	rs.ArtifactConfig = p.Artifacts.Download
 	rc.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	enabled := !gFlags.disableUsageMetrics
+	tracker := segment.New(&enabled)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -101,7 +101,7 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, tc testcomposer.Cl
 	rs.ArtifactConfig = p.Artifacts.Download
 	rc.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New()
+	tracker := segment.New(gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -101,7 +101,7 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, tc testcomposer.Cl
 	rs.ArtifactConfig = p.Artifacts.Download
 	rc.ArtifactConfig = p.Artifacts.Download
 
-	tracker := segment.New(gFlags.disableUsageMetrics)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -101,8 +101,7 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, tc testcomposer.Cl
 	rs.ArtifactConfig = p.Artifacts.Download
 	rc.ArtifactConfig = p.Artifacts.Download
 
-	enabled := !gFlags.disableUsageMetrics
-	tracker := segment.New(&enabled)
+	tracker := segment.New(!gFlags.disableUsageMetrics)
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -19,7 +19,7 @@ type Tracker struct {
 }
 
 // New creates a new instance of Tracker.
-func New(IsDisabled bool) *Tracker {
+func New(enabled bool) *Tracker {
 	client, err := analytics.NewWithConfig(setup.SegmentWriteKey, analytics.Config{
 		BatchSize: 1,
 		DefaultContext: &analytics.Context{

--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -14,7 +14,7 @@ import (
 
 // Tracker is the segment implemention for usage.Tracker.
 type Tracker struct {
-	client     analytics.Client
+	client  analytics.Client
 	Enabled bool
 }
 
@@ -38,12 +38,12 @@ func New(enabled bool) *Tracker {
 		return &Tracker{}
 	}
 
-	return &Tracker{client: client, IsDisabled: IsDisabled}
+	return &Tracker{client: client, Enabled: enabled}
 }
 
 // Collect reports the usage of subject along with its attached metadata that is props.
 func (t *Tracker) Collect(subject string, props usage.Properties) {
-	if t.IsDisabled {
+	if t.Enabled {
 		return
 	}
 	if t.client == nil {

--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -15,11 +15,11 @@ import (
 // Tracker is the segment implemention for usage.Tracker.
 type Tracker struct {
 	client  analytics.Client
-	Enabled bool
+	Enabled *bool
 }
 
 // New creates a new instance of Tracker.
-func New(enabled bool) *Tracker {
+func New(enabled *bool) *Tracker {
 	client, err := analytics.NewWithConfig(setup.SegmentWriteKey, analytics.Config{
 		BatchSize: 1,
 		DefaultContext: &analytics.Context{
@@ -43,7 +43,7 @@ func New(enabled bool) *Tracker {
 
 // Collect reports the usage of subject along with its attached metadata that is props.
 func (t *Tracker) Collect(subject string, props usage.Properties) {
-	if !t.Enabled {
+	if t.Enabled != nil && !(*t.Enabled) {
 		return
 	}
 	if t.client == nil {

--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -1,6 +1,8 @@
 package segment
 
 import (
+	"runtime"
+
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/ci"
 	"github.com/saucelabs/saucectl/internal/credentials"
@@ -8,16 +10,16 @@ import (
 	"github.com/saucelabs/saucectl/internal/usage"
 	"github.com/saucelabs/saucectl/internal/version"
 	"gopkg.in/segmentio/analytics-go.v3"
-	"runtime"
 )
 
 // Tracker is the segment implemention for usage.Tracker.
 type Tracker struct {
-	client analytics.Client
+	client     analytics.Client
+	IsDisabled bool
 }
 
 // New creates a new instance of Tracker.
-func New() *Tracker {
+func New(IsDisabled bool) *Tracker {
 	client, err := analytics.NewWithConfig(setup.SegmentWriteKey, analytics.Config{
 		BatchSize: 1,
 		DefaultContext: &analytics.Context{
@@ -36,11 +38,14 @@ func New() *Tracker {
 		return &Tracker{}
 	}
 
-	return &Tracker{client: client}
+	return &Tracker{client: client, IsDisabled: IsDisabled}
 }
 
 // Collect reports the usage of subject along with its attached metadata that is props.
 func (t *Tracker) Collect(subject string, props usage.Properties) {
+	if t.IsDisabled {
+		return
+	}
 	if t.client == nil {
 		return
 	}

--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -15,7 +15,7 @@ import (
 // Tracker is the segment implemention for usage.Tracker.
 type Tracker struct {
 	client     analytics.Client
-	IsDisabled bool
+	Enabled bool
 }
 
 // New creates a new instance of Tracker.

--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -15,11 +15,11 @@ import (
 // Tracker is the segment implemention for usage.Tracker.
 type Tracker struct {
 	client  analytics.Client
-	Enabled *bool
+	Enabled bool
 }
 
 // New creates a new instance of Tracker.
-func New(enabled *bool) *Tracker {
+func New(enabled bool) *Tracker {
 	client, err := analytics.NewWithConfig(setup.SegmentWriteKey, analytics.Config{
 		BatchSize: 1,
 		DefaultContext: &analytics.Context{
@@ -43,7 +43,7 @@ func New(enabled *bool) *Tracker {
 
 // Collect reports the usage of subject along with its attached metadata that is props.
 func (t *Tracker) Collect(subject string, props usage.Properties) {
-	if t.Enabled != nil && !(*t.Enabled) {
+	if !t.Enabled {
 		return
 	}
 	if t.client == nil {

--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -43,7 +43,7 @@ func New(enabled bool) *Tracker {
 
 // Collect reports the usage of subject along with its attached metadata that is props.
 func (t *Tracker) Collect(subject string, props usage.Properties) {
-	if t.Enabled {
+	if !t.Enabled {
 		return
 	}
 	if t.client == nil {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Introduce a flag to disable collecting segment metrics.
```
saucectl run --disable-usage-metrics
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->