### PR TITLE
Add flag docs reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ saucectl run
 ```
 This command will run the test based on the `./.sauce/config.yml` file.
 
+### Flags
+
+[Please refer to our docs](https://docs.saucelabs.com/testrunner-toolkit/saucectl/#-saucectl-run-flags) to learn more about the flags or run `saucectl run -h`.
+
 ## The `configure` Command
 ```sh
 saucectl configure


### PR DESCRIPTION
Improve clarity of how to use saucectl by providing a reference to the available flags in the readme.