### PR TITLE
Devx 1744 debug build fetch

### DIFF
--- a/internal/report/buildtable/buildtable.go
+++ b/internal/report/buildtable/buildtable.go
@@ -93,6 +93,7 @@ func (r *Reporter) ArtifactRequirements() []report.ArtifactType {
 func (r *Reporter) buildURLFromJobURL(jobURL string, buildSource build.Source) string {
 	pURL, err := url.Parse(jobURL)
 	if err != nil {
+		log.Debug().Str("jobURL", jobURL).Msg("Failed to parse job url")
 		return ""
 	}
 	p := strings.Split(pURL.Path, "/")

--- a/internal/report/buildtable/buildtable.go
+++ b/internal/report/buildtable/buildtable.go
@@ -93,7 +93,7 @@ func (r *Reporter) ArtifactRequirements() []report.ArtifactType {
 func (r *Reporter) buildURLFromJobURL(jobURL string, buildSource build.Source) string {
 	pURL, err := url.Parse(jobURL)
 	if err != nil {
-		log.Debug().Str("jobURL", jobURL).Msg("Failed to parse job url")
+		log.Debug().Err(err).Msgf("Failed to parse job url (%s)", jobURL)
 		return ""
 	}
 	p := strings.Split(pURL.Path, "/")
@@ -101,7 +101,7 @@ func (r *Reporter) buildURLFromJobURL(jobURL string, buildSource build.Source) s
 
 	bID, err := r.Service.GetBuildID(context.Background(), jID, buildSource)
 	if err != nil {
-		log.Debug().Err(err).Msg(fmt.Sprintf("Failed to retrieve build url for job %s", jID))
+		log.Debug().Err(err).Msgf("Failed to retrieve build url for job %s", jID)
 		return ""
 	}
 

--- a/internal/report/buildtable/buildtable.go
+++ b/internal/report/buildtable/buildtable.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/build"
 	"github.com/saucelabs/saucectl/internal/report"
 	"github.com/saucelabs/saucectl/internal/report/table"
@@ -99,6 +100,7 @@ func (r *Reporter) buildURLFromJobURL(jobURL string, buildSource build.Source) s
 
 	bID, err := r.Service.GetBuildID(context.Background(), jID, buildSource)
 	if err != nil {
+		log.Debug().Err(err).Msg(fmt.Sprintf("Failed to retrieve build url for job %s", jID))
 		return ""
 	}
 


### PR DESCRIPTION
* Add debug logs when saucectl fails to fetch a build id for the finished jobs. Sometimes fetching build metadata fails so add some optionally logging to assist debugging efforts.