### PR TITLE
Fix dry-run endless loop

### DIFF
--- a/internal/saucecloud/cypress.go
+++ b/internal/saucecloud/cypress.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/rs/zerolog/log"
 
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/framework"
@@ -49,15 +50,14 @@ func (r *CypressRunner) RunProject() (int, error) {
 		return 1, err
 	}
 
-	if r.Project.IsDryRun() {
-		if err := r.dryRun(r.Project, r.Project.GetRootDir(), r.Project.GetSauceCfg().Sauceignore, r.Project.GetSuiteNames()); err != nil {
-			return exitCode, err
-		}
-		return 0, nil
-	}
-	fileURI, err := r.remoteArchiveFolder(r.Project, r.Project.GetRootDir(), r.Project.GetSauceCfg().Sauceignore)
+	fileURI, err := r.remoteArchiveFolder(r.Project, r.Project.GetRootDir(), r.Project.GetSauceCfg().Sauceignore, r.Project.IsDryRun())
 	if err != nil {
 		return exitCode, err
+	}
+
+	if r.Project.IsDryRun() {
+		log.Info().Msgf("The following test suites would have run: [%s].", r.Project.GetSuiteNames())
+		return 0, nil
 	}
 
 	passed := r.runSuites(fileURI)

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"strings"
@@ -49,16 +50,14 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 		return 1, err
 	}
 
-	if r.Project.DryRun {
-		if err := r.dryRun(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
-			return exitCode, err
-		}
-		return 0, nil
-	}
-
-	fileURI, err := r.remoteArchiveFolder(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore)
+	fileURI, err := r.remoteArchiveFolder(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore, r.Project.DryRun)
 	if err != nil {
 		return exitCode, err
+	}
+
+	if r.Project.DryRun {
+		log.Info().Msgf("The following test suites would have run: [%s].", r.getSuiteNames())
+		return 0, nil
 	}
 
 	passed := r.runSuites(fileURI)

--- a/internal/saucecloud/replay.go
+++ b/internal/saucecloud/replay.go
@@ -8,7 +8,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/puppeteer/replay"
-	"os"
 )
 
 // ReplayRunner represents the Sauce Labs cloud implementation for puppeteer-replay.
@@ -48,25 +47,14 @@ func (r *ReplayRunner) RunProject() (int, error) {
 		files = append(files, suite.Recording)
 	}
 
-	if r.Project.DryRun {
-		log.Warn().Msg("Running tests in dry run mode.")
-		tmpDir, err := os.MkdirTemp("./", "sauce-app-payload-*")
-		if err != nil {
-			return 1, err
-		}
-		log.Info().Msgf("The following test suites would have run: [%s].", suiteNames)
-		zipName, err := r.archiveFiles(r.Project, tmpDir, files, "")
-		if err != nil {
-			return 1, err
-		}
-
-		log.Info().Msgf("Saving bundled project to %s.", zipName)
-		return 0, nil
-	}
-
-	fileURI, err := r.remoteArchiveFiles(r.Project, files, "")
+	fileURI, err := r.remoteArchiveFiles(r.Project, files, "", r.Project.DryRun)
 	if err != nil {
 		return exitCode, err
+	}
+
+	if r.Project.DryRun {
+		log.Info().Msgf("The following test suites would have run: %s.", suiteNames)
+		return 0, nil
 	}
 
 	passed := r.runSuites(fileURI)

--- a/internal/saucecloud/testcafe.go
+++ b/internal/saucecloud/testcafe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"strings"
@@ -48,17 +49,16 @@ func (r *TestcafeRunner) RunProject() (int, error) {
 		return 1, err
 	}
 
-	if r.Project.DryRun {
-		if err := r.dryRun(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore, r.getSuiteNames()); err != nil {
-			return exitCode, err
-		}
-		return 0, nil
-	}
-
-	fileURI, err := r.remoteArchiveFolder(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore)
+	fileURI, err := r.remoteArchiveFolder(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore, r.Project.DryRun)
 	if err != nil {
 		return exitCode, err
 	}
+
+	if r.Project.DryRun {
+		log.Info().Msgf("The following test suites would have run: [%s].", r.getSuiteNames())
+		return 0, nil
+	}
+
 	passed := r.runSuites(fileURI)
 	if passed {
 		return 0, nil


### PR DESCRIPTION
## Proposed changes
Because dry-run creates the zip in the current working directory, which in 99% of cases is also the project directory, saucectl starts adding the zip to itself recursively.

Refactor the dry-run logic to make use of the existing archiving workflow (instead of having its own). Not only does this fix the bug, but also aligns dry-run closer to what would actually happen during a real run.