### PR TITLE
Fix npm dependency inclusion rules

### DIFF
--- a/internal/node/package.go
+++ b/internal/node/package.go
@@ -37,6 +37,7 @@ func PackageFromFile(filename string) (Package, error) {
 	if err != nil {
 		return p, err
 	}
+	defer fd.Close()
 
 	err = json.NewDecoder(fd).Decode(&p)
 	return p, err

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -880,9 +880,24 @@ func (r *CloudRunner) getFileMatcher(projectFolder, sauceignoreFile string) (sau
 			reqs := node.Requirements(filepath.Join(projectFolder, "node_modules"), r.NPMDependencies...)
 			log.Info().Msgf("Found a total of %d related npm dependencies", len(reqs))
 			for _, req := range reqs {
+				segments := strings.Split(req, string(os.PathSeparator))
+
+				// Scoped packages, like '@saucelabs/hot-sauce', need special treatment in gitignore due to nested
+				// folders. Gitignore will ignore any subfolder inclusions, if the parent is already excluded.
+				// Since by default we ignore all files under 'node_modules/*', adding an inclusion of only
+				// '@saucelabs/hot-sauce' does not work, because '@saucelabs/` is excluded, which is its parent.
+				// We need to explicitly include the parent folder and exclude all its files by default, which prevents
+				// random packages within the scope to be picked up, unless specifically included.
+				if len(segments) > 1 {
+					for i := 0; i < len(segments)-1; i++ {
+						segment := segments[i]
+						patterns = append(patterns, sauceignore.NewPattern("/node_modules/"+segment+"/*"))
+						patterns = append(patterns, sauceignore.NewPattern("!/node_modules/"+segment))
+					}
+				}
 				patterns = append(patterns, sauceignore.NewPattern("!/node_modules/"+req))
 			}
-			matcher = sauceignore.NewMatcher(patterns)
+			matcher = sauceignore.NewMatcher(sauceignore.Dedupe(patterns))
 		}
 	}
 

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -844,14 +844,14 @@ func (r *CloudRunner) getAvailableVersionsMessage(frameworkName string) string {
 	if err != nil {
 		return ""
 	}
-	msg := fmt.Sprintf("Available versions of %s are:\n", frameworkName)
+	m := fmt.Sprintf("Available versions of %s are:\n", frameworkName)
 	for _, v := range versions {
 		if !v.Deprecated {
-			msg += fmt.Sprintf(" - %s\n", v.FrameworkVersion)
+			m += fmt.Sprintf(" - %s\n", v.FrameworkVersion)
 		}
 	}
-	msg += "\n"
-	return msg
+	m += "\n"
+	return m
 }
 
 func (r *CloudRunner) getFileMatcher(projectFolder, sauceignoreFile string) (sauceignore.Matcher, error) {

--- a/internal/sauceignore/matcher.go
+++ b/internal/sauceignore/matcher.go
@@ -88,3 +88,16 @@ func NewMatcherFromFile(path string) (Matcher, error) {
 
 	return NewMatcher(ps), nil
 }
+
+// Dedupe takes a list of patterns and returns them back sans any duplicates.
+func Dedupe(patterns []Pattern) []Pattern {
+	hash := make(map[Pattern]struct{})
+	var list []Pattern
+	for _, p := range patterns {
+		if _, ok := hash[p]; !ok {
+			hash[p] = struct{}{}
+			list = append(list, p)
+		}
+	}
+	return list
+}

--- a/internal/sauceignore/matcher_test.go
+++ b/internal/sauceignore/matcher_test.go
@@ -3,6 +3,7 @@ package sauceignore
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
@@ -162,4 +163,33 @@ node_modules/
 	return func() {
 		os.RemoveAll(tmpDir)
 	}, file, nil
+}
+
+func TestDedupe(t *testing.T) {
+	type args struct {
+		patterns []Pattern
+	}
+	tests := []struct {
+		name string
+		args args
+		want []Pattern
+	}{
+		{
+			name: "remove one duplicate",
+			args: args{[]Pattern{NewPattern("a"), NewPattern("b"), NewPattern("b")}},
+			want: []Pattern{NewPattern("a"), NewPattern("b")},
+		},
+		{
+			name: "no duplicate input",
+			args: args{[]Pattern{NewPattern("a"), NewPattern("b"), NewPattern("c")}},
+			want: []Pattern{NewPattern("a"), NewPattern("b"), NewPattern("c")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Dedupe(tt.args.patterns); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Dedupe() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Scoped npm dependencies are correctly resolved, but inaccurate gitignore/sauceignore rules caused them to be excluded during archiving.