### PR TITLE
Ensure that only supported platforms can be run

### DIFF
--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"regexp"
+	"strings"
 
 	"github.com/saucelabs/saucectl/internal/msg"
 )
@@ -63,4 +64,25 @@ func GitReleaseSegments(m *Metadata) (org, repo, tag string, err error) {
 	tagIndex := r.SubexpIndex("tag")
 
 	return matches[orgIndex], matches[repoIndex], matches[tagIndex], nil
+}
+
+// HasPlatform returns true if the provided Metadata has a matching platform.
+func HasPlatform(m Metadata, platform string) bool {
+	for _, p := range m.Platforms {
+		if strings.ToLower(platform) == strings.ToLower(p.PlatformName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// PlatformNames extracts platform names from the given platforms and returns them.
+func PlatformNames(platforms []Platform) []string {
+	var pp []string
+	for _, platform := range platforms {
+		pp = append(pp, platform.PlatformName)
+	}
+
+	return pp
 }

--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -69,7 +69,7 @@ func GitReleaseSegments(m *Metadata) (org, repo, tag string, err error) {
 // HasPlatform returns true if the provided Metadata has a matching platform.
 func HasPlatform(m Metadata, platform string) bool {
 	for _, p := range m.Platforms {
-		if strings.ToLower(platform) == strings.ToLower(p.PlatformName) {
+		if strings.EqualFold(platform, p.PlatformName) {
 			return true
 		}
 	}

--- a/internal/framework/framework_test.go
+++ b/internal/framework/framework_test.go
@@ -1,6 +1,9 @@
 package framework
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestGitReleaseSegments(t *testing.T) {
 	type args struct {
@@ -58,6 +61,90 @@ func TestGitReleaseSegments(t *testing.T) {
 			}
 			if gotTag != tt.wantTag {
 				t.Errorf("GitReleaseSegments() gotTag = %v, want %v", gotTag, tt.wantTag)
+			}
+		})
+	}
+}
+
+func TestHasPlatform(t *testing.T) {
+	type args struct {
+		m        Metadata
+		platform string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "exact match",
+			args: args{
+				m: Metadata{
+					FrameworkName: "playwright",
+					Platforms:     []Platform{{PlatformName: "Windows 11"}},
+				},
+				platform: "Windows 11",
+			},
+			want: true,
+		},
+		{
+			name: "case mismatch",
+			args: args{
+				m: Metadata{
+					FrameworkName: "playwright",
+					Platforms:     []Platform{{PlatformName: "Windows 11"}},
+				},
+				platform: "windows 11",
+			},
+			want: true,
+		},
+		{
+			name: "does not have platform",
+			args: args{
+				m: Metadata{
+					FrameworkName: "playwright",
+					Platforms:     []Platform{{PlatformName: "Windows 11"}},
+				},
+				platform: "Windows Me",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasPlatform(tt.args.m, tt.args.platform); got != tt.want {
+				t.Errorf("HasPlatform() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlatformNames(t *testing.T) {
+	type args struct {
+		platforms []Platform
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "happy path",
+			args: args{[]Platform{
+				{
+					PlatformName: "Windows 11",
+				},
+				{
+					PlatformName: "macOS 12",
+				},
+			}},
+			want: []string{"Windows 11", "macOS 12"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PlatformNames(tt.args.platforms); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PlatformNames() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/framework/search_test.go
+++ b/internal/framework/search_test.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"fmt"
 	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 	"github.com/saucelabs/saucectl/internal/node"
@@ -59,21 +60,17 @@ func TestFrameworkFind_ExactStrategy(t *testing.T) {
 			"invalidSearchOptions",
 			"version 1.0 for buster is not available",
 			nil,
-			&MockMetadataService{
-				MockSearch: func(context.Context, SearchOptions) (Metadata, error) {
-					return Metadata{}, errors.Errorf("Bad Request: unsupported version")
-				},
-			},
+			&MockMetadataService{},
 			"buster",
 			"1.0",
 		},
 		{
 			"unknownFrameworkError",
-			"framework availability unknown: unexpected error present",
+			"unable to determine available versions for framework: framework not supported",
 			nil,
 			&MockMetadataService{
-				MockSearch: func(context.Context, SearchOptions) (Metadata, error) {
-					return Metadata{}, errors.Errorf("unexpected error present")
+				MockVersions: func(ctx context.Context, frameworkName string) ([]Metadata, error) {
+					return []Metadata{}, fmt.Errorf("framework not supported")
 				},
 			},
 			"buster",
@@ -84,8 +81,8 @@ func TestFrameworkFind_ExactStrategy(t *testing.T) {
 			"",
 			nil,
 			&MockMetadataService{
-				MockSearch: func(context.Context, SearchOptions) (Metadata, error) {
-					return Metadata{}, nil
+				MockVersions: func(ctx context.Context, frameworkName string) ([]Metadata, error) {
+					return []Metadata{{FrameworkName: "buster-final", FrameworkVersion: "3.0"}}, nil
 				},
 			},
 			"buster-final",

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -151,3 +151,13 @@ func SuiteSplitNoMatch(suiteName, path string, pattern []string) {
 	color.Red(fmt.Sprintf("\nNo matching files found for suite '%s'\n", suiteName))
 	fmt.Printf("saucectl looked for %s in %s\n\n", strings.Join(pattern, ","), path)
 }
+
+func LogUnsupportedPlatform(platform string, supported []string) {
+	fmt.Printf("\nThe selected platform %s is not available.\n\n", platform)
+	fmt.Println("Available platforms are:")
+	var msg string
+	for _, p := range supported {
+		msg += fmt.Sprintf(" - %s\n", p)
+	}
+	fmt.Println(msg)
+}

--- a/internal/saucecloud/cypress.go
+++ b/internal/saucecloud/cypress.go
@@ -2,7 +2,10 @@ package saucecloud
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/framework"
+	"github.com/saucelabs/saucectl/internal/msg"
 	"strings"
 
 	"github.com/saucelabs/saucectl/internal/cypress"
@@ -35,6 +38,13 @@ func (r *CypressRunner) RunProject() (int, error) {
 		fmt.Print(deprecationMessage)
 	}
 
+	for _, s := range r.Project.Suites {
+		if s.PlatformName != "" && !framework.HasPlatform(m, s.PlatformName) {
+			msg.LogUnsupportedPlatform(s.PlatformName, framework.PlatformNames(m.Platforms))
+			return 1, errors.New("unsupported platform")
+		}
+	}
+
 	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner); err != nil {
 		return 1, err
 	}
@@ -63,7 +73,7 @@ func (r *CypressRunner) RunProject() (int, error) {
 }
 
 func (r *CypressRunner) getSuiteNames() string {
-	names := []string{}
+	var names []string
 	for _, s := range r.Project.Suites {
 		names = append(names, s.Name)
 	}

--- a/internal/saucecloud/cypress_test.go
+++ b/internal/saucecloud/cypress_test.go
@@ -205,12 +205,11 @@ func TestRunProject(t *testing.T) {
 	}
 
 	mdService := &mocks.FakeFrameworkInfoReader{
-		SearchFn: func(ctx context.Context, opts framework.SearchOptions) (framework.Metadata, error) {
-			return framework.Metadata{
+		VersionsFn: func(ctx context.Context, frameworkName string) ([]framework.Metadata, error) {
+			return []framework.Metadata{{
 				FrameworkName:    "cypress",
 				FrameworkVersion: "5.6.0",
-				Deprecated:       false,
-			}, nil
+			}}, nil
 		},
 	}
 

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -2,7 +2,10 @@ package saucecloud
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/framework"
+	"github.com/saucelabs/saucectl/internal/msg"
 	"strings"
 
 	"github.com/saucelabs/saucectl/internal/job"
@@ -33,6 +36,13 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 	if m.Deprecated {
 		deprecationMessage = r.deprecationMessage(playwright.Kind, r.Project.Playwright.Version)
 		fmt.Print(deprecationMessage)
+	}
+
+	for _, s := range r.Project.Suites {
+		if s.PlatformName != "" && !framework.HasPlatform(m, s.PlatformName) {
+			msg.LogUnsupportedPlatform(s.PlatformName, framework.PlatformNames(m.Platforms))
+			return 1, errors.New("unsupported platform")
+		}
 	}
 
 	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner); err != nil {

--- a/internal/saucecloud/replay.go
+++ b/internal/saucecloud/replay.go
@@ -2,11 +2,13 @@ package saucecloud
 
 import (
 	"context"
-	"os"
-
+	"errors"
 	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/job"
+	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/puppeteer/replay"
+	"os"
 )
 
 // ReplayRunner represents the Sauce Labs cloud implementation for puppeteer-replay.
@@ -26,6 +28,13 @@ func (r *ReplayRunner) RunProject() (int, error) {
 	}
 	if r.Project.RunnerVersion == "" {
 		r.Project.RunnerVersion = m.CloudRunnerVersion
+	}
+
+	for _, s := range r.Project.Suites {
+		if s.Platform != "" && !framework.HasPlatform(m, s.Platform) {
+			msg.LogUnsupportedPlatform(s.Platform, framework.PlatformNames(m.Platforms))
+			return 1, errors.New("unsupported platform")
+		}
 	}
 
 	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner); err != nil {

--- a/internal/saucecloud/testcafe.go
+++ b/internal/saucecloud/testcafe.go
@@ -2,7 +2,10 @@ package saucecloud
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/framework"
+	"github.com/saucelabs/saucectl/internal/msg"
 	"strings"
 
 	"github.com/saucelabs/saucectl/internal/job"
@@ -33,6 +36,12 @@ func (r *TestcafeRunner) RunProject() (int, error) {
 	if m.Deprecated {
 		deprecationMessage = r.deprecationMessage(testcafe.Kind, r.Project.Testcafe.Version)
 		fmt.Print(deprecationMessage)
+	}
+	for _, s := range r.Project.Suites {
+		if s.PlatformName != "" && !framework.HasPlatform(m, s.PlatformName) {
+			msg.LogUnsupportedPlatform(s.PlatformName, framework.PlatformNames(m.Platforms))
+			return 1, errors.New("unsupported platform")
+		}
 	}
 
 	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner); err != nil {


### PR DESCRIPTION
## Proposed changes
Ensure that only supported platforms can be run. Previously, an edge case existed when targeting a platform that is _generally_ supported for a specific framework but may be unavailable for certain framework versions.

This change introduces a check that is performed on a suite level to verify the availability.

### Impact
It's slightly less lenient when it comes to platform naming. For example, "macos 11.00" vs "mac 11" vs "macos 11" are not treated as aliases, meaning that only one of them (i.e. "macos 11.00") is accepted. This may break previous customer setups that used one of those aliases before.