### PR TITLE
[DEVX-1682] Don't log warnings when sauceignore is intentionally omitted

### DIFF
--- a/internal/sauceignore/matcher.go
+++ b/internal/sauceignore/matcher.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
@@ -14,8 +13,11 @@ const commentPrefix = "#"
 
 // patternsFromFile reads .sauceignore file and creates ignore patters if .sauceignore file is exists.
 func patternsFromFile(path string) ([]Pattern, error) {
-	fPath := filepath.Join(path)
-	f, err := os.Open(fPath)
+	if path == "" {
+		return []Pattern{}, nil
+	}
+
+	f, err := os.Open(path)
 	if err != nil {
 		// In case .sauceignore file doesn't exists.
 		if os.IsNotExist(err) {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Puppeteer replay doesn't rely on the sauceignore file, since project folders are never packaged up anyway, only the recordings are (kinda like espresso/xcuitest, where only the app/testApp files are uploaded).
The current implementation issues a warning that a sauceignore file is missing, despite explicitly omitting it.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->