### PR TITLE
Selective Node Module Inclusion

### DIFF
--- a/api/v1alpha/generated/saucectl.schema.json
+++ b/api/v1alpha/generated/saucectl.schema.json
@@ -126,6 +126,10 @@
                     "description": "Specifies any npm packages that are required to run tests.",
                     "type": "object"
                   },
+                  "dependencies": {
+                    "description": "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.",
+                    "type": "array"
+                  },
                   "registry": {
                     "description": "Override the default and official NPM registry URL with a custom one.",
                     "type": "string"

--- a/api/v1alpha/subschema/npm.schema.json
+++ b/api/v1alpha/subschema/npm.schema.json
@@ -13,6 +13,10 @@
           "description": "Specifies any npm packages that are required to run tests.",
           "type": "object"
         },
+        "dependencies": {
+          "description": "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.",
+          "type": "array"
+        },
         "registry": {
           "description": "Override the default and official NPM registry URL with a custom one.",
           "type": "string"

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -81,6 +81,7 @@ func NewCypressCmd() *cobra.Command {
 	// NPM
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
+	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
 	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https")
 
 	return cmd
@@ -187,6 +188,7 @@ func runCypressInSauce(p cypress.Project, regio region.Region) (int, error) {
 			Async:                  gFlags.async,
 			FailFast:               gFlags.failFast,
 			MetadataSearchStrategy: framework.NewSearchStrategy(p.Cypress.Version, p.RootDir),
+			NPMDependencies:        p.Npm.Dependencies,
 		},
 	}
 

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -198,6 +198,7 @@ func runPlaywrightInSauce(p playwright.Project, regio region.Region) (int, error
 			Async:                  gFlags.async,
 			FailFast:               gFlags.failFast,
 			MetadataSearchStrategy: framework.NewSearchStrategy(p.Playwright.Version, p.RootDir),
+			NPMDependencies:        p.Npm.Dependencies,
 		},
 	}
 

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -88,6 +88,7 @@ func NewPlaywrightCmd() *cobra.Command {
 	// NPM
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
+	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
 	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https")
 
 	// Deprecated flags

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -108,6 +108,7 @@ func NewTestcafeCmd() *cobra.Command {
 	// NPM
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
+	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
 	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https")
 
 	// Simulators
@@ -214,6 +215,7 @@ func runTestcafeInCloud(p testcafe.Project, regio region.Region) (int, error) {
 			Async:                  gFlags.async,
 			FailFast:               gFlags.failFast,
 			MetadataSearchStrategy: framework.NewSearchStrategy(p.Testcafe.Version, p.RootDir),
+			NPMDependencies:        p.Npm.Dependencies,
 		},
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,9 +146,10 @@ type Docker struct {
 
 // Npm represents the npm settings
 type Npm struct {
-	Registry  string            `yaml:"registry,omitempty" json:"registry,omitempty"`
-	Packages  map[string]string `yaml:"packages,omitempty" json:"packages"`
-	StrictSSL bool              `yaml:"strictSSL,omitempty" json:"strictSSL"`
+	Registry     string            `yaml:"registry,omitempty" json:"registry,omitempty"`
+	Packages     map[string]string `yaml:"packages,omitempty" json:"packages"`
+	Dependencies []string          `yaml:"dependencies,omitempty" json:"dependencies"`
+	StrictSSL    bool              `yaml:"strictSSL,omitempty" json:"strictSSL"`
 }
 
 // Defaults represents default suite settings.

--- a/internal/node/package.go
+++ b/internal/node/package.go
@@ -2,12 +2,15 @@ package node
 
 import (
 	"encoding/json"
+	"github.com/rs/zerolog/log"
 	"os"
+	"path/filepath"
 )
 
 type Package struct {
-	Dependencies    map[string]string `json:"dependencies,omitempty"`
-	DevDependencies map[string]string `json:"devDependencies,omitempty"`
+	Dependencies     map[string]string `json:"dependencies,omitempty"`
+	DevDependencies  map[string]string `json:"devDependencies,omitempty"`
+	PeerDependencies map[string]string `json:"peerDependencies,omitempty"`
 }
 
 func PackageFromFile(filename string) (Package, error) {
@@ -15,9 +18,76 @@ func PackageFromFile(filename string) (Package, error) {
 
 	fd, err := os.Open(filename)
 	if err != nil {
-		return p, err 
+		return p, err
 	}
 
 	err = json.NewDecoder(fd).Decode(&p)
 	return p, err
+}
+
+// Requirements returns a list of all root dependencies for the given packages, including themselves.
+func Requirements(root string, pkgs ...string) []string {
+	rootDeps := make(map[string]struct{})
+
+	log.Info().Msgf("Getting requirements for %s", pkgs)
+	for _, pkg := range pkgs {
+		requirements(rootDeps, root, pkg, true)
+	}
+
+	var deps []string
+	for k := range rootDeps {
+		deps = append(deps, k)
+	}
+	return deps
+}
+
+// requirements recursively traverses the dependency tree for the given package, adding all root (shared) dependencies
+// to the rootDeps map.
+func requirements(rootDeps map[string]struct{}, root, pkg string, rootDep bool) {
+	if _, ok := rootDeps[pkg]; ok {
+		return
+	}
+
+	log.Debug().Msgf("Getting requirements for %s", pkg)
+	p, err := PackageFromFile(filepath.Join(root, pkg, "package.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			// likely an unmet peer dependency, not necessarily an issue
+			log.Debug().Msgf("Unmet requirement %s", pkg)
+			return
+		}
+		log.Err(err).Msgf("Failed to get requirements for %s", pkg)
+		return
+	}
+	if rootDep {
+		rootDeps[pkg] = struct{}{}
+	}
+
+	var requiredDeps []string
+	for k := range p.Dependencies {
+		requiredDeps = append(requiredDeps, k)
+	}
+	for k := range p.PeerDependencies {
+		requiredDeps = append(requiredDeps, k)
+	}
+
+	for _, v := range requiredDeps {
+		// check for nested dependencies (deps that conflict with requirements, hence embedded in a nested node_modules)
+		submodule := filepath.Join(pkg, "node_modules", v)
+		_, err = os.Stat(filepath.Join(root, submodule))
+		if os.IsNotExist(err) {
+			// doesn't exist, so must be a root dependency
+			requirements(rootDeps, root, v, true)
+			continue
+		}
+
+		if err != nil {
+			log.Err(err).Msgf("Failed to inspect dependencies for %s", pkg)
+			continue
+		}
+
+		// Dependency exists in a nested node_modules. We don't need to add it to the list of requirements, but we do
+		// need to recurse into the node_modules to get its dependencies, since those might refer to other root deps.
+		requirements(rootDeps, root, submodule, false)
+	}
 }

--- a/internal/node/package.go
+++ b/internal/node/package.go
@@ -29,7 +29,7 @@ func PackageFromFile(filename string) (Package, error) {
 func Requirements(root string, pkgs ...string) []string {
 	rootDeps := make(map[string]struct{})
 
-	log.Info().Msgf("Getting requirements for %s", pkgs)
+	log.Info().Msgf("Getting requirements for npm dependencies %s", pkgs)
 	for _, pkg := range pkgs {
 		requirements(rootDeps, root, pkg, true)
 	}

--- a/internal/node/package.go
+++ b/internal/node/package.go
@@ -13,6 +13,23 @@ type Package struct {
 	PeerDependencies map[string]string `json:"peerDependencies,omitempty"`
 }
 
+// permExcludes is a list of packages we never want to resolve, because they are provided by Sauce Labs.
+var permExcludes = []string{
+	"cypress",
+	"playwright",
+	"playwright-core",
+	"testcafe",
+}
+
+func isPkgExcluded(pkg string) bool {
+	for _, p := range permExcludes {
+		if p == pkg {
+			return true
+		}
+	}
+	return false
+}
+
 func PackageFromFile(filename string) (Package, error) {
 	var p Package
 
@@ -45,6 +62,11 @@ func Requirements(root string, pkgs ...string) []string {
 // to the rootDeps map.
 func requirements(rootDeps map[string]struct{}, root, pkg string, rootDep bool) {
 	if _, ok := rootDeps[pkg]; ok {
+		return
+	}
+
+	if isPkgExcluded(pkg) {
+		log.Info().Msgf("Skipping dependency %s, as it's provided by Sauce Labs", pkg)
 		return
 	}
 

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -840,6 +840,7 @@ func (r *CloudRunner) getFileMatcher(projectFolder, sauceignoreFile string) (sau
 		if err == nil && len(r.NPMDependencies) > 0 {
 			log.Info().Msg("Picking up select dependencies from node_modules")
 			patterns, _ := sauceignore.PatternsFromFile(sauceignoreFile)
+
 			// by default, ignore everything under node_modules
 			patterns = append(patterns, sauceignore.NewPattern("/node_modules/*"))
 

--- a/internal/sauceignore/matcher.go
+++ b/internal/sauceignore/matcher.go
@@ -11,8 +11,8 @@ import (
 
 const commentPrefix = "#"
 
-// patternsFromFile reads .sauceignore file and creates ignore patters if .sauceignore file is exists.
-func patternsFromFile(path string) ([]Pattern, error) {
+// PatternsFromFile reads .sauceignore file and creates ignore patters if .sauceignore file is exists.
+func PatternsFromFile(path string) ([]Pattern, error) {
 	if path == "" {
 		return []Pattern{}, nil
 	}
@@ -81,7 +81,7 @@ func NewMatcher(ps []Pattern) Matcher {
 
 // NewMatcherFromFile constructs a new matcher from file.
 func NewMatcherFromFile(path string) (Matcher, error) {
-	ps, err := patternsFromFile(path)
+	ps, err := PatternsFromFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sauceignore/matcher_test.go
+++ b/internal/sauceignore/matcher_test.go
@@ -48,7 +48,7 @@ func TestPatternsFromFile(t *testing.T) {
 
 	for _, tc := range testsCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotPatters, err := patternsFromFile(tc.path)
+			gotPatters, err := PatternsFromFile(tc.path)
 			assert.Equal(t, err, tc.expectedErr)
 			assert.Equal(t, len(gotPatters), len(tc.expectedPatters))
 		})


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Allow the user to specify local npm dependencies that ought to be included in the payload. The dependencies must already be present in the `node_modules` directory. The user only needs to specify the "main" dependencies that are required to run their tests. `saucectl` will automatically determine all of the transitive dependencies.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
