### PR TITLE
[DEVX-1362] Add ability to launch tests asynchronously

### DIFF
--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -169,6 +169,7 @@ func runCypressInSauce(p cypress.Project, regio region.Region, tc testcomposer.C
 			ArtifactDownloader: &rs,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &tc,
 				"cypress", "sauce"),
+			Async: gFlags.async,
 		},
 	}
 

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -146,6 +146,7 @@ func runEspressoInCloud(p espresso.Project, regio region.Region, tc testcomposer
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &tc,
 				"espresso", "sauce"),
 			Framework: framework.Framework{Name: espresso.Kind},
+			Async:     gFlags.async,
 		},
 	}
 

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -177,6 +177,7 @@ func runPlaywrightInSauce(p playwright.Project, regio region.Region, tc testcomp
 			ArtifactDownloader: &rs,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &tc,
 				"playwright", "sauce"),
+			Async: gFlags.async,
 		},
 	}
 

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -72,6 +72,7 @@ type globalFlags struct {
 	selectedSuite       string
 	testEnvSilent       bool
 	disableUsageMetrics bool
+	async               bool
 }
 
 // Command creates the `run` command
@@ -103,6 +104,7 @@ func Command() *cobra.Command {
 	defaultCfgPath := filepath.Join(".sauce", "config.yml")
 	cmd.PersistentFlags().StringVarP(&gFlags.cfgFilePath, "config", "c", defaultCfgPath, "Specifies which config file to use")
 	cmd.PersistentFlags().DurationVarP(&gFlags.globalTimeout, "timeout", "t", 0, "Global timeout that limits how long saucectl can run in total. Supports duration values like '10s', '30m' etc. (default: no timeout)")
+	cmd.PersistentFlags().BoolVar(&gFlags.async, "async", false, "Launches tests without waiting for test results (sauce mode only)")
 	sc.StringP("region", "r", "sauce::region", "us-west-1", "The sauce labs region.")
 	sc.StringToStringP("env", "e", "env", map[string]string{}, "Set environment variables, e.g. -e foo=bar. Not supported when running espresso/xcuitest!")
 	sc.Bool("show-console-log", "showConsoleLog", false, "Shows suites console.log locally. By default console.log is only shown on failures.")

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -198,6 +198,7 @@ func runTestcafeInCloud(p testcafe.Project, regio region.Region, tc testcomposer
 			ArtifactDownloader: &rs,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &tc,
 				"testcafe", "sauce"),
+			Async: gFlags.async,
 		},
 	}
 	cleanTestCafePackages(&p)

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -138,6 +138,7 @@ func runXcuitestInCloud(p xcuitest.Project, regio region.Region, tc testcomposer
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &tc,
 				"xcuitest", "sauce"),
 			Framework: framework.Framework{Name: xcuitest.Kind},
+			Async:     gFlags.async,
 		},
 	}
 	return r.RunProject()

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -341,7 +341,7 @@ func (r *ContainerRunner) collectResults(artifactCfg config.ArtifactDownload, re
 		inProgress--
 
 		jobID := getJobID(res.jobInfo.JobDetailsURL)
-		if download.ShouldDownloadArtifact(jobID, res.passed, res.timedOut, artifactCfg) {
+		if download.ShouldDownloadArtifact(jobID, res.passed, res.timedOut, false, artifactCfg) {
 			r.ArtfactDownloader.DownloadArtifact(jobID)
 		}
 

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -360,13 +360,17 @@ func (r *ContainerRunner) collectResults(artifactCfg config.ArtifactDownload, re
 			})
 		}
 
+		status := job.StatePassed
+		if !res.passed {
+			status = job.StateFailed
+		}
 		if !res.skipped {
 			tr := report.TestResult{
 				Name:      res.name,
 				Duration:  res.duration,
 				StartTime: res.startTime,
 				EndTime:   res.endTime,
-				Passed:    res.passed,
+				Status:    status,
 				Browser:   res.browser,
 				Platform:  "Docker",
 				URL:       res.jobInfo.JobDetailsURL,

--- a/internal/download/artifact.go
+++ b/internal/download/artifact.go
@@ -3,8 +3,8 @@ package download
 import "github.com/saucelabs/saucectl/internal/config"
 
 // ShouldDownloadArtifact returns true if it should download artifacts, otherwise false
-func ShouldDownloadArtifact(jobID string, passed, timedOut bool, cfg config.ArtifactDownload) bool {
-	if jobID == "" || timedOut {
+func ShouldDownloadArtifact(jobID string, passed, timedOut bool, async bool, cfg config.ArtifactDownload) bool {
+	if jobID == "" || timedOut || async {
 		return false
 	}
 	if cfg.When == config.WhenAlways {

--- a/internal/download/artifact_test.go
+++ b/internal/download/artifact_test.go
@@ -14,6 +14,7 @@ func TestShouldDownloadArtifact(t *testing.T) {
 		jobID    string
 		passed   bool
 		timedOut bool
+		async    bool
 		want     bool
 	}
 	testCases := []testCase{
@@ -27,6 +28,13 @@ func TestShouldDownloadArtifact(t *testing.T) {
 			name:   "should not download when jobID is empty and not being required",
 			config: config.ArtifactDownload{When: config.WhenNever},
 			jobID:  "",
+			want:   false,
+		},
+		{
+			name:   "should not download when jobs are processed asynchronously",
+			config: config.ArtifactDownload{When: config.WhenAlways},
+			jobID:  "fake-id",
+			async:  true,
 			want:   false,
 		},
 		{
@@ -95,7 +103,7 @@ func TestShouldDownloadArtifact(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ShouldDownloadArtifact(tt.jobID, tt.passed, tt.timedOut, tt.config)
+			got := ShouldDownloadArtifact(tt.jobID, tt.passed, tt.timedOut, tt.async, tt.config)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -7,7 +7,10 @@ const (
 	StateInProgress = "in progress"
 	StateComplete   = "complete"
 	StateError      = "error"
+)
 
+// The following states are only used by RDC.
+const (
 	StatePassed = "passed"
 	StateFailed = "failed"
 )
@@ -30,11 +33,23 @@ type Job struct {
 		DeviceName      string `json:"deviceName"`
 	} `json:"base_config"`
 
-	// IsRDC flags a job started as a RDC run.
+	// IsRDC flags a job started as an RDC run.
 	IsRDC bool `json:"-"`
 
 	// TimedOut flags a job as an unfinished one.
 	TimedOut bool `json:"-"`
+}
+
+// TotalStatus returns the total status of a job, combining the result of fields Status + Passed.
+func (j Job) TotalStatus() string {
+	if Done(j.Status) {
+		if j.Passed {
+			return StatePassed
+		}
+		return StateFailed
+	}
+
+	return j.Status
 }
 
 // Done returns true if the job status is one of DoneStates. False otherwise.

--- a/internal/junit/reporter_test.go
+++ b/internal/junit/reporter_test.go
@@ -1,6 +1,7 @@
 package junit
 
 import (
+	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/report"
 	"io"
 	"os"
@@ -25,7 +26,7 @@ func TestReporter_Render(t *testing.T) {
 					{
 						Name:     "Firefox",
 						Duration: 34479 * time.Millisecond,
-						Passed:   true,
+						Status:   job.StatePassed,
 						Browser:  "Firefox",
 						Platform: "Windows 10",
 						URL:      "https://app.saucelabs.com/tests/1234",
@@ -33,7 +34,7 @@ func TestReporter_Render(t *testing.T) {
 					{
 						Name:     "Chrome",
 						Duration: 5123 * time.Millisecond,
-						Passed:   true,
+						Status:   job.StatePassed,
 						Browser:  "Chrome",
 						Platform: "Windows 10",
 					},
@@ -63,14 +64,14 @@ func TestReporter_Render(t *testing.T) {
 					{
 						Name:     "Firefox",
 						Duration: 34479 * time.Millisecond,
-						Passed:   true,
+						Status:   job.StatePassed,
 						Browser:  "Firefox",
 						Platform: "Windows 10",
 					},
 					{
 						Name:     "Chrome",
 						Duration: 171452 * time.Millisecond,
-						Passed:   false,
+						Status:   job.StateFailed,
 						Browser:  "Chrome",
 						Platform: "Windows 10",
 					},

--- a/internal/notification/slack/slack.go
+++ b/internal/notification/slack/slack.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/job"
 	"strings"
 	"sync"
 	"time"
@@ -53,9 +54,9 @@ func (r *Reporter) Render() {
 	passed := true
 	for _, ts := range r.TestResults {
 		url := ts.URL + "?utm_source=slack&utm_medium=chat&utm_campaign=testresults"
-		tables = append(tables, []string{statusText(ts.Passed), addRightSpaces(ts.Name, r.getJobURL(ts.Name, url), longestName),
+		tables = append(tables, []string{ts.Status, addRightSpaces(ts.Name, r.getJobURL(ts.Name, url), longestName),
 			ts.Platform, ts.DeviceName, ts.Browser, ts.Duration.Truncate(1 * time.Second).String()})
-		if !ts.Passed {
+		if ts.Status != job.StatePassed {
 			passed = false
 		}
 	}
@@ -172,11 +173,4 @@ func (r *Reporter) creatAttachment(passed bool) slack.Attachment {
 		Color:  color,
 		Blocks: slack.Blocks{BlockSet: r.createBlocks()},
 	}
-}
-
-func statusText(passed bool) string {
-	if !passed {
-		return "failed"
-	}
-	return "passed"
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -8,7 +8,7 @@ type TestResult struct {
 	Duration   time.Duration `json:"duration"`
 	StartTime  time.Time     `json:"startTime"`
 	EndTime    time.Time     `json:"endTime"`
-	Passed     bool          `json:"passed"`
+	Status     string        `json:"status"`
 	Browser    string        `json:"browser"`
 	Platform   string        `json:"platform"`
 	DeviceName string        `json:"deviceName"`

--- a/internal/report/table/table_test.go
+++ b/internal/report/table/table_test.go
@@ -2,6 +2,7 @@ package table
 
 import (
 	"bytes"
+	"github.com/saucelabs/saucectl/internal/job"
 	"reflect"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func TestReporter_Render(t *testing.T) {
 						Duration:  34479 * time.Millisecond,
 						StartTime: startTime,
 						EndTime:   startTime.Add(34479 * time.Millisecond),
-						Passed:    true,
+						Status:    job.StatePassed,
 						Browser:   "Firefox",
 						Platform:  "Windows 10",
 						Attempts:  3,
@@ -38,7 +39,7 @@ func TestReporter_Render(t *testing.T) {
 						Duration:  5123 * time.Millisecond,
 						StartTime: startTime,
 						EndTime:   startTime.Add(5123 * time.Millisecond),
-						Passed:    true,
+						Status:    job.StatePassed,
 						Browser:   "Chrome",
 						Platform:  "Windows 10",
 						Attempts:  1,
@@ -63,7 +64,7 @@ func TestReporter_Render(t *testing.T) {
 						Duration:  34479 * time.Millisecond,
 						StartTime: startTime,
 						EndTime:   startTime.Add(34479 * time.Millisecond),
-						Passed:    true,
+						Status:   job.StatePassed,
 						Browser:   "Firefox",
 						Platform:  "Windows 10",
 						Attempts:  1,
@@ -73,7 +74,7 @@ func TestReporter_Render(t *testing.T) {
 						Duration:  171452 * time.Millisecond,
 						StartTime: startTime,
 						EndTime:   startTime.Add(171452 * time.Millisecond),
-						Passed:    false,
+						Status:   job.StateFailed,
 						Browser:   "Chrome",
 						Platform:  "Windows 10",
 						Attempts:  3,
@@ -123,7 +124,7 @@ func TestReporter_Reset(t *testing.T) {
 					{
 						Name:     "Firefox",
 						Duration: 34479 * time.Millisecond,
-						Passed:   true,
+						Status:   job.StatePassed,
 						Browser:  "Firefox",
 						Platform: "Windows 10",
 					}},
@@ -163,7 +164,7 @@ func TestReporter_Add(t *testing.T) {
 				t: report.TestResult{
 					Name:     "Firefox",
 					Duration: 34479 * time.Millisecond,
-					Passed:   true,
+					Status:   job.StatePassed,
 					Browser:  "Firefox",
 					Platform: "Windows 10",
 				},

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -159,7 +159,7 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 			}
 		}
 
-		if download.ShouldDownloadArtifact(res.job.ID, res.job.Passed, res.job.TimedOut, artifactCfg) {
+		if download.ShouldDownloadArtifact(res.job.ID, res.job.Passed, res.job.TimedOut, r.Async, artifactCfg) {
 			if res.job.IsRDC {
 				r.RDCArtifactDownloader.DownloadArtifact(res.job.ID)
 			} else {

--- a/internal/saucecloud/cypress_test.go
+++ b/internal/saucecloud/cypress_test.go
@@ -78,7 +78,7 @@ func TestRunSuites(t *testing.T) {
 	}
 	reader := mocks.FakeJobReader{
 		PollJobFn: func(ctx context.Context, id string, interval time.Duration, timeout time.Duration) (job.Job, error) {
-			return job.Job{ID: id, Passed: true}, nil
+			return job.Job{ID: id, Passed: true, Status: job.StatePassed}, nil
 		},
 		GetJobAssetFileNamesFn: func(ctx context.Context, jobID string) ([]string, error) {
 			return []string{"file1", "file2"}, nil

--- a/internal/saucecloud/xcuitest_test.go
+++ b/internal/saucecloud/xcuitest_test.go
@@ -37,7 +37,7 @@ func TestXcuitestRunner_RunProject(t *testing.T) {
 	}
 	reader := mocks.FakeJobReader{
 		PollJobFn: func(ctx context.Context, id string, interval time.Duration, timeout time.Duration) (job.Job, error) {
-			return job.Job{ID: id, Passed: true}, nil
+			return job.Job{ID: id, Passed: true, Status: job.StatePassed}, nil
 		},
 		GetJobAssetFileNamesFn: func(ctx context.Context, jobID string) ([]string, error) {
 			return []string{"file1", "file2"}, nil
@@ -95,7 +95,7 @@ func TestXcuitestRunner_RunProject(t *testing.T) {
 	}
 	cnt, err := runner.RunProject()
 	assert.Nil(t, err)
-	assert.Equal(t, cnt, 0)
+	assert.Equal(t, 0, cnt)
 	assert.Equal(t, "iPhone 11", startOpts.DeviceName)
 	assert.Equal(t, "iOS", startOpts.PlatformName)
 	assert.Equal(t, "14.3", startOpts.PlatformVersion)


### PR DESCRIPTION
Add ability to `saucectl run` without waiting for the rest results.
Launch failures will still be caught and awaited.

Regular, sync way:
```
saucectl run
[...]
15:49:40 INF Starting suite. region=us-west-1 suite="saucy barista - test size"
15:49:40 INF Starting suite. region=us-west-1 suite="saucy barista - combined"
15:49:40 INF Starting suite. region=us-west-1 suite="saucy barista - package"
15:49:50 INF Suites in progress: 3
15:50:00 INF Suites in progress: 3
15:50:08 INF Suite started. deviceId= deviceName="Android GoogleApi Emulator" platform=Android platformVersion=11.0 suite="saucy barista - test size" url=https://app.saucelabs.com/tests/bb9518974a474e95b3a38e0244fbcc8e
15:50:10 INF Suite started. deviceId= deviceName="Android GoogleApi Emulator" platform=Android platformVersion=11.0 suite="saucy barista - package" url=https://app.saucelabs.com/tests/d4345db35ba248c2a9ca9f8a0579180e
15:50:10 INF Suites in progress: 3
15:50:10 INF Suite started. deviceId= deviceName="Google Pixel C GoogleAPI Emulator" platform=Android platformVersion=8.1 suite="saucy barista - combined" url=https://app.saucelabs.com/tests/f08d3f3b950d42b0a9494b77290684b1
15:50:20 INF Suites in progress: 3
15:50:23 INF Suite finished. passed=true suite="saucy barista - test size" url=https://app.saucelabs.com/tests/bb9518974a474e95b3a38e0244fbcc8e
15:50:30 INF Suites in progress: 2
15:50:40 INF Suites in progress: 2
15:50:50 INF Suites in progress: 2
15:50:55 INF Suite finished. passed=true suite="saucy barista - package" url=https://app.saucelabs.com/tests/d4345db35ba248c2a9ca9f8a0579180e
15:50:55 INF Suite finished. passed=true suite="saucy barista - combined" url=https://app.saucelabs.com/tests/f08d3f3b950d42b0a9494b77290684b1

       Name                              Duration    Status    Platform        Device                               Attempts
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  ✔    saucy barista - test size              43s    passed    Android 11.0    Android GoogleApi Emulator                  1
  ✔    saucy barista - package              1m14s    passed    Android 11.0    Android GoogleApi Emulator                  1
  ✔    saucy barista - combined             1m15s    passed    Android 8.1     Google Pixel C GoogleAPI Emulator           1
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  ✔    All tests have passed                1m15s
```

With `--async` enabled:
```
saucectl run --async
[...]
15:51:59 INF Starting suite. region=us-west-1 suite="saucy barista - test size"
15:51:59 INF Starting suite. region=us-west-1 suite="saucy barista - combined"
15:51:59 INF Starting suite. region=us-west-1 suite="saucy barista - package"
15:52:09 INF Suites in progress: 3
15:52:19 INF Suites in progress: 3
15:52:26 INF Suite started. deviceId= deviceName="Android GoogleApi Emulator" platform=Android platformVersion=11.0 suite="saucy barista - package" url=https://app.saucelabs.com/tests/f4a77aa9a24b4d289342be8d8e8051e2
15:52:29 INF Suite started. deviceId= deviceName="Android GoogleApi Emulator" platform=Android platformVersion=11.0 suite="saucy barista - test size" url=https://app.saucelabs.com/tests/95ff85a905be4095806f666a57271d5b
15:52:29 INF Suites in progress: 1
15:52:33 INF Suite started. deviceId= deviceName="Google Pixel C GoogleAPI Emulator" platform=Android platformVersion=8.1 suite="saucy barista - combined" url=https://app.saucelabs.com/tests/960ab744a696486fb78044ca7965decc

       Name                              Duration    Status         Attempts
──────────────────────────────────────────────────────────────────────────────
  *    saucy barista - package                26s    in progress           1
  *    saucy barista - test size              29s    in progress           1
  *    saucy barista - combined               33s    in progress           1
──────────────────────────────────────────────────────────────────────────────
  *    All tests have launched                33s
```