### PR TITLE
Replace golint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,7 @@ jobs:
 
       - name: Lint project
         run: |
-          go get -u golang.org/x/lint/golint
-          golint -set_exit_status ./...
+          go vet ./...
   test:
     runs-on: ubuntu-latest
     container:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ It is possible that the code base does not currently comply with these guideline
 The rules:
 
 1. All code should be formatted with `gofmt -s`.
-2. All code should pass the default levels of [`golint`](https://github.com/golang/lint).
+2. All code should pass the default levels of [`go vet`](https://pkg.go.dev/cmd/vet).
 3. All code should follow the guidelines covered in [Effective Go](http://golang.org/doc/effective_go.html) and [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments).
 4. Comment the code. Tell us the why, the history and the context.
 5. Document _all_ declarations and methods, even private ones. Declare expectations, caveats and anything else that may be important. If a type gets exported, having the comments already there will ensure it's ready.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build-%:
 
 #lint: @ Run the linter
 lint:
-	golint ./...
+	go vet ./...
 
 #format: @ Format code with gofmt
 format:

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -503,7 +503,7 @@ func jobIDFromURL(URL string) string {
 
 // registerInterruptOnSignal runs tearDown on SIGINT / Interrupt.
 func (r *ContainerRunner) registerInterruptOnSignal(containerID, suiteName string, interrupted *bool) chan os.Signal {
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
 
 	go func(c <-chan os.Signal, interrupted *bool, containerID, suiteName string) {
@@ -520,7 +520,7 @@ func (r *ContainerRunner) registerInterruptOnSignal(containerID, suiteName strin
 
 // registerSkipSuitesOnSignal prevent new suites from being executed when a SIGINT is captured.
 func (r *ContainerRunner) registerSkipSuitesOnSignal() chan os.Signal {
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
 
 	go func(c <-chan os.Signal, cr *ContainerRunner) {

--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -36,7 +36,7 @@ func TestPullImage(t *testing.T) {
 	assert.Equal(t, err.Error(), "ImagePullFailure")
 }
 
-func ExampleGetJobID() {
+func Example_getJobID() {
 	fmt.Println(getJobID("https://app.saucelabs.com/tests/cb6741a1a119448a9760531024657967"))
 	// Output: cb6741a1a119448a9760531024657967
 }

--- a/internal/notification/slack/slack_test.go
+++ b/internal/notification/slack/slack_test.go
@@ -24,7 +24,7 @@ func Test_shouldSendNotification(t *testing.T) {
 			name: "empty slack channel",
 			params: params{
 				testResults: []report.TestResult{report.TestResult{URL: "http://example.com"}},
-				config:      config.Notifications{config.Slack{Channels: []string{}}},
+				config:      config.Notifications{Slack: config.Slack{Channels: []string{}}},
 			},
 			expected: false,
 		},
@@ -32,7 +32,7 @@ func Test_shouldSendNotification(t *testing.T) {
 			name: "send always",
 			params: params{
 				testResults: []report.TestResult{report.TestResult{URL: "http://example.com"}},
-				config:      config.Notifications{config.Slack{Channels: []string{"test-channel"}, Send: config.WhenAlways}},
+				config:      config.Notifications{Slack: config.Slack{Channels: []string{"test-channel"}, Send: config.WhenAlways}},
 				passed:      true,
 			},
 			expected: true,
@@ -41,7 +41,7 @@ func Test_shouldSendNotification(t *testing.T) {
 			name: "send pass",
 			params: params{
 				testResults: []report.TestResult{report.TestResult{URL: "http://example.com"}},
-				config:      config.Notifications{config.Slack{Channels: []string{"test-channel"}, Send: config.WhenPass}},
+				config:      config.Notifications{Slack: config.Slack{Channels: []string{"test-channel"}, Send: config.WhenPass}},
 				passed:      true,
 			},
 			expected: true,
@@ -50,7 +50,7 @@ func Test_shouldSendNotification(t *testing.T) {
 			name: "send on fail",
 			params: params{
 				testResults: []report.TestResult{report.TestResult{URL: "http://example.com"}},
-				config:      config.Notifications{config.Slack{Channels: []string{"test-channel"}, Send: config.WhenFail}},
+				config:      config.Notifications{Slack: config.Slack{Channels: []string{"test-channel"}, Send: config.WhenFail}},
 				passed:      false,
 			},
 			expected: true,
@@ -59,7 +59,7 @@ func Test_shouldSendNotification(t *testing.T) {
 			name: "default",
 			params: params{
 				testResults: []report.TestResult{report.TestResult{URL: "http://example.com"}},
-				config:      config.Notifications{config.Slack{Channels: []string{"test-channel"}}},
+				config:      config.Notifications{Slack: config.Slack{Channels: []string{"test-channel"}}},
 				passed:      true,
 			},
 			expected: false,

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -600,7 +600,7 @@ func (r *CloudRunner) stopSuiteExecution(jobID string, suiteName string) {
 
 // registerInterruptOnSignal stops execution on Sauce Cloud when a SIGINT is captured.
 func (r *CloudRunner) registerInterruptOnSignal(jobID, suiteName string) chan os.Signal {
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
 
 	go func(c <-chan os.Signal, jobID, suiteName string) {
@@ -616,7 +616,7 @@ func (r *CloudRunner) registerInterruptOnSignal(jobID, suiteName string) chan os
 
 // registerSkipSuitesOnSignal prevent new suites from being executed when a SIGINT is captured.
 func (r *CloudRunner) registerSkipSuitesOnSignal() chan os.Signal {
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
 
 	go func(c <-chan os.Signal, cr *CloudRunner) {

--- a/internal/saucecloud/xcuitest.go
+++ b/internal/saucecloud/xcuitest.go
@@ -157,7 +157,7 @@ func archiveAppsToIpaIfRequired(appPath, testAppPath string) (archivedAppPath st
 		archivedTestAppPath, err = archiveAppToIpa(testAppPath)
 		if err != nil {
 			log.Error().Msgf("Unable to archive %s to ipa: %v", testAppPath, err)
-			fmt.Errorf("unable to archive %s", testAppPath)
+			archivedErr = fmt.Errorf("unable to archive %s", testAppPath)
 			return
 		}
 	}


### PR DESCRIPTION
`golint` has been deprecated. Replacing its usage with `go vet`. Though `go vet` is technically not a linter, it may be exactly what we need and nothing more.