### PR TITLE
[DEVX-1761] Warn if project archive is unusually large

### DIFF
--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -36,7 +36,8 @@ func New(f io.Writer, matcher sauceignore.Matcher) (Writer, error) {
 	return w, nil
 }
 
-// Add adds the file at src to the destination dst in the archive.
+// Add adds the file at src to the destination dst in the archive and returns a count of
+// the files added to the archive.
 func (w *Writer) Add(src, dst string) (int, error) {
 	finfo, err := os.Stat(src)
 	if err != nil {

--- a/internal/archive/zip/zip_test.go
+++ b/internal/archive/zip/zip_test.go
@@ -45,6 +45,7 @@ func TestZipper_Add(t *testing.T) {
 		args      args
 		wantErr   bool
 		wantFiles []string
+		wantCount int
 	}{
 		{
 			name:      "zip it up",
@@ -52,6 +53,7 @@ func TestZipper_Add(t *testing.T) {
 			args:      args{dir.Path(), "", out.Name()},
 			wantErr:   false,
 			wantFiles: []string{"/screenshot1.png", "/some.foo.js", "/some.other.bar.js"},
+			wantCount: 3,
 		},
 		{
 			name: "zip some.other.bar.js and skip some.foo.js file and screenshots folder",
@@ -64,6 +66,7 @@ func TestZipper_Add(t *testing.T) {
 			args:      args{dir.Path(), "", sauceignoreOut.Name()},
 			wantErr:   false,
 			wantFiles: []string{"/some.other.bar.js"},
+			wantCount: 1,
 		},
 	}
 	for _, tt := range tests {
@@ -72,7 +75,8 @@ func TestZipper_Add(t *testing.T) {
 				W: tt.fields.W,
 				M: tt.fields.M,
 			}
-			if err := z.Add(tt.args.src, tt.args.dst); (err != nil) != tt.wantErr {
+			fileCount, err := z.Add(tt.args.src, tt.args.dst)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("Add() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if err := z.Close(); err != nil {
@@ -89,6 +93,10 @@ func TestZipper_Add(t *testing.T) {
 					t.Errorf("got %v, want %v", f.Name, tt.wantFiles[i])
 				}
 			}
+			if tt.wantCount != fileCount {
+				t.Errorf("got %v, want %v", fileCount, tt.wantCount)
+			}
+
 		})
 	}
 }

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -76,9 +76,8 @@ or peruse some of our example repositories:
   - https://github.com/saucelabs/saucectl-puppeteer-example
   - https://github.com/saucelabs/saucectl-testcafe-example`
 
-// UploadingTimeoutSuggestion is a recommendation to add unnecessary files to .sauceignore in the case that the bundled file is too big.
-const UploadingTimeoutSuggestion = `We *highly* recommend using .sauceignore file so that saucectl does not
-create big archives with unnecessary files.
+// SauceIgnoreSuggestion is a recommendation to add unnecessary files to .sauceignore in the case that the bundled file is too big.
+const SauceIgnoreSuggestion = `We *highly* recommend using .sauceignore file so that saucectl does not create big archives with unnecessary files.
 
 For more information, visit https://docs.saucelabs.com/dev/cli/saucectl/usage/use-cases/#excluding-files-from-the-bundle
 
@@ -87,6 +86,16 @@ or peruse some of our example repositories:
   - https://github.com/saucelabs/saucectl-playwright-example
   - https://github.com/saucelabs/saucectl-puppeteer-example
   - https://github.com/saucelabs/saucectl-testcafe-example`
+
+// ArchiveFileCountWarning is a warning to the user that their project archive may be unintentionally large.
+const ArchiveFileCountWarning = "The project archive is unusually large which can cause delays in your test execution."
+
+// LogArchiveSizeWarning prints out a warning about the project archive size along with
+// suggestions on how to fix it.
+func LogArchiveSizeWarning() {
+	warning := color.New(color.FgYellow)
+	fmt.Printf("\n%s\n\n%s\n\n", warning.Sprint(ArchiveFileCountWarning), SauceIgnoreSuggestion)
+}
 
 // LogSauceIgnoreNotExist prints out a formatted and color coded version of SauceIgnoreNotExist.
 func LogSauceIgnoreNotExist() {
@@ -109,7 +118,7 @@ func LogUploadTimeout() {
 
 // LogUploadTimeoutSuggestion prints out adding unnecessary files to .sauceignore
 func LogUploadTimeoutSuggestion() {
-	fmt.Printf("%s\n\n", UploadingTimeoutSuggestion)
+	fmt.Printf("%s\n\n", SauceIgnoreSuggestion)
 }
 
 // LogRootDirWarning prints out a warning message regarding the lack of an explicit rootDir configuration.

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -430,14 +430,19 @@ func (r *CloudRunner) archiveFolder(project interface{}, tempDir string, project
 		return "", err
 	}
 
+	totalFileCount := 0
 	for _, child := range folderContent {
-		if err := z.Add(filepath.Join(projectFolder, child.Name()), ""); err != nil {
+		fileCount, err := z.Add(filepath.Join(projectFolder, child.Name()), "")
+		if err != nil {
 			return "", err
 		}
+		totalFileCount += fileCount
 	}
-	if err := z.Add(rcPath, ""); err != nil {
+	fileCount, err := z.Add(rcPath, "")
+	if err != nil {
 		return "", err
 	}
+	totalFileCount += fileCount
 
 	err = z.Close()
 	if err != nil {
@@ -449,7 +454,7 @@ func (r *CloudRunner) archiveFolder(project interface{}, tempDir string, project
 		return "", err
 	}
 
-	log.Info().Dur("durationMs", time.Since(start)).Int64("size", f.Size()).Msg("Project archived.")
+	log.Info().Dur("durationMs", time.Since(start)).Int64("size", f.Size()).Int("fileCount", totalFileCount).Msg("Project archived.")
 
 	return zipName, nil
 }
@@ -475,16 +480,22 @@ func (r *CloudRunner) archiveFiles(project interface{}, tempDir string, files []
 	if err := jsonio.WriteFile(rcPath, project); err != nil {
 		return "", err
 	}
+
+	totalFileCount := 0
 	log.Debug().Str("name", rcPath).Msg("Adding to archive")
-	if err := z.Add(rcPath, ""); err != nil {
+	fileCount, err := z.Add(rcPath, "")
+	if err != nil {
 		return "", err
 	}
+	totalFileCount += fileCount
 
 	for _, f := range files {
 		log.Debug().Str("name", f).Msg("Adding to archive")
-		if err := z.Add(f, filepath.Dir(f)); err != nil {
+		fileCount, err := z.Add(f, filepath.Dir(f))
+		if err != nil {
 			return "", err
 		}
+		totalFileCount += fileCount
 	}
 
 	err = z.Close()
@@ -497,7 +508,7 @@ func (r *CloudRunner) archiveFiles(project interface{}, tempDir string, files []
 		return "", err
 	}
 
-	log.Info().Dur("durationMs", time.Since(start)).Int64("size", f.Size()).Msg("Project archived.")
+	log.Info().Dur("durationMs", time.Since(start)).Int64("size", f.Size()).Int("fileCount", totalFileCount).Msg("Project archived.")
 
 	return zipName, nil
 }

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -83,6 +83,12 @@ const BaseFilepathLength = 53
 // MaxFilepathLength represents the maximum path length acceptable.
 const MaxFilepathLength = 255
 
+// ArchiveFileCountSoftLimit is the threshold count of files added to the archive
+// before a warning is printed.
+// The value here (2^15) is somewhat arbitrary. In testing, ~32K files in the archive
+// resulted in about 30s for download and extraction.
+const ArchiveFileCountSoftLimit = 32768
+
 func (r *CloudRunner) createWorkerPool(ccy int, maxRetries int) (chan job.StartOptions, chan result, error) {
 	jobOpts := make(chan job.StartOptions, maxRetries+1)
 	results := make(chan result, ccy)
@@ -455,6 +461,9 @@ func (r *CloudRunner) archiveFolder(project interface{}, tempDir string, project
 	}
 
 	log.Info().Dur("durationMs", time.Since(start)).Int64("size", f.Size()).Int("fileCount", totalFileCount).Msg("Project archived.")
+	if (totalFileCount >= ArchiveFileCountSoftLimit) {
+		msg.LogArchiveSizeWarning()
+	}
 
 	return zipName, nil
 }
@@ -509,6 +518,9 @@ func (r *CloudRunner) archiveFiles(project interface{}, tempDir string, files []
 	}
 
 	log.Info().Dur("durationMs", time.Since(start)).Int64("size", f.Size()).Int("fileCount", totalFileCount).Msg("Project archived.")
+	if (totalFileCount >= ArchiveFileCountSoftLimit) {
+		msg.LogArchiveSizeWarning()
+	}
 
 	return zipName, nil
 }

--- a/internal/saucecloud/xcuitest.go
+++ b/internal/saucecloud/xcuitest.go
@@ -183,7 +183,7 @@ func archiveAppToIpa(appPath string) (string, error) {
 	}
 	arch, _ := zip.New(tmpFile, sauceignore.NewMatcher([]sauceignore.Pattern{}))
 	defer arch.Close()
-	err = arch.Add(appPath, "Payload/")
+	_, err = arch.Add(appPath, "Payload/")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Print a warning if the project archive has more than 32768 files. The number of files is arbitrary, but corresponds to about 30s of additional test setup time (15s download, 15s extraction).

```🍖 ../saucectl/saucectl run --select-suite "Chrome using global mode setting"
Running version 0.0.0+unknown
11:10:57 WRN A new version of saucectl is available (v0.100.0)
11:10:57 INF Running Cypress in Sauce Labs

                                        (.
                                       #.
                                       #.
                           .####################
                         #####////////*******/######
                       .##///////*****************###/
                      ,###////*********************###
                      ####//***********************####
                       ###/************************###
                        ######********************###. ##
                           (########################  ##     ##
                                   ,######(#*         ##*   (##
                               /############*          #####
                           (########(  #########(    ###
                         .#######,    */  ############
                      ,##########  %#### , ########*
                    *### .#######/  ##  / ########
                   ###   .###########//###########
               ######     ########################
             (#(    *#(     #######.    (#######
                    ##,    /########    ########
                           *########    ########

   _____        _    _  _____ ______    _____ _      ____  _    _ _____
  / ____|  /\  | |  | |/ ____|  ____|  / ____| |    / __ \| |  | |  __ \
 | (___   /  \ | |  | | |    | |__    | |    | |   | |  | | |  | | |  | |
  \___ \ / /\ \| |  | | |    |  __|   | |    | |   | |  | | |  | | |  | |
  ____) / ____ \ |__| | |____| |____  | |____| |___| |__| | |__| | |__| |
 |_____/_/    \_\____/ \_____|______|  \_____|______\____/ \____/|_____/

11:11:14 INF Project archived. durationMs=15817 fileCount=35784 size=83659202

The project archive is unusually large which can cause delays in your test execution.

We *highly* recommend using .sauceignore file so that saucectl does not create big archives with unnecessary files.

For more information, visit https://docs.saucelabs.com/dev/cli/saucectl/usage/use-cases/#excluding-files-from-the-bundle

or peruse some of our example repositories:
  - https://github.com/saucelabs/saucectl-cypress-example
  - https://github.com/saucelabs/saucectl-playwright-example
  - https://github.com/saucelabs/saucectl-puppeteer-example
  - https://github.com/saucelabs/saucectl-testcafe-example

11:11:14 INF Checking if /var/folders/dc/vm6rxrr17mv86r47v6h1n6sc0000gq/T/saucectl-app-payload1781652041/app.zip has already been uploaded previously
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->