### PR TITLE
[DEVX-1829] Fix path match issue for windows

### DIFF
--- a/internal/fpath/file.go
+++ b/internal/fpath/file.go
@@ -138,12 +138,11 @@ func FindFiles(rootDir string, sources []string, matchBy MatchPattern) ([]string
 		}
 
 		// Normalize path separators, since the target execution environment may not support backslashes.
-		pathSlashes := filepath.ToSlash(path)
-		relSlashes, err := filepath.Rel(rootDir, pathSlashes)
+		rel, err := filepath.Rel(rootDir, path)
 		if err != nil {
 			return err
 		}
-
+		relSlashes := filepath.ToSlash(rel)
 		for _, pattern := range sources {
 			patternSlashes := filepath.ToSlash(pattern)
 			var ok bool


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
It should get the relative path and then use `filepath.ToSlash()` to replace the separator in relative path. 
Before, comparing
```
pattern: "recordings/myfiles"
relSlashes: "recordings\myfiles"
```
After, comparing
```
pattern: "recordings/myfiles"
relSlashes: "recordings/myfiles"
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->