### PR TITLE
[DEVX-1445] Add support for headless on Cypress

### DIFF
--- a/api/v1alpha/framework/cypress.schema.json
+++ b/api/v1alpha/framework/cypress.schema.json
@@ -139,6 +139,10 @@
                 "description": "One or more paths to the Cypress test files to run for this suite, if not otherwise specified explicitly in cypress.json.",
                 "type": "array"
               },
+              "headless": {
+                "description": "Controls whether or not tests are run in headless mode (default: false)",
+                "type": "boolean"
+              },
               "env": {
                 "$ref": "../subschema/common.schema.json#/definitions/env"
               }

--- a/api/v1alpha/generated/saucectl.schema.json
+++ b/api/v1alpha/generated/saucectl.schema.json
@@ -360,6 +360,10 @@
                       "description": "One or more paths to the Cypress test files to run for this suite, if not otherwise specified explicitly in cypress.json.",
                       "type": "array"
                     },
+                    "headless": {
+                      "description": "Controls whether or not tests are run in headless mode (default: false)",
+                      "type": "boolean"
+                    },
                     "env": {
                       "$ref": "#/allOf/0/then/properties/env"
                     }

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -78,6 +78,7 @@ func NewCypressCmd() *cobra.Command {
 	// Misc
 	sc.String("rootDir", "rootDir", ".", "Control what files are available in the context of a test run, unless explicitly excluded by .sauceignore")
 	sc.String("shard", "suite::shard", "", "Controls whether or not (and how) tests are sharded across multiple machines")
+	sc.String("headless", "suite::config::headless", "", "Controls whether or not tests are run in headless mode (default: false)")
 
 	// NPM
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -67,6 +67,7 @@ type Suite struct {
 type SuiteConfig struct {
 	TestFiles []string          `yaml:"testFiles,omitempty" json:"testFiles"`
 	Env       map[string]string `yaml:"env,omitempty" json:"env"`
+	Headless  bool              `yaml:"headless,omitempty" json:"headless"`
 }
 
 // Reporter represents a cypress report configuration.


### PR DESCRIPTION
## Proposed changes

Allow Cypress to be run in headless mode
(Supported by runners carrying Cypress 8.3.0+)

Relates to https://github.com/saucelabs/saucectl/issues/476

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->