### PR TITLE
Ignore in progress jobs when computing pass/fail for results

### DIFF
--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -119,7 +119,9 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 	for i := 0; i < expected; i++ {
 		res := <-results
 		// in case one of test suites not passed
-		if !res.job.Passed {
+		// ignore jobs that are still in progress (i.e. async execution or client timeout)
+		// since their status is unknown
+		if job.Done(res.job.Status) && !res.job.Passed {
 			passed = false
 		}
 		completed++


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Running in async mode caused the process to have a non-zero exit code. Non-zero exit code should be reserved for errors and actual failed results.

Fixes #554 

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

I'm not totally sure this is the correct logic. Should timed out jobs be considered non-passing and force a non-zero exit code?