### PR TITLE
[DEVX-1440] Add cleanup method for artifacts 

### DIFF
--- a/api/v1alpha/generated/saucectl.schema.json
+++ b/api/v1alpha/generated/saucectl.schema.json
@@ -43,6 +43,10 @@
                 "description": "Manage test output, such as logs, videos, and screenshots.",
                 "type": "object",
                 "properties": {
+                  "cleanup": {
+                    "description": "Whether to remove all contents of artifacts directory",
+                    "type": "boolean"
+                  },
                   "download": {
                     "description": "Settings related to downloading test artifacts from Sauce Labs.",
                     "type": "object",

--- a/api/v1alpha/subschema/artifacts.schema.json
+++ b/api/v1alpha/subschema/artifacts.schema.json
@@ -9,6 +9,10 @@
       "description": "Manage test output, such as logs, videos, and screenshots.",
       "type": "object",
       "properties": {
+        "cleanup": {
+          "description": "Whether to remove all contents of artifacts directory",
+          "type": "boolean"
+        },
         "download": {
           "description": "Settings related to downloading test artifacts from Sauce Labs.",
           "type": "object",

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -15,6 +15,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/docker"
+	"github.com/saucelabs/saucectl/internal/download"
 	"github.com/saucelabs/saucectl/internal/flags"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/region"
@@ -153,6 +154,10 @@ func runCypress(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as 
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()
+
+	if p.Artifacts.Cleanup {
+		download.Cleanup(p.Artifacts.Download.Directory)
+	}
 
 	dockerProject, sauceProject := cypress.SplitSuites(p)
 	if len(dockerProject.Suites) != 0 {

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/saucelabs/saucectl/internal/appstore"
 	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/download"
 	"github.com/saucelabs/saucectl/internal/espresso"
 	"github.com/saucelabs/saucectl/internal/flags"
 	"github.com/saucelabs/saucectl/internal/framework"
@@ -119,6 +120,10 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, tc testcompose
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()
+
+	if p.Artifacts.Cleanup {
+		download.Cleanup(p.Artifacts.Download.Directory)
+	}
 
 	return runEspressoInCloud(p, regio, tc, rs, rc, as)
 }

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -13,6 +13,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/docker"
+	"github.com/saucelabs/saucectl/internal/download"
 	"github.com/saucelabs/saucectl/internal/flags"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/playwright"
@@ -131,6 +132,10 @@ func runPlaywright(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, 
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()
+
+	if p.Artifacts.Cleanup {
+		download.Cleanup(p.Artifacts.Download.Directory)
+	}
 
 	dockerProject, sauceProject := playwright.SplitSuites(p)
 	if len(dockerProject.Suites) != 0 {

--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/docker"
+	"github.com/saucelabs/saucectl/internal/download"
 	"github.com/saucelabs/saucectl/internal/flags"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/puppeteer"
@@ -110,6 +111,10 @@ func runPuppeteer(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client) (
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()
+
+	if p.Artifacts.Cleanup {
+		download.Cleanup(p.Artifacts.Download.Directory)
+	}
 
 	return runPuppeteerInDocker(p, tc, rs)
 }

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -129,6 +129,7 @@ func Command() *cobra.Command {
 	sc.String("artifacts.download.when", "artifacts::download::when", "never", "Specifies when to download test artifacts")
 	sc.StringSlice("artifacts.download.match", "artifacts::download::match", []string{}, "Specifies which test artifacts to download")
 	sc.String("artifacts.download.directory", "artifacts::download::directory", "", "Specifies the location where to download test artifacts to")
+	sc.Bool("artifacts.cleanup", "artifacts::cleanup", false, "Specifies whether to remove all contents of artifacts directory")
 
 	// Reporters
 	sc.Bool("reporters.junit.enabled", "reporters::junit::enabled", false, "Toggle saucectl's own junit reporting on/off. This only affects the reports that saucectl itself generates as a summary of your tests. Each Job in Sauce Labs has an independent report regardless.")

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -13,6 +13,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/docker"
+	"github.com/saucelabs/saucectl/internal/download"
 	"github.com/saucelabs/saucectl/internal/flags"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/region"
@@ -150,6 +151,10 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, tc testcomposer.Clie
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()
+
+	if p.Artifacts.Cleanup {
+		download.Cleanup(p.Artifacts.Download.Directory)
+	}
 
 	dockerProject, sauceProject := testcafe.SplitSuites(p)
 	if len(dockerProject.Suites) != 0 {

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/saucelabs/saucectl/internal/appstore"
 	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/download"
 	"github.com/saucelabs/saucectl/internal/flags"
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/rdc"
@@ -111,6 +112,10 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, tc testcomposer.Cl
 		tracker.Collect(strings.Title(fullCommandName(cmd)), props)
 		_ = tracker.Close()
 	}()
+
+	if p.Artifacts.Cleanup {
+		download.Cleanup(p.Artifacts.Download.Directory)
+	}
 
 	return runXcuitestInCloud(p, regio, tc, rs, rc, as)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,7 @@ type Slack struct {
 // Artifacts represents the test artifacts configuration.
 type Artifacts struct {
 	Download ArtifactDownload `yaml:"download,omitempty" json:"download"`
+	Cleanup  bool             `yaml:"cleanup,omitempty" json:"cleanup"`
 }
 
 // Reporters represents the reporter configuration.

--- a/internal/download/artifact.go
+++ b/internal/download/artifact.go
@@ -29,6 +29,6 @@ func ShouldDownloadArtifact(jobID string, passed, timedOut bool, async bool, cfg
 func Cleanup(directory string) {
 	err := os.RemoveAll(directory)
 	if err != nil {
-		log.Err(err).Msg("Unable to cleanup previous artifacts ()")
+		log.Err(err).Msg("Unable to cleanup previous artifacts")
 	}
 }

--- a/internal/download/artifact.go
+++ b/internal/download/artifact.go
@@ -1,6 +1,11 @@
 package download
 
-import "github.com/saucelabs/saucectl/internal/config"
+import (
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/config"
+)
 
 // ShouldDownloadArtifact returns true if it should download artifacts, otherwise false
 func ShouldDownloadArtifact(jobID string, passed, timedOut bool, async bool, cfg config.ArtifactDownload) bool {
@@ -18,4 +23,12 @@ func ShouldDownloadArtifact(jobID string, passed, timedOut bool, async bool, cfg
 	}
 
 	return false
+}
+
+// Cleanup removes previous downloaded artifacts
+func Cleanup(directory string) {
+	err := os.RemoveAll(directory)
+	if err != nil {
+		log.Err(err).Msg("Unable to cleanup previous artifacts ()")
+	}
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Add a `cleanupPrevious` field in config and saucectl will cleanup previous downloaded artifacts.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->