### PR TITLE
[DEVX-1546] Check for path length before archiving

### DIFF
--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -131,3 +131,10 @@ func Error(msg string) {
 func IgnoredNpmPackagesMsg(framework string, installedVersion string, ignoredPackages []string) string {
 	return fmt.Sprintf("%s.version (%s) already defined in your config. Ignoring installation of npm packages: %s", framework, installedVersion, strings.Join(ignoredPackages, ", "))
 }
+
+// PathTooLongForArchive prints the error message due to some filepath being too long.
+func PathTooLongForArchive(path string) {
+	color.Red("\nSome of your filepaths are too long (200 char limit) !\n\n")
+	fmt.Printf("Example: %s\n\n", path)
+	fmt.Printf("If you didn't mean to include those files, exclude them via the .sauceignore file.\nIf you need to include those files, then you have to shorten the filepath, for example, by renaming files, folders or avoid nesting files too deeply.\n")
+}

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -136,5 +136,5 @@ func IgnoredNpmPackagesMsg(framework string, installedVersion string, ignoredPac
 func PathTooLongForArchive(path string) {
 	color.Red("\nSome of your filepaths are too long (200 char limit) !\n\n")
 	fmt.Printf("Example: %s\n\n", path)
-	fmt.Printf("If you didn't mean to include those files, exclude them via the .sauceignore file.\nIf you need to include those files, then you have to shorten the filepath, for example, by renaming files, folders or avoid nesting files too deeply.\n")
+	fmt.Printf("If you didn't mean to include those files, exclude them via the .sauceignore file.\nIf you need to include those files, then you have to shorten the filepath, for example, by renaming files, folders or avoid nesting files too deeply.\n\n")
 }

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -77,6 +77,7 @@ type result struct {
 const ConsoleLogAsset = "console.log"
 
 // BaseFilepathLength represents the path length where project will be unpacked.
+// Example: "D:\sauce-playwright-runner\1.12.0\bundle\__project__\"
 const BaseFilepathLength = 53
 
 // MaxFilepathLength represents the maximum path length acceptable.

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -76,11 +76,11 @@ type result struct {
 // ConsoleLogAsset represents job asset log file name.
 const ConsoleLogAsset = "console.log"
 
-// BaseDirLength represents the path length where project will be unpacked.
-const BaseDirLength = 53
+// BaseFilepathLength represents the path length where project will be unpacked.
+const BaseFilepathLength = 53
 
-// MaxDirLength represents the maximum path length acceptable.
-const MaxDirLength = 255
+// MaxFilepathLength represents the maximum path length acceptable.
+const MaxFilepathLength = 255
 
 func (r *CloudRunner) createWorkerPool(ccy int, maxRetries int) (chan job.StartOptions, chan result, error) {
 	jobOpts := make(chan job.StartOptions, maxRetries+1)
@@ -372,7 +372,7 @@ func checkPathLength(projectFolder string, matcher sauceignore.Matcher) (string,
 		// When walk fails, we may not want to fail saucectl execution.
 		return "", nil
 	}
-	if BaseDirLength+maxLength > MaxDirLength {
+	if BaseFilepathLength+maxLength > MaxFilepathLength {
 		return exampleName, errors.New("path too long")
 	}
 	return "", nil

--- a/internal/saucecloud/cloud_test.go
+++ b/internal/saucecloud/cloud_test.go
@@ -346,7 +346,7 @@ func TestCheckPathLength(t *testing.T) {
 				projectFolder: "failing-test",
 				matcher: sauceignore.NewMatcher([]sauceignore.Pattern{
 					{
-						"bqRamRa7aqyg3mDeaP8zvx7fUs5m5vr74g9ecPyAUkk93MyeETA6hWjyhgsPGtNQS9WEwJpmswcCADYJs7y8t55FsP79TZw7Fy7x",
+						P: "bqRamRa7aqyg3mDeaP8zvx7fUs5m5vr74g9ecPyAUkk93MyeETA6hWjyhgsPGtNQS9WEwJpmswcCADYJs7y8t55FsP79TZw7Fy7x",
 					},
 				}),
 			},


### PR DESCRIPTION
## Proposed changes

Windows has some contraints on path length.
This PR brings the check before archiving, preventing future failure in VMs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->