### PR TITLE
Add release note template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes 🪳
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Proposed changes
Add release note template for better organized release notes.

I considered adding a category by framework, but decided against it due to the fairly large release note layout it ended up creating, as well as some ambiguity around tagging MRs that affect a subset of frameworks but not all.