### PR TITLE
Automate Docker Integration Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,3 +266,19 @@ jobs:
           --testOptions.notClass SwagLabsMobileAppUITests.SwagLabsFlow/testCompleteFlow \
           --device name="iPhone.*" \
           --timeout 10m
+  windows-doctor:
+    needs: build
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Download saucectl binary
+        uses: actions/download-artifact@v2
+        with:
+          name: saucectlbin
+
+      - name: saucectl doctor
+        run: |
+          ./saucectl.exe doctor

--- a/cmd/saucectl/saucectl.go
+++ b/cmd/saucectl/saucectl.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/cmd/doctor"
 	"os"
 	"time"
 
@@ -62,6 +63,7 @@ func main() {
 		ini.Command(),
 		signup.Command(),
 		completion.Command(),
+		doctor.Command(),
 	)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/internal/cmd/doctor/cmd.go
+++ b/internal/cmd/doctor/cmd.go
@@ -1,0 +1,23 @@
+package doctor
+
+import (
+	"github.com/saucelabs/saucectl/internal/doctor"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// Command creates the `doctor` command
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "doctor",
+		Short:        "Runs a series of checks to ensure that your environment is ready to run tests",
+		SilenceUsage: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := doctor.Verify(); err != nil {
+				os.Exit(1)
+			}
+		},
+	}
+
+	return cmd
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -6,6 +6,15 @@ import (
 	"fmt"
 	"github.com/fatih/color"
 	"github.com/saucelabs/saucectl/internal/docker"
+	"strings"
+)
+
+var indent = "    "
+
+var (
+	point = "[•] "
+	fail  = color.RedString("[✖] ")
+	pass  = color.GreenString("[✔] ")
 )
 
 // Verify verifies that all essential dependencies are met.
@@ -25,24 +34,50 @@ func VerifyDocker() error {
 		return err
 	}
 
-	fmt.Println("[•] Docker")
+	printPoint(0, "Docker")
 	if !handler.IsInstalled() {
-		fmt.Printf("    %s Connection: unable to connect to docker. Is it installed & running?\n", color.RedString("[✖]"))
+		printFail(1, "Connection: unable to connect to docker. Is it installed & running?")
 		return errors.New("unable to communicate with docker")
 	}
-	fmt.Printf("    %s Connection\n", color.GreenString("[✔]"))
+	printPass(1, "Connection")
 
 	if err := handler.PullImage(context.Background(), "hello-world"); err != nil {
-		fmt.Printf("    %s Pulling Images: %s\n", color.RedString("[✖]"), err)
+		printFail(1, "Pull Images: %s", err)
 		return err
 	}
-	fmt.Printf("    %s Pull Images\n", color.GreenString("[✔]"))
+	printPass(1, "Pull Images")
 
 	if err := handler.IsLaunchable("hello-world"); err != nil {
-		fmt.Printf("    %s Launch Containers: %s\n", color.RedString("[✖]"), err)
+		printFail(1, "Launch Containers: %s")
 		return err
 	}
-	fmt.Printf("    %s Launch Containers\n", color.GreenString("[✔]"))
+	printPass(1, "Launch Containers")
 
 	return nil
+}
+
+func printPoint(lvl int, msg string, a ...interface{}) {
+	printBullet(lvl, point, msg, a...)
+}
+
+func printFail(lvl int, msg string, a ...interface{}) {
+	printBullet(lvl, fail, msg, a...)
+}
+
+func printPass(lvl int, msg string, a ...interface{}) {
+	printBullet(lvl, pass, msg, a...)
+}
+
+func printBullet(lvl int, bullet, msg string, a ...interface{}) {
+	var b strings.Builder
+
+	for i := 0; i < lvl; i++ {
+		b.WriteString(indent)
+	}
+
+	b.WriteString(bullet)
+
+	_, _ = fmt.Fprintf(&b, msg, a...)
+
+	fmt.Println(b.String())
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -33,7 +33,7 @@ func VerifyDocker() error {
 	fmt.Printf("    %s Connection\n", color.GreenString("[✔]"))
 
 	if err := handler.PullImage(context.Background(), "hello-world"); err != nil {
-		fmt.Printf("    %s Pulling Images: %s\n", err, color.RedString("[✖]"))
+		fmt.Printf("    %s Pulling Images: %s\n", color.RedString("[✖]"), err)
 		return err
 	}
 	fmt.Printf("    %s Pull Images\n", color.GreenString("[✔]"))

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,47 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/saucelabs/saucectl/internal/docker"
+)
+
+// Verify verifies that all essential dependencies are met.
+func Verify() error {
+	var err error
+	if err = VerifyDocker(); err != nil {
+		return err
+	}
+
+	return err
+}
+
+// VerifyDocker verifies that docker dependencies are met.
+func VerifyDocker() error {
+	handler, err := docker.Create()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("[•] Docker")
+	if !handler.IsInstalled() {
+		fmt.Printf("    %s Connection: unable to connect to docker. Is it installed & running?\n", color.RedString("[✖]"))
+		return errors.New("unable to communicate with docker")
+	}
+	fmt.Printf("    %s Connection\n", color.GreenString("[✔]"))
+
+	if err := handler.PullImage(context.Background(), "hello-world"); err != nil {
+		fmt.Printf("    %s Pulling Images: %s\n", err, color.RedString("[✖]"))
+		return err
+	}
+	fmt.Printf("    %s Pull Images\n", color.GreenString("[✔]"))
+
+	if err := handler.IsLaunchable("hello-world"); err != nil {
+		fmt.Printf("    %s Launch Containers: %s\n", err, color.RedString("[✖]"))
+	}
+	fmt.Printf("    %s Launch Containers\n", color.GreenString("[✔]"))
+
+	return nil
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -40,6 +40,7 @@ func VerifyDocker() error {
 
 	if err := handler.IsLaunchable("hello-world"); err != nil {
 		fmt.Printf("    %s Launch Containers: %s\n", err, color.RedString("[✖]"))
+		return err
 	}
 	fmt.Printf("    %s Launch Containers\n", color.GreenString("[✔]"))
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -39,7 +39,7 @@ func VerifyDocker() error {
 	fmt.Printf("    %s Pull Images\n", color.GreenString("[✔]"))
 
 	if err := handler.IsLaunchable("hello-world"); err != nil {
-		fmt.Printf("    %s Launch Containers: %s\n", err, color.RedString("[✖]"))
+		fmt.Printf("    %s Launch Containers: %s\n", color.RedString("[✖]"), err)
 		return err
 	}
 	fmt.Printf("    %s Launch Containers\n", color.GreenString("[✔]"))

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -48,7 +48,7 @@ func VerifyDocker() error {
 	printPass(1, "Pull Images")
 
 	if err := handler.IsLaunchable("hello-world"); err != nil {
-		printFail(1, "Launch Containers: %s")
+		printFail(1, "Launch Containers: %s", err)
 		return err
 	}
 	printPass(1, "Launch Containers")


### PR DESCRIPTION
Automate docker integration tests, particularly for windows.
Introduce a new command `doctor` (inspired by `flutter doctor`) that performs a list of checks against saucectl's dependencies. The main concern was/is docker, but can be later extended to check Sauce Labs connectivity, user credentials etc.

```
Run ./saucectl.exe doctor
[•] Docker
    [✔] Connection
    [✔] Pull Images
    [✔] Launch Containers
```