### PR TITLE
Use a buffered reader when reading files to add to zip archive

### DIFF
--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -62,8 +62,7 @@ func (w *Writer) Add(src, dst string) (int, error) {
 		}
 		defer f.Close()
 
-		reader := bufio.NewReader(f)
-		_, err = reader.WriteTo(w)
+		_, err = io.Copy(w, f)
 		return 1, err
 	}
 

--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -2,7 +2,6 @@ package zip
 
 import (
 	"archive/zip"
-	"bufio"
 	"io"
 	"os"
 	"path"

--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -2,6 +2,7 @@ package zip
 
 import (
 	"archive/zip"
+	"bufio"
 	"io"
 	"os"
 	"path"
@@ -55,11 +56,14 @@ func (w *Writer) Add(src, dst string) (int, error) {
 		if err != nil {
 			return 0, err
 		}
-		b, err := os.ReadFile(src)
+		f, err := os.Open(src)
 		if err != nil {
 			return 0, err
 		}
-		_, err = w.Write(b)
+		defer f.Close()
+
+		reader := bufio.NewReader(f)
+		_, err = reader.WriteTo(w)
 		return 1, err
 	}
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
When archiving the project, we read files fully into memory before writing to the zip archive. This results in linear memory usage in the worst case and might result in OOM errors in some situations where there are very large files to archive.

Buffering the read improves the worst case behaviour to be closer to constant memory usage.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->