### PR TITLE
[DEVX-1692] Fix missing default decoders

### DIFF
--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -8,6 +8,8 @@ sauce:
       - e2e
     build: "$BUILD_ID"
 rootDir: tests/e2e/
+defaults:
+  timeout: 5m
 docker:
   fileTransfer: mount
 cypress:

--- a/.sauce/espresso.yml
+++ b/.sauce/espresso.yml
@@ -7,6 +7,8 @@ sauce:
     tags:
       - e2e
     build: "$BUILD_ID"
+defaults:
+  timeout: 5m
 espresso:
   app: ./tests/e2e/espresso/calc.apk
   testApp: ./tests/e2e/espresso/calc-success.apk

--- a/.sauce/playwright.yml
+++ b/.sauce/playwright.yml
@@ -7,6 +7,8 @@ sauce:
     tags:
       - e2e
     build: "$BUILD_ID"
+defaults:
+  timeout: 5m
 docker:
   fileTransfer: mount
 rootDir: tests/e2e/playwright/

--- a/.sauce/testcafe.yml
+++ b/.sauce/testcafe.yml
@@ -7,6 +7,8 @@ sauce:
     tags:
       - e2e
     build: "$BUILD_ID"
+defaults:
+  timeout: 5m
 docker:
   fileTransfer: copy
 testcafe:

--- a/.sauce/xcuitest.yml
+++ b/.sauce/xcuitest.yml
@@ -11,6 +11,9 @@ sauce:
       - other tag
     build: Release $CI_COMMIT_SHORT_SHA
 
+defaults:
+  timeout: 5m
+
 xcuitest:
   app: ./tests/e2e/xcuitest/SauceLabs.Mobile.Sample.XCUITest.App.ipa
   testApp: ./tests/e2e/xcuitest/SwagLabsMobileAppUITests-Runner.ipa

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/viper"
@@ -264,9 +265,13 @@ func Unmarshal(cfgPath string, project interface{}) error {
 	}
 
 	return viper.Unmarshal(&project, func(decodeCfg *mapstructure.DecoderConfig) {
-		decodeCfg.DecodeHook = func(in reflect.Kind, out reflect.Kind, v interface{}) (interface{}, error) {
-			return expandEnv(v), nil
-		}
+		decodeCfg.DecodeHook = mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToTimeDurationHookFunc(),
+			mapstructure.StringToSliceHookFunc(","),
+			func(in reflect.Kind, out reflect.Kind, v interface{}) (interface{}, error) {
+				return expandEnv(v), nil
+			},
+		)
 	})
 }
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
#524 introduced a new decoding hook, but inadvertently also replaced default decoders that were set by viper itself.
Special values, like `duration`, were handled by those defaults and consequently broke (like our timeout setting).

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->