### PR TITLE
Append misc error strings with actual error messages

### DIFF
--- a/internal/framework/search.go
+++ b/internal/framework/search.go
@@ -78,8 +78,14 @@ func toNpmPackageName(frameworkName string) string {
 	return p
 }
 
+// Monkey patch functions to allow mocking during unit testing
+var (
+	PackageFromFile = node.PackageFromFile
+	NewConstraint   = semver.NewConstraint
+)
+
 func (s PackageStrategy) Find(ctx context.Context, svc MetadataService, frameworkName string, packageJsonPath string) (Metadata, error) {
-	p, err := node.PackageFromFile(s.packageJsonFilePath)
+	p, err := PackageFromFile(s.packageJsonFilePath)
 
 	if err != nil {
 		return Metadata{}, fmt.Errorf("error reading package.json: %w", err)
@@ -92,7 +98,7 @@ func (s PackageStrategy) Find(ctx context.Context, svc MetadataService, framewor
 	if !ok {
 		ver, ok = p.Dependencies[packageName]
 		if !ok {
-			return Metadata{}, fmt.Errorf("unable to determine dependencies for package %s:%s", packageName, ver)
+			return Metadata{}, fmt.Errorf("unable to determine dependencies for package: %s", packageName)
 		}
 	}
 
@@ -116,7 +122,7 @@ func (s PackageStrategy) Find(ctx context.Context, svc MetadataService, framewor
 		return vi.GreaterThan(vj)
 	})
 
-	c, err := semver.NewConstraint(ver)
+	c, err := NewConstraint(ver)
 	if err != nil {
 		return Metadata{}, fmt.Errorf("unable to parse package version (%s): %w", ver, err)
 	}

--- a/internal/framework/search.go
+++ b/internal/framework/search.go
@@ -92,7 +92,7 @@ func (s PackageStrategy) Find(ctx context.Context, svc MetadataService, framewor
 	if !ok {
 		ver, ok = p.Dependencies[packageName]
 		if !ok {
-			return Metadata{}, fmt.Errorf("unable to determine package dependencies for %s:%s", packageName, ver)
+			return Metadata{}, fmt.Errorf("unable to determine dependencies for package %s:%s", packageName, ver)
 		}
 	}
 

--- a/internal/framework/search.go
+++ b/internal/framework/search.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/saucelabs/saucectl/internal/node"
 )
 

--- a/internal/framework/search_test.go
+++ b/internal/framework/search_test.go
@@ -1,0 +1,103 @@
+package framework
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"testing"
+)
+
+type MockMetadataService struct {
+	MockSearch     func(context.Context, SearchOptions) (Metadata, error)
+	MockFrameworks func(ctx context.Context) ([]Framework, error)
+	MockVersions   func(ctx context.Context, frameworkName string) ([]Metadata, error)
+}
+
+func (m *MockMetadataService) Frameworks(ctx context.Context) ([]Framework, error) {
+	if m.MockFrameworks != nil {
+		return m.MockFrameworks(ctx)
+	}
+
+	return nil, nil
+}
+
+func (m *MockMetadataService) Search(ctx context.Context, opts SearchOptions) (Metadata, error) {
+	if m.MockSearch != nil {
+		return m.MockSearch(ctx, opts)
+	}
+
+	return Metadata{}, nil
+}
+
+func (m *MockMetadataService) Versions(ctx context.Context, frameworkName string) ([]Metadata, error) {
+	if m.MockVersions != nil {
+		return m.MockVersions(ctx, frameworkName)
+	}
+
+	return nil, nil
+}
+
+func TestFrameworkFind_ExactStrategy(t *testing.T) {
+	var tests = []struct {
+		testName         string
+		expectedMessage  string
+		ctx              context.Context
+		svc              MetadataService
+		frameworkName    string
+		frameworkVersion string
+	}{
+		{
+			"withoutFrameworkVersion",
+			"framework version not defined",
+			nil,
+			nil,
+			"buster",
+			"",
+		},
+		{
+			"invalidSearchOptions",
+			"version 1.0 for buster is not available",
+			nil,
+			&MockMetadataService{
+				MockSearch: func(context.Context, SearchOptions) (Metadata, error) {
+					return Metadata{}, errors.Errorf("Bad Request: unsupported version")
+				},
+			},
+			"buster",
+			"1.0",
+		},
+		{
+			"unknownFrameworkError",
+			"framework availability unknown: unexpected error present",
+			nil,
+			&MockMetadataService{
+				MockSearch: func(context.Context, SearchOptions) (Metadata, error) {
+					return Metadata{}, errors.Errorf("unexpected error present")
+				},
+			},
+			"buster",
+			"2.0",
+		},
+		{
+			"noErrorPresent",
+			"",
+			nil,
+			&MockMetadataService{
+				MockSearch: func(context.Context, SearchOptions) (Metadata, error) {
+					return Metadata{}, nil
+				},
+			},
+			"buster-final",
+			"3.0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			_, err := ExactStrategy{}.Find(tc.ctx, tc.svc, tc.frameworkName, tc.frameworkVersion)
+
+			if err != nil && err.Error() != tc.expectedMessage {
+				t.Errorf("Wrong error message displays:\nExpected: %s\nActual: %s", tc.expectedMessage, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
It's difficult to diagnose problems during run execution when framework errors are completely generic

## Proposed changes
Solves #533

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments
None