### PR TITLE
Print out more accurate job errors

### DIFF
--- a/internal/resto/client.go
+++ b/internal/resto/client.go
@@ -31,6 +31,8 @@ var (
 	ErrServerError = errors.New(msg.InternalServerError)
 	// ErrJobNotFound is returned when the requested job was not found.
 	ErrJobNotFound = errors.New(msg.JobNotFound)
+	// ErrAssetNotFound is returned when the requested asset was not found.
+	ErrAssetNotFound = errors.New(msg.AssetNotFound)
 	// ErrTunnelNotFound is returned when the requested tunnel was not found.
 	ErrTunnelNotFound = errors.New(msg.TunnelNotFound)
 )
@@ -344,7 +346,7 @@ func doAssetRequest(httpClient *retryablehttp.Client, request *http.Request) ([]
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, ErrJobNotFound
+		return nil, ErrAssetNotFound
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/resto/client_test.go
+++ b/internal/resto/client_test.go
@@ -376,7 +376,7 @@ func TestClient_GetJobAssetFileContent(t *testing.T) {
 			client:       New(ts.URL, "test", "123", timeout),
 			jobID:        "2",
 			expectedResp: nil,
-			expectedErr:  ErrJobNotFound,
+			expectedErr:  ErrAssetNotFound,
 		},
 		{
 			name:         "get job asset with ID 3",

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -624,7 +624,7 @@ func (r *CloudRunner) logSuite(res result) {
 			Msg(msg)
 	} else {
 		l := log.Error().Str("suite", res.name).Bool("passed", res.job.Passed).Str("url", jobDetailsPage)
-		if res.job.TotalStatus() == job.StateError {
+		if res.job.Error != "" {
 			l.Str("error", res.job.Error)
 			msg = "Suite finished with error."
 		}
@@ -637,6 +637,11 @@ func (r *CloudRunner) logSuite(res result) {
 func (r *CloudRunner) logSuiteConsole(res result) {
 	// To avoid clutter, we don't show the console on job passes.
 	if res.job.Passed && !r.ShowConsoleLog {
+		return
+	}
+
+	// If a job errored (not to be confused with tests failing), there are likely no assets available anyway.
+	if res.job.Error != "" {
 		return
 	}
 

--- a/internal/webdriver/webdriver_test.go
+++ b/internal/webdriver/webdriver_test.go
@@ -92,9 +92,10 @@ func TestClient_StartJob(t *testing.T) {
 				jobStarterPayload: job.StartOptions{},
 			},
 			want:    "",
-			wantErr: fmt.Errorf("job start failed; unexpected response code:'300', msg:''"),
+			wantErr: fmt.Errorf("job start failed (401): go away"),
 			serverFunc: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(300)
+				w.WriteHeader(401)
+				_, _ = w.Write([]byte("go away"))
 			},
 		},
 		{
@@ -108,10 +109,10 @@ func TestClient_StartJob(t *testing.T) {
 				jobStarterPayload: job.StartOptions{},
 			},
 			want:    "",
-			wantErr: fmt.Errorf("job start failed; unexpected response code:'500', msg:'Internal server error'"),
+			wantErr: fmt.Errorf("job start failed (500): internal server error"),
 			serverFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(500)
-				_, err := w.Write([]byte("Internal server error"))
+				_, err := w.Write([]byte("internal server error"))
 				if err != nil {
 					t.Errorf("failed to write response: %v", err)
 				}


### PR DESCRIPTION
## Proposed changes

Print out more accurate job errors by inspecting the `error` field the server returns.

For example, infra errors or other technical failures:
```
14:45:38 INF Project archived. durationMs=2 fileCount=2 size=1358
14:45:38 INF Checking if /var/folders/ck/mccvpn5x4lz6strcwjjmb5000000gn/T/saucectl-app-payload658285873/app.zip has already been uploaded previously
14:45:38 INF Checksum: 512b7260a7b22455f9eaf5d5af62fa8bc1d62809a81d7855171c5e89da09dda2
14:45:39 INF Project uploaded. durationMs=758 storageId=b4dd9e93-ecb8-42ea-970d-7ce1af282f0e
14:45:39 INF Launching workers. concurrency=10
14:45:39 INF Starting suite. region=us-west-1 suite="getting some coffee - recordings/coffee-cart.json"
14:45:45 INF Suite started. browser=googlechrome platform="Windows 10" suite="getting some coffee - recordings/coffee-cart.json" url=https://app.saucelabs.com/tests/edbf7606bd844b03b02de812ce93f974
14:45:49 INF Suites in progress: 1
14:45:59 INF Suites in progress: 1
14:46:00 ERR Suite finished with error. error="No active tunnel found for identifier oi" passed=false suite="getting some coffee - recordings/coffee-cart.json" url=https://app.saucelabs.com/tests/edbf7606bd844b03b02de812ce93f974


  Results:


       Name                                                 Duration    Status    Browser             Platform      Attempts
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  ✖    getting some coffee - recordings/coffee-cart.json         21s    failed    googlechrome 103    Windows 10           1
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  ✖    1 of 1 suites have failed (100%)                          21s

  Build Link: https://app.saucelabs.com/builds/vdc/36ea7e0896853fa0956f5fbb4d1c7c6b
```
