### PR TITLE
[DEVX-1725] Job Start Route Optimization

### DIFF
--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -116,6 +116,7 @@ func runCypress(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as 
 	regio := region.FromString(p.Sauce.Region)
 
 	tc.URL = regio.APIBaseURL()
+	webdriverClient.URL = regio.WebDriverBaseURL()
 	rs.URL = regio.APIBaseURL()
 	as.URL = regio.APIBaseURL()
 
@@ -172,7 +173,7 @@ func runCypressInSauce(p cypress.Project, regio region.Region, tc testcomposer.C
 		Project: p,
 		CloudRunner: saucecloud.CloudRunner{
 			ProjectUploader:    &as,
-			JobStarter:         &tc,
+			JobStarter:         &webdriverClient,
 			JobReader:          &rs,
 			JobStopper:         &rs,
 			JobWriter:          &tc,

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -107,6 +107,7 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, tc testcompose
 	regio := region.FromString(p.Sauce.Region)
 
 	tc.URL = regio.APIBaseURL()
+	webdriverClient.URL = regio.WebDriverBaseURL()
 	rs.URL = regio.APIBaseURL()
 	as.URL = regio.APIBaseURL()
 	rc.URL = regio.APIBaseURL()
@@ -144,7 +145,8 @@ func runEspressoInCloud(p espresso.Project, regio region.Region, tc testcomposer
 		Project: p,
 		CloudRunner: saucecloud.CloudRunner{
 			ProjectUploader:       &as,
-			JobStarter:            &tc,
+			JobStarter:            &webdriverClient,
+			RDCJobStarter:         &rc,
 			JobReader:             &rs,
 			RDCJobReader:          &rc,
 			JobStopper:            &rs,

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -122,6 +122,7 @@ func runPlaywright(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, 
 
 	regio := region.FromString(p.Sauce.Region)
 
+	webdriverClient.URL = regio.WebDriverBaseURL()
 	tc.URL = regio.APIBaseURL()
 	rs.URL = regio.APIBaseURL()
 	as.URL = regio.APIBaseURL()
@@ -183,7 +184,7 @@ func runPlaywrightInSauce(p playwright.Project, regio region.Region, tc testcomp
 		Project: p,
 		CloudRunner: saucecloud.CloudRunner{
 			ProjectUploader:    &as,
-			JobStarter:         &tc,
+			JobStarter:         &webdriverClient,
 			JobReader:          &rs,
 			JobStopper:         &rs,
 			JobWriter:          &tc,

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"github.com/saucelabs/saucectl/internal/framework"
 	"os"
 	"strings"
 
@@ -90,6 +91,7 @@ func runReplay(cmd *cobra.Command, tc testcomposer.Client, rs resto.Client, as a
 
 	regio := region.FromString(p.Sauce.Region)
 
+	webdriverClient.URL = regio.WebDriverBaseURL()
 	tc.URL = regio.APIBaseURL()
 	rs.URL = regio.APIBaseURL()
 	as.URL = regio.APIBaseURL()
@@ -126,7 +128,7 @@ func runPuppeteerReplayInSauce(p replay.Project, regio region.Region, tc testcom
 		Project: p,
 		CloudRunner: saucecloud.CloudRunner{
 			ProjectUploader:    &as,
-			JobStarter:         &tc,
+			JobStarter:         &webdriverClient,
 			JobReader:          &rs,
 			JobStopper:         &rs,
 			JobWriter:          &tc,
@@ -138,8 +140,9 @@ func runPuppeteerReplayInSauce(p replay.Project, regio region.Region, tc testcom
 			ArtifactDownloader: &rs,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &tc, &rs,
 				"puppeteer-replay", "sauce"),
-			Async:    gFlags.async,
-			FailFast: gFlags.failFast,
+			Async:                  gFlags.async,
+			FailFast:               gFlags.failFast,
+			MetadataSearchStrategy: framework.ExactStrategy{},
 		},
 	}
 

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -3,6 +3,7 @@ package run
 import (
 	"errors"
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/webdriver"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -49,16 +50,17 @@ var (
 	runShort = "Runs tests on Sauce Labs"
 
 	// General Request Timeouts
-	testComposerTimeout = 300 * time.Second
+	testComposerTimeout = 15 * time.Minute
 	rdcTimeout          = 15 * time.Second
 	githubTimeout       = 2 * time.Second
 
 	typeDef config.TypeDef
 
-	tcClient    testcomposer.Client
-	restoClient resto.Client
-	appsClient  appstore.AppStore
-	rdcClient   rdc.Client
+	tcClient        testcomposer.Client
+	webdriverClient webdriver.Client
+	restoClient     resto.Client
+	appsClient      appstore.AppStore
+	rdcClient       rdc.Client
 
 	// ErrEmptySuiteName is thrown when a flag is specified that has a dependency on the --name flag.
 	ErrEmptySuiteName = errors.New(msg.EmptyAdhocSuiteName)
@@ -198,6 +200,12 @@ func preRun() error {
 	typeDef = d
 
 	tcClient = testcomposer.Client{
+		HTTPClient:  &http.Client{Timeout: testComposerTimeout},
+		URL:         "", // updated later once region is determined
+		Credentials: creds,
+	}
+
+	webdriverClient = webdriver.Client{
 		HTTPClient:  &http.Client{Timeout: testComposerTimeout},
 		URL:         "", // updated later once region is determined
 		Credentials: creds,

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -138,6 +138,8 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, tc testcomposer.Clie
 	}
 
 	regio := region.FromString(p.Sauce.Region)
+
+	webdriverClient.URL = regio.WebDriverBaseURL()
 	tc.URL = regio.APIBaseURL()
 	rs.URL = regio.APIBaseURL()
 	as.URL = regio.APIBaseURL()
@@ -199,7 +201,7 @@ func runTestcafeInCloud(p testcafe.Project, regio region.Region, tc testcomposer
 		Project: p,
 		CloudRunner: saucecloud.CloudRunner{
 			ProjectUploader:    &as,
-			JobStarter:         &tc,
+			JobStarter:         &webdriverClient,
 			JobReader:          &rs,
 			JobStopper:         &rs,
 			JobWriter:          &tc,

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -98,6 +98,7 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, tc testcomposer.Cl
 
 	regio := region.FromString(p.Sauce.Region)
 
+	webdriverClient.URL = regio.WebDriverBaseURL()
 	tc.URL = regio.APIBaseURL()
 	rs.URL = regio.APIBaseURL()
 	as.URL = regio.APIBaseURL()
@@ -135,7 +136,8 @@ func runXcuitestInCloud(p xcuitest.Project, regio region.Region, tc testcomposer
 		Project: p,
 		CloudRunner: saucecloud.CloudRunner{
 			ProjectUploader:       &as,
-			JobStarter:            &tc,
+			JobStarter:            &webdriverClient,
+			RDCJobStarter:         &rc,
 			JobReader:             &rs,
 			RDCJobReader:          &rc,
 			JobStopper:            &rs,

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -298,10 +298,6 @@ func Validate(p *Project) error {
 		}
 	}
 
-	if err := normalizeBrowsers(p.Suites); err != nil {
-		return err
-	}
-
 	cfg, err := loadCypressConfiguration(p.RootDir, p.Cypress.ConfigFile, p.Sauce.Sauceignore)
 	if err != nil {
 		return err
@@ -309,18 +305,6 @@ func Validate(p *Project) error {
 
 	p.Suites, err = shardSuites(cfg, p.Suites, p.Sauce.Concurrency)
 	return err
-}
-
-// normalizeBrowsers converts the user specified browsers into something our platform can understand better.
-func normalizeBrowsers(suites []Suite) error {
-	for i := range suites {
-		switch suites[i].Browser {
-		case "chrome":
-			suites[i].Browser = "googlechrome"
-		}
-	}
-
-	return nil
 }
 
 // SplitSuites divided Suites to dockerSuites and sauceSuites

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -298,6 +298,10 @@ func Validate(p *Project) error {
 		}
 	}
 
+	if err := normalizeBrowsers(p.Suites); err != nil {
+		return err
+	}
+
 	cfg, err := loadCypressConfiguration(p.RootDir, p.Cypress.ConfigFile, p.Sauce.Sauceignore)
 	if err != nil {
 		return err
@@ -305,6 +309,19 @@ func Validate(p *Project) error {
 
 	p.Suites, err = shardSuites(cfg, p.Suites, p.Sauce.Concurrency)
 	return err
+}
+
+// normalizeBrowsers converts the user specified browsers into something our platform can understand better.
+func normalizeBrowsers(suites []Suite) error {
+	for i := range suites {
+		suite := suites[i]
+		switch suite.Browser {
+		case "chrome":
+			suite.Browser = "googlechrome"
+		}
+	}
+
+	return nil
 }
 
 // SplitSuites divided Suites to dockerSuites and sauceSuites

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -314,10 +314,9 @@ func Validate(p *Project) error {
 // normalizeBrowsers converts the user specified browsers into something our platform can understand better.
 func normalizeBrowsers(suites []Suite) error {
 	for i := range suites {
-		suite := suites[i]
-		switch suite.Browser {
+		switch suites[i].Browser {
 		case "chrome":
-			suite.Browser = "googlechrome"
+			suites[i].Browser = "googlechrome"
 		}
 	}
 

--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -30,12 +30,13 @@ type SearchOptions struct {
 
 // Metadata represents test runner metadata.
 type Metadata struct {
-	FrameworkName    string
-	FrameworkVersion string
-	Deprecated       bool
-	DockerImage      string
-	GitRelease       string
-	Platforms        []Platform
+	FrameworkName      string
+	FrameworkVersion   string
+	Deprecated         bool
+	DockerImage        string
+	GitRelease         string
+	Platforms          []Platform
+	CloudRunnerVersion string
 }
 
 // Platform represent a supported platform.

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -313,16 +313,15 @@ func Validate(p *Project) error {
 // normalizeBrowsers converts the user specified browsers into something our platform can understand better.
 func normalizeBrowsers(suites []Suite) error {
 	for i := range suites {
-		suite := suites[i]
-		switch suite.Params.BrowserName {
+		switch suites[i].Params.BrowserName {
 		case "chrome", "chromium":
-			suite.Params.BrowserName = "playwright-chromium"
+			suites[i].Params.BrowserName = "playwright-chromium"
 		case "firefox":
-			suite.Params.BrowserName = "playwright-firefox"
+			suites[i].Params.BrowserName = "playwright-firefox"
 		case "webkit":
-			suite.Params.BrowserName = "playwright-webkit"
+			suites[i].Params.BrowserName = "playwright-webkit"
 		default:
-			return fmt.Errorf(msg.UnsupportedBrowser, suite.Params.BrowserName, strings.Join(supportedBrowsers, ", "))
+			return fmt.Errorf(msg.UnsupportedBrowser, suites[i].Params.BrowserName, strings.Join(supportedBrowsers, ", "))
 		}
 	}
 

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/saucelabs/saucectl/internal/concurrency"
@@ -297,12 +298,36 @@ func Validate(p *Project) error {
 		}
 	}
 
+	if err := checkSupportedBrowsers(p); err != nil {
+		return err
+	}
+
 	regio := region.FromString(p.Sauce.Region)
 	if regio == region.None {
 		return errors.New(msg.MissingRegion)
 	}
 
 	return nil
+}
+
+func checkSupportedBrowsers(p *Project) error {
+	for _, suite := range p.Suites {
+		if suite.Params.BrowserName != "" && !isSupportedBrowser(suite.Params.BrowserName) {
+			return fmt.Errorf(msg.UnsupportedBrowser, suite.Params.BrowserName, strings.Join(supportedBrowsers, ", "))
+		}
+	}
+
+	return nil
+}
+
+func isSupportedBrowser(browser string) bool {
+	for _, supportedBr := range supportedBrowsers {
+		if supportedBr == browser {
+			return true
+		}
+	}
+
+	return false
 }
 
 // FilterSuites filters out suites in the project that don't match the given suite name.

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/saucelabs/saucectl/internal/concurrency"
@@ -298,31 +297,9 @@ func Validate(p *Project) error {
 		}
 	}
 
-	if err := normalizeBrowsers(p.Suites); err != nil {
-		return err
-	}
-
 	regio := region.FromString(p.Sauce.Region)
 	if regio == region.None {
 		return errors.New(msg.MissingRegion)
-	}
-
-	return nil
-}
-
-// normalizeBrowsers converts the user specified browsers into something our platform can understand better.
-func normalizeBrowsers(suites []Suite) error {
-	for i := range suites {
-		switch suites[i].Params.BrowserName {
-		case "chrome", "chromium":
-			suites[i].Params.BrowserName = "playwright-chromium"
-		case "firefox":
-			suites[i].Params.BrowserName = "playwright-firefox"
-		case "webkit":
-			suites[i].Params.BrowserName = "playwright-webkit"
-		default:
-			return fmt.Errorf(msg.UnsupportedBrowser, suites[i].Params.BrowserName, strings.Join(supportedBrowsers, ", "))
-		}
 	}
 
 	return nil

--- a/internal/puppeteer/replay/config.go
+++ b/internal/puppeteer/replay/config.go
@@ -38,6 +38,7 @@ type Project struct {
 	Artifacts     config.Artifacts     `yaml:"artifacts,omitempty" json:"artifacts"`
 	Reporters     config.Reporters     `yaml:"reporters,omitempty" json:"-"`
 	Notifications config.Notifications `yaml:"notifications,omitempty" json:"-"`
+	RunnerVersion string               `yaml:"runnerVersion,omitempty" json:"runnerVersion"`
 }
 
 // Suite represents the playwright test suite configuration.

--- a/internal/rdc/client.go
+++ b/internal/rdc/client.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"time"
 
@@ -573,8 +572,8 @@ func formatEspressoArgs(options map[string]interface{}) map[string]string {
 
 		// class/notClass need special treatment, because we accept these as slices, but the backend wants
 		// a comma separated string.
-		if (k == "class" || k == "notClass") && reflect.TypeOf(v).Kind() == reflect.Slice {
-			value = slice.Join(v.([]any))
+		if k == "class" || k == "notClass" {
+			value = slice.Join(v, ",")
 		}
 
 		if value == "" {

--- a/internal/rdc/client.go
+++ b/internal/rdc/client.go
@@ -1,6 +1,7 @@
 package rdc
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -41,6 +42,7 @@ const retryMax = 3
 // Client http client.
 type Client struct {
 	HTTPClient     *retryablehttp.Client
+	NativeClient   *http.Client
 	URL            string
 	Username       string
 	AccessKey      string
@@ -71,15 +73,54 @@ type readJobResponse struct {
 	Error              string              `json:"error,omitempty"`
 }
 
+// SessionRequest represents the RDC session request.
+type SessionRequest struct {
+	TestFramework       string            `json:"test_framework,omitempty"`
+	AppID               string            `json:"app_id,omitempty"`
+	TestAppID           string            `json:"test_app_id,omitempty"`
+	OtherApps           []string          `json:"other_apps,omitempty"`
+	DeviceQuery         DeviceQuery       `json:"device_query,omitempty"`
+	TestOptions         map[string]string `json:"test_options,omitempty"`
+	TestsToRun          []string          `json:"tests_to_run,omitempty"`
+	TestsToSkip         []string          `json:"tests_to_skip,omitempty"`
+	TestName            string            `json:"test_name,omitempty"`
+	TunnelName          string            `json:"tunnel_name,omitempty"`
+	TunnelOwner         string            `json:"tunnel_owner,omitempty"`
+	UseTestOrchestrator bool              `json:"use_test_orchestrator,omitempty"`
+	Tags                []string          `json:"tags,omitempty"`
+	Build               string            `json:"build,omitempty"`
+	AppSettings         job.AppSettings   `json:"settings,omitempty"`
+	RealDeviceKind      string            `json:"kind,omitempty"`
+}
+
+// DeviceQuery represents the device selection query for RDC.
+type DeviceQuery struct {
+	Type                         string `json:"type"`
+	DeviceDescriptorID           string `json:"device_descriptor_id,omitempty"`
+	PrivateDevicesOnly           bool   `json:"private_devices_only,omitempty"`
+	CarrierConnectivityRequested bool   `json:"carrier_connectivity_requested,omitempty"`
+	RequestedDeviceType          string `json:"requested_device_type,omitempty"`
+	DeviceName                   string `json:"device_name,omitempty"`
+	PlatformVersion              string `json:"platform_version,omitempty"`
+}
+
+type sessionStartResponse struct {
+	TestReport struct {
+		ID string `json:"id"`
+	} `json:"test_report"`
+}
+
 // New creates a new client.
 func New(url, username, accessKey string, timeout time.Duration, artifactConfig config.ArtifactDownload) Client {
+	nativeClient := &http.Client{Timeout: timeout}
 	httpClient := retryablehttp.NewClient()
-	httpClient.HTTPClient = &http.Client{Timeout: timeout}
+	httpClient.HTTPClient = nativeClient
 	httpClient.Logger = nil
 	httpClient.RetryMax = retryMax
 
 	return Client{
 		HTTPClient:     httpClient,
+		NativeClient:   nativeClient,
 		URL:            url,
 		Username:       username,
 		AccessKey:      accessKey,
@@ -116,6 +157,78 @@ func (c *Client) ReadAllowedCCY(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	return cr.Organization.Maximum, nil
+}
+
+// StartJob creates a new job in Sauce Labs.
+func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID string, isRDC bool, err error) {
+	url := fmt.Sprintf("%s/v1/rdc/native-composer/tests", c.URL)
+
+	var frameworkName string
+	switch opts.Framework {
+	case "espresso":
+		frameworkName = "ANDROID_INSTRUMENTATION"
+	case "xcuitest":
+		frameworkName = "XCUITEST"
+	}
+
+	useTestOrchestrator := false
+	if v, ok := opts.TestOptions["useTestOrchestrator"]; ok {
+		useTestOrchestrator = fmt.Sprintf("%v", v) == "true"
+	}
+
+	jobReq := SessionRequest{
+		TestName:            opts.Name,
+		AppID:               opts.App,
+		TestAppID:           opts.Suite,
+		OtherApps:           opts.OtherApps,
+		TestOptions:         formatEspressoArgsForRDC(opts.TestOptions),
+		TestsToRun:          opts.TestsToRun,
+		TestsToSkip:         opts.TestsToSkip,
+		DeviceQuery:         prepareDeviceQuery(opts),
+		TestFramework:       frameworkName,
+		TunnelName:          opts.Tunnel.ID,
+		TunnelOwner:         opts.Tunnel.Parent,
+		UseTestOrchestrator: useTestOrchestrator,
+		Tags:                opts.Tags,
+		Build:               opts.Build,
+		RealDeviceKind:      opts.RealDeviceKind,
+		AppSettings:         opts.AppSettings,
+	}
+
+	var b bytes.Buffer
+	err = json.NewEncoder(&b).Encode(jobReq)
+	if err != nil {
+		return
+	}
+
+	req, err := requesth.NewWithContext(ctx, http.MethodPost, url, &b)
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(c.Username, c.AccessKey)
+
+	resp, err := c.NativeClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode >= 300 {
+		err = fmt.Errorf("job start failed; unexpected response code:'%d', msg:'%v'", resp.StatusCode, strings.TrimSpace(string(body)))
+		return "", true, err
+	}
+
+	var sessionStart sessionStartResponse
+	if err = json.Unmarshal(body, &sessionStart); err != nil {
+		return "", true, fmt.Errorf("job start status unknown: unable to parse server response: %w", err)
+	}
+
+	return sessionStart.TestReport.ID, true, nil
 }
 
 // ReadJob returns the job details.
@@ -440,4 +553,43 @@ func (c *Client) GetDevices(ctx context.Context, OS string) ([]devices.Device, e
 		})
 	}
 	return dev, nil
+}
+
+// formatEspressoArgsForRDC adapts option shape to match RDC expectations
+func formatEspressoArgsForRDC(options map[string]interface{}) map[string]string {
+	mappedOptions := map[string]string{}
+	for k, v := range options {
+		if v == nil {
+			continue
+		}
+		// We let the user set 'useTestOrchestrator' inside TestOptions, but RDC has a dedicated setting for it.
+		if k == "useTestOrchestrator" {
+			continue
+		}
+
+		value := fmt.Sprintf("%v", v)
+		if value == "" {
+			continue
+		}
+		mappedOptions[k] = value
+	}
+	return mappedOptions
+}
+
+// prepareDeviceQuery prepares the DeviceQuery according jobs requirements.
+func prepareDeviceQuery(opts job.StartOptions) DeviceQuery {
+	if opts.DeviceID != "" {
+		return DeviceQuery{
+			Type:               "HardcodedDeviceQuery",
+			DeviceDescriptorID: opts.DeviceID,
+		}
+	}
+	return DeviceQuery{
+		Type:                         "DynamicDeviceQuery",
+		CarrierConnectivityRequested: opts.DeviceHasCarrier,
+		DeviceName:                   opts.DeviceName,
+		PlatformVersion:              opts.PlatformVersion,
+		PrivateDevicesOnly:           opts.DevicePrivateOnly,
+		RequestedDeviceType:          opts.DeviceType,
+	}
 }

--- a/internal/rdc/client_test.go
+++ b/internal/rdc/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,25 @@ import (
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/stretchr/testify/assert"
 )
+
+type ResponseRecord struct {
+	Index   int
+	Records []func(w http.ResponseWriter, r *http.Request)
+	Test    *testing.T
+}
+
+func (r *ResponseRecord) Record(resFunc func(w http.ResponseWriter, req *http.Request)) {
+	r.Records = append(r.Records, resFunc)
+}
+
+func (r *ResponseRecord) Play(w http.ResponseWriter, req *http.Request) {
+	if r.Index >= len(r.Records) {
+		r.Test.Errorf("responder requested more times than it has available records")
+	}
+
+	r.Records[r.Index](w, req)
+	r.Index++
+}
 
 func TestClient_ReadAllowedCCY(t *testing.T) {
 	testCases := []struct {
@@ -562,5 +582,130 @@ func TestClient_GetDevices(t *testing.T) {
 				t.Errorf("GetDevices() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestClient_StartJob(t *testing.T) {
+	rec := ResponseRecord{
+		Test: t,
+	}
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.Play(w, r)
+	}))
+	type args struct {
+		ctx               context.Context
+		jobStarterPayload job.StartOptions
+	}
+	type fields struct {
+		HTTPClient *http.Client
+		URL        string
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		want       string
+		wantErr    error
+		serverFunc func(w http.ResponseWriter, r *http.Request) // what shall the mock server respond with
+	}{
+		{
+			name: "Happy path",
+			fields: fields{
+				HTTPClient: mockServer.Client(),
+				URL:        mockServer.URL,
+			},
+			args: args{
+				ctx: context.TODO(),
+				jobStarterPayload: job.StartOptions{
+					User:        "fake-user",
+					AccessKey:   "fake-access-key",
+					BrowserName: "fake-browser-name",
+					Name:        "fake-test-name",
+					Framework:   "fake-framework",
+					Build:       "fake-buildname",
+					Tags:        nil,
+				},
+			},
+			want:    "fake-job-id",
+			wantErr: nil,
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				resp := sessionStartResponse{
+					TestReport: struct {
+						ID string `json:"id"`
+					}{ID: "fake-job-id"},
+				}
+				respondJSON(w, resp, 201)
+			},
+		},
+		{
+			name: "Non 2xx status code",
+			fields: fields{
+				HTTPClient: mockServer.Client(),
+				URL:        mockServer.URL,
+			},
+			args: args{
+				ctx:               context.TODO(),
+				jobStarterPayload: job.StartOptions{},
+			},
+			want:    "",
+			wantErr: fmt.Errorf("job start failed; unexpected response code:'300', msg:''"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(300)
+			},
+		},
+		{
+			name: "Unknown error",
+			fields: fields{
+				HTTPClient: mockServer.Client(),
+				URL:        mockServer.URL,
+			},
+			args: args{
+				ctx:               context.TODO(),
+				jobStarterPayload: job.StartOptions{},
+			},
+			want:    "",
+			wantErr: fmt.Errorf("job start failed; unexpected response code:'500', msg:'Internal server error'"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(500)
+				_, err := w.Write([]byte("Internal server error"))
+				if err != nil {
+					t.Errorf("failed to write response: %v", err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				NativeClient: tt.fields.HTTPClient,
+				URL:          tt.fields.URL,
+			}
+
+			rec.Record(tt.serverFunc)
+
+			got, _, err := c.StartJob(tt.args.ctx, tt.args.jobStarterPayload)
+			if (err != nil) && !reflect.DeepEqual(err, tt.wantErr) {
+				t.Errorf("StartJob() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StartJob() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func respondJSON(w http.ResponseWriter, v interface{}, httpStatus int) {
+	w.WriteHeader(httpStatus)
+	b, err := json.Marshal(v)
+
+	if err != nil {
+		log.Err(err).Msg("failed to marshal job json")
+		http.Error(w, "failed to marshal job json", http.StatusInternalServerError)
+		return
+	}
+
+	if _, err := w.Write(b); err != nil {
+		log.Err(err).Msg("Failed to write out response")
 	}
 }

--- a/internal/rdc/client_test.go
+++ b/internal/rdc/client_test.go
@@ -90,6 +90,7 @@ func TestClient_ReadAllowedCCY(t *testing.T) {
 		}))
 
 		client := New(ts.URL, "test", "123", timeout, config.ArtifactDownload{})
+		client.HTTPClient.RetryWaitMax = 1 * time.Millisecond
 		ccy, err := client.ReadAllowedCCY(context.Background())
 		assert.Equal(t, ccy, tt.want)
 		if err != nil {
@@ -315,6 +316,7 @@ func TestClient_GetJobStatus(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			tc.client.HTTPClient.RetryWaitMax = 1 * time.Millisecond
 			got, err := tc.client.PollJob(context.Background(), tc.jobID, 10*time.Millisecond, 0)
 			assert.Equal(t, tc.expectedResp, got)
 			if err != nil {

--- a/internal/region/region.go
+++ b/internal/region/region.go
@@ -15,12 +15,14 @@ const (
 )
 
 var meta = []struct {
-	Name       string
-	APIBaseURL string
-	AppBaseURL string
+	Name             string
+	APIBaseURL       string
+	AppBaseURL       string
+	WebDriverBaseURL string
 }{
 	// None
 	{
+		"",
 		"",
 		"",
 		"",
@@ -30,18 +32,21 @@ var meta = []struct {
 		"us-west-1",
 		"https://api.us-west-1.saucelabs.com",
 		"https://app.saucelabs.com",
+		"https://ondemand.us-west-1.saucelabs.com",
 	},
 	// EUCentral1
 	{
 		"eu-central-1",
 		"https://api.eu-central-1.saucelabs.com",
 		"https://app.eu-central-1.saucelabs.com",
+		"https://ondemand.eu-central-1.saucelabs.com",
 	},
 	// Staging
 	{
 		"staging",
 		"https://api.staging.saucelabs.net",
 		"https://app.staging.saucelabs.net",
+		"https://ondemand.staging.saucelabs.net",
 	},
 }
 

--- a/internal/region/region.go
+++ b/internal/region/region.go
@@ -75,3 +75,8 @@ func (r Region) APIBaseURL() string {
 func (r Region) AppBaseURL() string {
 	return meta[r].AppBaseURL
 }
+
+// WebDriverBaseURL returns the webdriver base URL for the region.
+func (r Region) WebDriverBaseURL() string {
+	return meta[r].WebDriverBaseURL
+}

--- a/internal/saucecloud/cloud_test.go
+++ b/internal/saucecloud/cloud_test.go
@@ -248,7 +248,7 @@ func TestRunJobRetries(t *testing.T) {
 
 func TestRunJobTimeoutRDC(t *testing.T) {
 	r := CloudRunner{
-		JobStarter: &mocks.FakeJobStarter{
+		RDCJobStarter: &mocks.FakeJobStarter{
 			StartJobFn: func(ctx context.Context, opts job.StartOptions) (jobID string, isRDC bool, err error) {
 				return "1", true, nil
 			},
@@ -267,6 +267,7 @@ func TestRunJobTimeoutRDC(t *testing.T) {
 	opts <- job.StartOptions{
 		DisplayName: "dummy",
 		Timeout:     1,
+		RealDevice:  true,
 	}
 	close(opts)
 	res := <-results

--- a/internal/saucecloud/cypress.go
+++ b/internal/saucecloud/cypress.go
@@ -26,6 +26,7 @@ func (r *CypressRunner) RunProject() (int, error) {
 		return exitCode, err
 	}
 	r.Project.Cypress.Version = m.FrameworkVersion
+	r.Project.RunnerVersion = m.CloudRunnerVersion
 
 	if m.Deprecated {
 		deprecationMessage = r.deprecationMessage(cypress.Kind, r.Project.Cypress.Version)

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -26,6 +26,7 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 		return exitCode, err
 	}
 	r.Project.Playwright.Version = m.FrameworkVersion
+	r.Project.RunnerVersion = m.CloudRunnerVersion
 
 	if m.Deprecated {
 		deprecationMessage = r.deprecationMessage(playwright.Kind, r.Project.Playwright.Version)

--- a/internal/saucecloud/replay.go
+++ b/internal/saucecloud/replay.go
@@ -1,6 +1,7 @@
 package saucecloud
 
 import (
+	"context"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -17,6 +18,13 @@ type ReplayRunner struct {
 // RunProject runs the tests defined in cypress.Project.
 func (r *ReplayRunner) RunProject() (int, error) {
 	exitCode := 1
+
+	m, err := r.MetadataSearchStrategy.Find(context.Background(), r.MetadataService, replay.Kind, "latest")
+	if err != nil {
+		r.logFrameworkError(err)
+		return exitCode, err
+	}
+	r.Project.RunnerVersion = m.CloudRunnerVersion
 
 	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner); err != nil {
 		return 1, err
@@ -79,6 +87,7 @@ func (r *ReplayRunner) runSuites(fileURI string) bool {
 				Suite:            s.Name,
 				Framework:        "puppeteer-replay",
 				FrameworkVersion: "latest",
+				RunnerVersion:    r.Project.RunnerVersion,
 				BrowserName:      s.BrowserName,
 				BrowserVersion:   s.BrowserVersion,
 				PlatformName:     s.Platform,

--- a/internal/saucecloud/testcafe.go
+++ b/internal/saucecloud/testcafe.go
@@ -26,6 +26,7 @@ func (r *TestcafeRunner) RunProject() (int, error) {
 		return exitCode, err
 	}
 	r.Project.Testcafe.Version = m.FrameworkVersion
+	r.Project.RunnerVersion = m.CloudRunnerVersion
 
 	if m.Deprecated {
 		deprecationMessage = r.deprecationMessage(testcafe.Kind, r.Project.Testcafe.Version)

--- a/internal/saucecloud/xcuitest_test.go
+++ b/internal/saucecloud/xcuitest_test.go
@@ -64,8 +64,8 @@ func TestXcuitestRunner_RunProject(t *testing.T) {
 
 	runner := &XcuitestRunner{
 		CloudRunner: CloudRunner{
-			JobStarter:         &starter,
-			JobReader:          &reader,
+			RDCJobStarter:      &starter,
+			RDCJobReader:       &reader,
 			JobWriter:          &writer,
 			CCYReader:          ccyReader,
 			ProjectUploader:    uploader,

--- a/internal/slice/slice.go
+++ b/internal/slice/slice.go
@@ -1,0 +1,17 @@
+package slice
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Join joins a slice of objects into a comma separated string.
+// Example:
+//   ["value1", "value2"] -> "value1,value2"
+func Join(values []any) string {
+	var vv []string
+	for _, v := range values {
+		vv = append(vv, fmt.Sprintf("%v", v))
+	}
+	return strings.Join(vv, ",")
+}

--- a/internal/slice/slice.go
+++ b/internal/slice/slice.go
@@ -2,16 +2,37 @@ package slice
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 )
 
-// Join joins a slice of objects into a comma separated string.
-// Example:
-//   ["value1", "value2"] -> "value1,value2"
-func Join(values []any) string {
-	var vv []string
-	for _, v := range values {
-		vv = append(vv, fmt.Sprintf("%v", v))
+// Join concatenates the elements of its first argument to create a single string. The separator string sep is placed
+// between elements in the resulting string.
+//
+// Disclaimer: Use this function judiciously.
+func Join(value any, sep string) string {
+	if reflect.TypeOf(value).Kind() != reflect.Slice {
+		return fmt.Sprintf("%v", value)
 	}
-	return strings.Join(vv, ",")
+
+	switch reflect.TypeOf(value).Elem().Kind() {
+	case reflect.String:
+		return strings.Join(value.([]string), sep)
+	case reflect.Interface:
+		elems := value.([]interface{})
+		var vv []string
+		for _, v := range elems {
+			vv = append(vv, fmt.Sprintf("%v", v))
+		}
+		return strings.Join(vv, sep)
+	case reflect.Int:
+		elems := value.([]int)
+		var vv []string
+		for _, v := range elems {
+			vv = append(vv, fmt.Sprintf("%d", v))
+		}
+		return strings.Join(vv, sep)
+	default:
+		return fmt.Sprintf("%v", value)
+	}
 }

--- a/internal/slice/slice_test.go
+++ b/internal/slice/slice_test.go
@@ -1,0 +1,33 @@
+package slice
+
+import (
+	"fmt"
+)
+
+func ExampleJoin_strings() {
+	fmt.Println(Join([]string{"a", "b", "c"}, ","))
+	// Output: a,b,c
+}
+
+func ExampleJoin_ints() {
+	fmt.Println(Join([]int{1, 2, 3}, ","))
+	// Output: 1,2,3
+}
+
+func ExampleJoin_interfaces() {
+	fmt.Println(Join([]interface{}{"a", "b", "c"}, ","))
+	// Output: a,b,c
+}
+
+func ExampleJoin_string() {
+	fmt.Println(Join("hello", ","))
+	// Output: hello
+}
+
+func ExampleJoin_struct() {
+	type Person struct {
+		Name string
+	}
+	fmt.Println(Join(Person{Name: "Someone Else"}, ","))
+	// Output: {Someone Else}
+}

--- a/internal/testcafe/config.go
+++ b/internal/testcafe/config.go
@@ -260,10 +260,27 @@ func Validate(p *Project) error {
 		}
 	}
 
+	if err := normalizeBrowsers(p.Suites); err != nil {
+		return err
+	}
+
 	var err error
 	p.Suites, err = shardSuites(p.RootDir, p.Suites, p.Sauce.Concurrency)
 
 	return err
+}
+
+// normalizeBrowsers converts the user specified browsers into something our platform can understand better.
+func normalizeBrowsers(suites []Suite) error {
+	for i := range suites {
+		suite := suites[i]
+		switch suite.BrowserName {
+		case "chrome":
+			suite.BrowserName = "googlechrome"
+		}
+	}
+
+	return nil
 }
 
 // SplitSuites divided Suites to dockerSuites and sauceSuites

--- a/internal/testcafe/config.go
+++ b/internal/testcafe/config.go
@@ -273,10 +273,9 @@ func Validate(p *Project) error {
 // normalizeBrowsers converts the user specified browsers into something our platform can understand better.
 func normalizeBrowsers(suites []Suite) error {
 	for i := range suites {
-		suite := suites[i]
-		switch suite.BrowserName {
+		switch suites[i].BrowserName {
 		case "chrome":
-			suite.BrowserName = "googlechrome"
+			suites[i].BrowserName = "googlechrome"
 		}
 	}
 

--- a/internal/testcafe/config.go
+++ b/internal/testcafe/config.go
@@ -260,26 +260,10 @@ func Validate(p *Project) error {
 		}
 	}
 
-	if err := normalizeBrowsers(p.Suites); err != nil {
-		return err
-	}
-
 	var err error
 	p.Suites, err = shardSuites(p.RootDir, p.Suites, p.Sauce.Concurrency)
 
 	return err
-}
-
-// normalizeBrowsers converts the user specified browsers into something our platform can understand better.
-func normalizeBrowsers(suites []Suite) error {
-	for i := range suites {
-		switch suites[i].BrowserName {
-		case "chrome":
-			suites[i].BrowserName = "googlechrome"
-		}
-	}
-
-	return nil
 }
 
 // SplitSuites divided Suites to dockerSuites and sauceSuites

--- a/internal/testcomposer/testcomposer.go
+++ b/internal/testcomposer/testcomposer.go
@@ -161,11 +161,12 @@ func (c *Client) Search(ctx context.Context, opts framework.SearchOptions) (fram
 	}
 
 	m := framework.Metadata{
-		FrameworkName:    resp.Name,
-		FrameworkVersion: resp.Version,
-		Deprecated:       resp.Deprecated,
-		DockerImage:      resp.Runner.DockerImage,
-		GitRelease:       resp.Runner.GitRelease,
+		FrameworkName:      resp.Name,
+		FrameworkVersion:   resp.Version,
+		Deprecated:         resp.Deprecated,
+		DockerImage:        resp.Runner.DockerImage,
+		GitRelease:         resp.Runner.GitRelease,
+		CloudRunnerVersion: resp.Runner.CloudRunnerVersion,
 	}
 
 	return m, nil

--- a/internal/webdriver/webdriver.go
+++ b/internal/webdriver/webdriver.go
@@ -1,0 +1,233 @@
+package webdriver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/saucelabs/saucectl/internal/version"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/job"
+	"github.com/saucelabs/saucectl/internal/requesth"
+)
+
+// Client service
+type Client struct {
+	HTTPClient  *http.Client
+	URL         string
+	Credentials credentials.Credentials
+}
+
+// Job represents the sauce labs test job.
+type Job struct {
+	ID    string `json:"id"`
+	Owner string `json:"owner"`
+}
+
+// FrameworkResponse represents the response body for framework information.
+type FrameworkResponse struct {
+	Name       string     `json:"name"`
+	Deprecated bool       `json:"deprecated"`
+	Version    string     `json:"version"`
+	Runner     runner     `json:"runner"`
+	Platforms  []platform `json:"platforms"`
+}
+
+// TokenResponse represents the response body for slack token.
+type TokenResponse struct {
+	Token string `json:"token"`
+}
+
+type platform struct {
+	Name     string
+	Browsers []string
+}
+
+type runner struct {
+	CloudRunnerVersion string `json:"cloudRunnerVersion"`
+	DockerImage        string `json:"dockerImage"`
+	GitRelease         string `json:"gitRelease"`
+}
+
+// SessionRequest represents the webdriver session request.
+type SessionRequest struct {
+	Capabilities        *Capabilities `json:"capabilities,omitempty"`
+	DesiredCapabilities *MatchingCaps `json:"desiredCapabilities,omitempty"`
+}
+
+// Capabilities represents the webdriver capabilities.
+// https://www.w3.org/TR/webdriver/
+type Capabilities struct {
+	AlwaysMatch MatchingCaps `json:"alwaysMatch,omitempty"`
+}
+
+// MatchingCaps are specific attributes that together form the capabilities that are used to match a session.
+type MatchingCaps struct {
+	App               string    `json:"app,omitempty"`
+	BrowserName       string    `json:"browserName,omitempty"`
+	BrowserVersion    string    `json:"browserVersion,omitempty"`
+	PlatformName      string    `json:"platformName,omitempty"`
+	SauceOptions      SauceOpts `json:"sauce:options,omitempty"`
+	PlatformVersion   string    `json:"platformVersion,omitempty"`
+	DeviceName        string    `json:"deviceName,omitempty"`
+	DeviceOrientation string    `json:"deviceOrientation,omitempty"`
+}
+
+// SauceOpts represents the Sauce Labs specific capabilities.
+type SauceOpts struct {
+	DevX             bool     `json:"devX,omitempty"`
+	TestName         string   `json:"name,omitempty"`
+	Tags             []string `json:"tags,omitempty"`
+	BuildName        string   `json:"build,omitempty"`
+	Batch            Batch    `json:"_batch,omitempty"`
+	IdleTimeout      int      `json:"idleTimeout,omitempty"`
+	MaxDuration      int      `json:"maxDuration,omitempty"`
+	TunnelIdentifier string   `json:"tunnelIdentifier,omitempty"`
+	TunnelParent     string   `json:"parentTunnel,omitempty"` // note that 'parentTunnel` is backwards, because that's the way sauce likes it
+	ScreenResolution string   `json:"screen_resolution,omitempty"`
+	SauceCloudNode   string   `json:"_sauceCloudNode,omitempty"`
+	UserAgent        string   `json:"user_agent,omitempty"`
+	TimeZone         string   `json:"timeZone,omitempty"`
+}
+
+// Batch represents capabilities for batch frameworks.
+type Batch struct {
+	Framework        string              `json:"framework,omitempty"`
+	FrameworkVersion string              `json:"frameworkVersion,omitempty"`
+	RunnerVersion    string              `json:"runnerVersion,omitempty"`
+	TestFile         string              `json:"testFile,omitempty"`
+	Args             []map[string]string `json:"args"`
+}
+
+// sessionStartResponse represents the response body for starting a session.
+type sessionStartResponse struct {
+	Status    int    `json:"status,omitempty"`
+	SessionID string `json:"sessionId,omitempty"`
+	Value     struct {
+		Message string `json:"message,omitempty"`
+	} `json:"value,omitempty"`
+}
+
+// StartJob creates a new job in Sauce Labs.
+func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID string, isRDC bool, err error) {
+	url := fmt.Sprintf("%s/wd/hub/session", c.URL)
+
+	caps := Capabilities{AlwaysMatch: MatchingCaps{
+		App:             opts.App,
+		BrowserName:     normalizeBrowser(opts.Framework, opts.BrowserName),
+		BrowserVersion:  opts.BrowserVersion,
+		PlatformName:    opts.PlatformName,
+		PlatformVersion: opts.PlatformVersion,
+		SauceOptions: SauceOpts{
+			UserAgent:        "saucectl/" + version.Version,
+			DevX:             true,
+			TunnelIdentifier: opts.Tunnel.ID,
+			TunnelParent:     opts.Tunnel.Parent,
+			ScreenResolution: opts.ScreenResolution,
+			SauceCloudNode:   opts.Experiments["_sauceCloudNode"],
+			TestName:         opts.Name,
+			BuildName:        opts.Build,
+			Tags:             opts.Tags,
+			Batch: Batch{
+				Framework:        opts.Framework,
+				FrameworkVersion: opts.FrameworkVersion,
+				RunnerVersion:    opts.RunnerVersion,
+				TestFile:         opts.Suite,
+				Args:             formatEspressoArgs(opts.TestOptions),
+			},
+			IdleTimeout: 9999,
+			MaxDuration: 10800,
+			TimeZone:    opts.TimeZone,
+		},
+		DeviceName:        opts.DeviceName,
+		DeviceOrientation: opts.DeviceOrientation,
+	}}
+
+	session := SessionRequest{
+		Capabilities: &caps,
+	}
+
+	// Espresso emulator requests are allergic to W3C capabilities, so use legacy format. However, using legacy format
+	// alone does not work, as the platform interprets this as a request for appium.
+	if opts.Framework == "espresso" {
+		session.DesiredCapabilities = &caps.AlwaysMatch
+	}
+
+	var b bytes.Buffer
+	err = json.NewEncoder(&b).Encode(session)
+	if err != nil {
+		return
+	}
+
+	req, err := requesth.NewWithContext(ctx, http.MethodPost, url, &b)
+	if err != nil {
+		return
+	}
+	req.SetBasicAuth(c.Credentials.Username, c.Credentials.AccessKey)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode >= 300 {
+		err = fmt.Errorf("job start failed; unexpected response code:'%d', msg:'%v'", resp.StatusCode, strings.TrimSpace(string(body)))
+		return "", false, err
+	}
+
+	var sessionStart sessionStartResponse
+	if err = json.Unmarshal(body, &sessionStart); err != nil {
+		return "", false, fmt.Errorf("job start status unknown: unable to parse server response: %w", err)
+	}
+
+	return sessionStart.SessionID, false, nil
+}
+
+// formatEspressoArgs adapts option shape to match chef expectations
+func formatEspressoArgs(options map[string]interface{}) []map[string]string {
+	var mappedOptions []map[string]string
+	for k, v := range options {
+		if v == nil {
+			continue
+		}
+		value := fmt.Sprintf("%v", v)
+		if value == "" {
+			continue
+		}
+		mappedOptions = append(mappedOptions, map[string]string{
+			"name":  k,
+			"value": value,
+		})
+	}
+	return mappedOptions
+}
+
+// normalizeBrowser converts the user specified browsers into something Sauce Labs can understand better.
+func normalizeBrowser(framework, browser string) string {
+	switch framework {
+	case "cypress", "testcafe":
+		switch browser {
+		case "chrome":
+			return "googlechrome"
+		}
+	case "playwright":
+		switch browser {
+		case "chrome", "chromium":
+			return "playwright-chromium"
+		case "firefox":
+			return "playwright-firefox"
+		case "webkit":
+			return "playwright-webkit"
+		}
+	}
+	return browser
+}

--- a/internal/webdriver/webdriver.go
+++ b/internal/webdriver/webdriver.go
@@ -55,8 +55,8 @@ type runner struct {
 
 // SessionRequest represents the webdriver session request.
 type SessionRequest struct {
-	Capabilities        *Capabilities `json:"capabilities,omitempty"`
-	DesiredCapabilities *MatchingCaps `json:"desiredCapabilities,omitempty"`
+	Capabilities        Capabilities `json:"capabilities,omitempty"`
+	DesiredCapabilities MatchingCaps `json:"desiredCapabilities,omitempty"`
 }
 
 // Capabilities represents the webdriver capabilities.
@@ -147,14 +147,11 @@ func (c *Client) StartJob(ctx context.Context, opts job.StartOptions) (jobID str
 		DeviceOrientation: opts.DeviceOrientation,
 	}}
 
+	// Emulator/Simulator requests are allergic to W3C capabilities. Requests get routed to RDC. However, using legacy
+	// format alone is insufficient, we need both.
 	session := SessionRequest{
-		Capabilities: &caps,
-	}
-
-	// Espresso emulator requests are allergic to W3C capabilities, so use legacy format. However, using legacy format
-	// alone does not work, as the platform interprets this as a request for appium.
-	if opts.Framework == "espresso" {
-		session.DesiredCapabilities = &caps.AlwaysMatch
+		Capabilities:        caps,
+		DesiredCapabilities: caps.AlwaysMatch,
 	}
 
 	var b bytes.Buffer

--- a/internal/webdriver/webdriver.go
+++ b/internal/webdriver/webdriver.go
@@ -9,7 +9,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/version"
 	"io"
 	"net/http"
-	"reflect"
 	"strings"
 
 	"github.com/saucelabs/saucectl/internal/credentials"
@@ -203,8 +202,8 @@ func formatEspressoArgs(options map[string]interface{}) []map[string]string {
 
 		// class/notClass need special treatment, because we accept these as slices, but the backend wants
 		// a comma separated string.
-		if (k == "class" || k == "notClass") && reflect.TypeOf(v).Kind() == reflect.Slice {
-			value = slice.Join(v.([]any))
+		if k == "class" || k == "notClass" {
+			value = slice.Join(v, ",")
 		}
 
 		if value == "" {

--- a/internal/webdriver/webdriver.go
+++ b/internal/webdriver/webdriver.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/slice"
 	"github.com/saucelabs/saucectl/internal/version"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/saucelabs/saucectl/internal/credentials"
@@ -196,7 +198,15 @@ func formatEspressoArgs(options map[string]interface{}) []map[string]string {
 		if v == nil {
 			continue
 		}
+
 		value := fmt.Sprintf("%v", v)
+
+		// class/notClass need special treatment, because we accept these as slices, but the backend wants
+		// a comma separated string.
+		if (k == "class" || k == "notClass") && reflect.TypeOf(v).Kind() == reflect.Slice {
+			value = slice.Join(v.([]any))
+		}
+
 		if value == "" {
 			continue
 		}

--- a/internal/webdriver/webdriver_test.go
+++ b/internal/webdriver/webdriver_test.go
@@ -1,0 +1,155 @@
+package webdriver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/job"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+type ResponseRecord struct {
+	Index   int
+	Records []func(w http.ResponseWriter, r *http.Request)
+	Test    *testing.T
+}
+
+func (r *ResponseRecord) Record(resFunc func(w http.ResponseWriter, req *http.Request)) {
+	r.Records = append(r.Records, resFunc)
+}
+
+func (r *ResponseRecord) Play(w http.ResponseWriter, req *http.Request) {
+	if r.Index >= len(r.Records) {
+		r.Test.Errorf("responder requested more times than it has available records")
+	}
+
+	r.Records[r.Index](w, req)
+	r.Index++
+}
+
+func TestClient_StartJob(t *testing.T) {
+	rec := ResponseRecord{
+		Test: t,
+	}
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.Play(w, r)
+	}))
+	type args struct {
+		ctx               context.Context
+		jobStarterPayload job.StartOptions
+	}
+	type fields struct {
+		HTTPClient *http.Client
+		URL        string
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		want       string
+		wantErr    error
+		serverFunc func(w http.ResponseWriter, r *http.Request) // what shall the mock server respond with
+	}{
+		{
+			name: "Happy path",
+			fields: fields{
+				HTTPClient: mockServer.Client(),
+				URL:        mockServer.URL,
+			},
+			args: args{
+				ctx: context.TODO(),
+				jobStarterPayload: job.StartOptions{
+					User:        "fake-user",
+					AccessKey:   "fake-access-key",
+					BrowserName: "fake-browser-name",
+					Name:        "fake-test-name",
+					Framework:   "fake-framework",
+					Build:       "fake-buildname",
+					Tags:        nil,
+				},
+			},
+			want:    "fake-job-id",
+			wantErr: nil,
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				resp := sessionStartResponse{
+					SessionID: "fake-job-id",
+				}
+				respondJSON(w, resp, 201)
+			},
+		},
+		{
+			name: "Non 2xx status code",
+			fields: fields{
+				HTTPClient: mockServer.Client(),
+				URL:        mockServer.URL,
+			},
+			args: args{
+				ctx:               context.TODO(),
+				jobStarterPayload: job.StartOptions{},
+			},
+			want:    "",
+			wantErr: fmt.Errorf("job start failed; unexpected response code:'300', msg:''"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(300)
+			},
+		},
+		{
+			name: "Unknown error",
+			fields: fields{
+				HTTPClient: mockServer.Client(),
+				URL:        mockServer.URL,
+			},
+			args: args{
+				ctx:               context.TODO(),
+				jobStarterPayload: job.StartOptions{},
+			},
+			want:    "",
+			wantErr: fmt.Errorf("job start failed; unexpected response code:'500', msg:'Internal server error'"),
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(500)
+				_, err := w.Write([]byte("Internal server error"))
+				if err != nil {
+					t.Errorf("failed to write response: %v", err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				HTTPClient: tt.fields.HTTPClient,
+				URL:        tt.fields.URL,
+			}
+
+			rec.Record(tt.serverFunc)
+
+			got, _, err := c.StartJob(tt.args.ctx, tt.args.jobStarterPayload)
+			if (err != nil) && !reflect.DeepEqual(err, tt.wantErr) {
+				t.Errorf("StartJob() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StartJob() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func respondJSON(w http.ResponseWriter, v interface{}, httpStatus int) {
+	w.WriteHeader(httpStatus)
+	b, err := json.Marshal(v)
+
+	if err != nil {
+		log.Err(err).Msg("failed to marshal job json")
+		http.Error(w, "failed to marshal job json", http.StatusInternalServerError)
+		return
+	}
+
+	if _, err := w.Write(b); err != nil {
+		log.Err(err).Msg("Failed to write out response")
+	}
+}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Optimize the job start route by skipping test-composer and calling the appropriate services directly.

I kept the changes for this PR as minimal as possible by moving some of the logic from test-composer to saucectl.
Certain places are in need of some TLC and refactor, but those will follow via separate PRs.
