### PR TITLE
[DEVX-359] Skip tests after failure

### DIFF
--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -201,7 +201,8 @@ func runCypressInSauce(p cypress.Project, regio region.Region, tc testcomposer.C
 			ArtifactDownloader: &rs,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &tc,
 				"cypress", "sauce"),
-			Async: gFlags.async,
+			Async:    gFlags.async,
+			FailFast: gFlags.failFast,
 		},
 	}
 

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -147,6 +147,7 @@ func runEspressoInCloud(p espresso.Project, regio region.Region, tc testcomposer
 				"espresso", "sauce"),
 			Framework: framework.Framework{Name: espresso.Kind},
 			Async:     gFlags.async,
+			FailFast:  gFlags.failFast,
 		},
 	}
 

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -179,7 +179,8 @@ func runPlaywrightInSauce(p playwright.Project, regio region.Region, tc testcomp
 			ArtifactDownloader: &rs,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &tc,
 				"playwright", "sauce"),
-			Async: gFlags.async,
+			Async:    gFlags.async,
+			FailFast: gFlags.failFast,
 		},
 	}
 

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -73,6 +73,7 @@ type globalFlags struct {
 	testEnvSilent       bool
 	disableUsageMetrics bool
 	async               bool
+	failFast            bool
 }
 
 // Command creates the `run` command
@@ -105,6 +106,7 @@ func Command() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&gFlags.cfgFilePath, "config", "c", defaultCfgPath, "Specifies which config file to use")
 	cmd.PersistentFlags().DurationVarP(&gFlags.globalTimeout, "timeout", "t", 0, "Global timeout that limits how long saucectl can run in total. Supports duration values like '10s', '30m' etc. (default: no timeout)")
 	cmd.PersistentFlags().BoolVar(&gFlags.async, "async", false, "Launches tests without waiting for test results (sauce mode only)")
+	cmd.PersistentFlags().BoolVar(&gFlags.failFast, "fail-fast", false, "Stops suites after the first failure (sauce mode only)")
 	sc.StringP("region", "r", "sauce::region", "us-west-1", "The sauce labs region.")
 	sc.StringToStringP("env", "e", "env", map[string]string{}, "Set environment variables, e.g. -e foo=bar. Not supported when running espresso/xcuitest!")
 	sc.Bool("show-console-log", "showConsoleLog", false, "Shows suites console.log locally. By default console.log is only shown on failures.")

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -198,7 +198,8 @@ func runTestcafeInCloud(p testcafe.Project, regio region.Region, tc testcomposer
 			ArtifactDownloader: &rs,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &tc,
 				"testcafe", "sauce"),
-			Async: gFlags.async,
+			Async:    gFlags.async,
+			FailFast: gFlags.failFast,
 		},
 	}
 	cleanTestCafePackages(&p)

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -139,6 +139,7 @@ func runXcuitestInCloud(p xcuitest.Project, regio region.Region, tc testcomposer
 				"xcuitest", "sauce"),
 			Framework: framework.Framework{Name: xcuitest.Kind},
 			Async:     gFlags.async,
+			FailFast:  gFlags.failFast,
 		},
 	}
 	return r.RunProject()

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -312,6 +312,11 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 			continue
 		}
 
+		if r.FailFast && !jobData.Passed {
+			log.Warn().Err(err).Msg("FailFast mode enabled. Skipping upcoming suites.")
+			r.interrupted = true
+		}
+
 		results <- result{
 			name:      opts.DisplayName,
 			browser:   opts.BrowserName,

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -52,7 +52,8 @@ type CloudRunner struct {
 
 	Reporters []report.Reporter
 
-	Async bool
+	Async    bool
+	FailFast bool
 
 	interrupted bool
 }


### PR DESCRIPTION
## Proposed changes

Introduces a `--fail-fast` parameter.
It skips the non-started suites from being started when one of the previous suites have failed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->