### PR TITLE
[DEVX-1569] Expand xcuitest app/testapp variables

### DIFF
--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -3,6 +3,7 @@ package xcuitest
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -67,6 +68,15 @@ func FromFile(cfgPath string) (Project, error) {
 	if err := config.Unmarshal(cfgPath, &p); err != nil {
 		return p, err
 	}
+
+	p.Xcuitest.App = os.ExpandEnv(p.Xcuitest.App)
+	p.Xcuitest.TestApp = os.ExpandEnv(p.Xcuitest.TestApp)
+
+	var otherApps []string
+	for _, o := range p.Xcuitest.OtherApps {
+		otherApps = append(otherApps, os.ExpandEnv(o))
+	}
+	p.Xcuitest.OtherApps = otherApps
 
 	p.ConfigFilePath = cfgPath
 


### PR DESCRIPTION
## Proposed changes

Fixes #497 

Feature parity with espresso. Allows variable expansion for the app/testApp fields.

```
xcuitest:
  app: $APP
  testApp: $TEST_APP
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)