### PR TITLE
Fix reporter schema

### DIFF
--- a/api/v1alpha/generated/saucectl.schema.json
+++ b/api/v1alpha/generated/saucectl.schema.json
@@ -221,13 +221,14 @@
                 "properties": {
                   "junit": {
                     "type": "object",
+                    "description": "The JUnit reporter merges test results from all jobs in the JUnit format into a single report.",
                     "properties": {
                       "enabled": {
                         "description": "Toggles the reporter on/off.",
                         "type": "boolean"
                       },
                       "filename": {
-                        "description": "Filename for the generated junit report",
+                        "description": "Filename for the generated JUnit report.",
                         "type": "string",
                         "default": "saucectl-report.xml"
                       }

--- a/api/v1alpha/generated/saucectl.schema.json
+++ b/api/v1alpha/generated/saucectl.schema.json
@@ -219,14 +219,19 @@
               "reporters": {
                 "type": "object",
                 "properties": {
-                  "enabled": {
-                    "description": "Toggles the reporter on/off.",
-                    "type": "boolean"
-                  },
-                  "filename": {
-                    "description": "Filename for the generated junit report",
-                    "type": "string",
-                    "default": "saucectl-report.xml"
+                  "junit": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "description": "Toggles the reporter on/off.",
+                        "type": "boolean"
+                      },
+                      "filename": {
+                        "description": "Filename for the generated junit report",
+                        "type": "string",
+                        "default": "saucectl-report.xml"
+                      }
+                    }
                   }
                 },
                 "additionalProperties": false

--- a/api/v1alpha/subschema/reporters.schema.json
+++ b/api/v1alpha/subschema/reporters.schema.json
@@ -8,14 +8,19 @@
     "reporters": {
       "type": "object",
       "properties": {
-        "enabled": {
-          "description": "Toggles the reporter on/off.",
-          "type": "boolean"
-        },
-        "filename": {
-          "description": "Filename for the generated junit report",
-          "type": "string",
-          "default": "saucectl-report.xml"
+        "junit": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Toggles the reporter on/off.",
+              "type": "boolean"
+            },
+            "filename": {
+              "description": "Filename for the generated junit report",
+              "type": "string",
+              "default": "saucectl-report.xml"
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/api/v1alpha/subschema/reporters.schema.json
+++ b/api/v1alpha/subschema/reporters.schema.json
@@ -10,13 +10,14 @@
       "properties": {
         "junit": {
           "type": "object",
+          "description": "The JUnit reporter merges test results from all jobs in the JUnit format into a single report.",
           "properties": {
             "enabled": {
               "description": "Toggles the reporter on/off.",
               "type": "boolean"
             },
             "filename": {
-              "description": "Filename for the generated junit report",
+              "description": "Filename for the generated JUnit report.",
               "type": "string",
               "default": "saucectl-report.xml"
             }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Fix the reporter schema. The current properties within the reporter schema actually belong to the junit reporter underneath, which was missing. Relocate the properties and add the junit reporter (see [docs](https://docs.saucelabs.com/mobile-apps/automated-testing/espresso-xcuitest/espresso/#reporters)).

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->