### PR TITLE
Mute Segment Logs

### DIFF
--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -12,10 +12,21 @@ import (
 	"gopkg.in/segmentio/analytics-go.v3"
 )
 
-// Tracker is the segment implemention for usage.Tracker.
+// Tracker is the segment implementation for usage.Tracker.
 type Tracker struct {
 	client  analytics.Client
 	Enabled bool
+}
+
+// debugLogger is a logger that redirects logs to the debug log.
+type debugLogger struct{}
+
+func (l debugLogger) Logf(format string, args ...interface{}) {
+	log.Debug().Msgf(format, args...)
+}
+
+func (l debugLogger) Errorf(format string, args ...interface{}) {
+	log.Debug().Msgf(format, args...)
 }
 
 // New creates a new instance of Tracker.
@@ -31,6 +42,7 @@ func New(enabled bool) *Tracker {
 				Name: runtime.GOOS + " " + runtime.GOARCH,
 			},
 		},
+		Logger: debugLogger{},
 	})
 	if err != nil {
 		// Usage is not crucial to the execution of saucectl, so proceed without notifying or blocking the user.

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -66,6 +66,7 @@ func (p Properties) SetNPM(npm config.Npm) Properties {
 		pkgs = append(pkgs, k)
 	}
 	p["npm_packages"] = pkgs
+	p["npm_dependencies"] = npm.Dependencies
 
 	return p
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Mute segment logs. At least a bit.

1. Redirect logs to our own logger, so that they follow our format.
2. Reduce all log levels to debug, since they are 99% irrelevant to the user.

Also include an unrelated change to the above: Capture list of npm dependencies.