### PR TITLE
fix: Add error when check version availability is failing

### DIFF
--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -680,7 +680,7 @@ func (r *CloudRunner) checkVersionAvailability(frameworkName string, frameworkVe
 		return errors.New("unsupported framework version")
 	}
 	if err != nil {
-		return errors.New("unable to check framework version availability")
+		return errors.New(fmt.Sprintf("unable to check framework version availability: %v", err))
 	}
 	if metadata.Deprecated {
 		color.Red(fmt.Sprintf("\nVersion %s for %s is deprecated and will be removed during our next framework release cycle !\n\n", frameworkVersion, frameworkName))

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -680,7 +680,7 @@ func (r *CloudRunner) checkVersionAvailability(frameworkName string, frameworkVe
 		return errors.New("unsupported framework version")
 	}
 	if err != nil {
-		return errors.New(fmt.Sprintf("unable to check framework version availability: %v", err))
+		return fmt.Errorf("unable to check framework version availability: %v", err)
 	}
 	if metadata.Deprecated {
 		color.Red(fmt.Sprintf("\nVersion %s for %s is deprecated and will be removed during our next framework release cycle !\n\n", frameworkVersion, frameworkName))


### PR DESCRIPTION
## Proposed changes

Add clarity (root error) when framework version check is failing.

Before:
```
{15:19}~/Projects/saucectl(main ✗) ➭ saucectl run -c .sauce/cypress.yml --select-suite "saucy test in sauce" --test-env-silent
Running version 0.76.0
15:20:00 INF Running Cypress in Sauce Labs
15:20:02 ERR failed to execute run command error="unable to check framework version availability"
{15:20}~/Projects/saucectl(main ✗) ➭
```

After:
```
{15:20}~/Projects/saucectl(main ✗) ➭ ./saucectl run -c .sauce/cypress.yml --select-suite "saucy test in sauce" --test-env-silent
Running version 0.0.0+unknown
15:20:11 WRN A new version of saucectl is available (v0.76.0)
15:20:11 INF Running Cypress in Sauce Labs
15:20:13 ERR failed to execute run command error="unable to check framework version availability: unexpected status '401' from test-composer: Unauthorized\n"
{15:20}~/Projects/saucectl(main ✗) ➭ 
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x]  Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->