### PR TITLE
Treat node_modules as a separate payload

### DIFF
--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -476,6 +476,10 @@ func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher
 		return "", fmt.Errorf("'node_modules' is ignored by sauceignore, but you have npm dependencies defined in your project; please remove 'node_modules' from your sauceignore file")
 	}
 
+	if !hasMods {
+		return "", nil
+	}
+
 	var files []string
 
 	// does the user only want a subset of dependencies?

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -462,7 +462,7 @@ func checkPathLength(projectFolder string, matcher sauceignore.Matcher) (string,
 // string if node_modules doesn't exist or is actively ignored.
 func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher sauceignore.Matcher) (string, error) {
 	modDir := filepath.Join(rootDir, "node_modules")
-	ignored := matcher.Match([]string{modDir}, true)
+	ignored := matcher.Match(strings.Split(modDir, string(os.PathSeparator)), true)
 
 	_, err := os.Stat(modDir)
 	hasMods := err == nil
@@ -487,7 +487,7 @@ func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher
 		reqs := node.Requirements(filepath.Join(rootDir, "node_modules"), r.NPMDependencies...)
 		log.Info().Msgf("Found a total of %d related npm dependencies", len(reqs))
 		for _, v := range reqs {
-			files = append(files, filepath.Join("node_modules", v))
+			files = append(files, filepath.Join(rootDir, "node_modules", v))
 		}
 	}
 
@@ -497,7 +497,7 @@ func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher
 		log.Warn().Msg("Adding the entire node_modules folder to the payload. " +
 			"This behavior is deprecated, not recommended and will be removed in the future. " +
 			"Please address your dependency needs via https://docs.saucelabs.com/dev/cli/saucectl/usage/use-cases/#set-npm-packages-in-configyml")
-		files = append(files, "node_modules")
+		files = append(files, filepath.Join(rootDir, "node_modules"))
 	}
 
 	return r.archiveFiles(nil, "node_modules", tempDir, rootDir, files, matcher)

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -469,7 +469,7 @@ func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher
 	wantMods := len(r.NPMDependencies) > 0
 
 	if !hasMods && wantMods {
-		return "", fmt.Errorf("unable to access 'node_modules' folder, but you have npm dependencies defined in your project")
+		return "", fmt.Errorf("unable to access 'node_modules' folder, but you have npm dependencies defined in your configuration")
 	}
 
 	if ignored && wantMods {

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -476,7 +476,7 @@ func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher
 		return "", fmt.Errorf("'node_modules' is ignored by sauceignore, but you have npm dependencies defined in your project; please remove 'node_modules' from your sauceignore file")
 	}
 
-	if !hasMods {
+	if !hasMods || ignored {
 		return "", nil
 	}
 

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -490,6 +490,9 @@ func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher
 	// node_modules exists, has not been ignored and a subset has not been specified, so include the entire folder.
 	// This is the legacy behavior (backwards compatible) of saucectl.
 	if hasMods && !ignored && !wantMods {
+		log.Warn().Msg("Adding the entire node_modules folder to the payload. " +
+			"This behavior is deprecated, not recommended and will be removed in the future. " +
+			"Please address your dependency needs via https://docs.saucelabs.com/dev/cli/saucectl/usage/use-cases/#set-npm-packages-in-configyml")
 		files = append(files, "node_modules")
 	}
 

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -469,7 +469,7 @@ func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher
 	wantMods := len(r.NPMDependencies) > 0
 
 	if !hasMods && wantMods {
-		return "", fmt.Errorf("unable to access 'node_modules' folder, but you have npm dependencies defined in your configuration")
+		return "", fmt.Errorf("unable to access 'node_modules' folder, but you have npm dependencies defined in your configuration; ensure that the folder exists and is accessible")
 	}
 
 	if ignored && wantMods {

--- a/internal/saucecloud/cypress.go
+++ b/internal/saucecloud/cypress.go
@@ -45,7 +45,7 @@ func (r *CypressRunner) RunProject() (int, error) {
 		}
 	}
 
-	if err := r.validateTunnel(r.Project.GetSauceCfg().Tunnel.Name, r.Project.GetSauceCfg().Tunnel.Owner); err != nil {
+	if err := r.validateTunnel(r.Project.GetSauceCfg().Tunnel.Name, r.Project.GetSauceCfg().Tunnel.Owner, r.Project.IsDryRun()); err != nil {
 		return 1, err
 	}
 

--- a/internal/saucecloud/cypress.go
+++ b/internal/saucecloud/cypress.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/rs/zerolog/log"
-
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/job"
@@ -50,7 +49,7 @@ func (r *CypressRunner) RunProject() (int, error) {
 		return 1, err
 	}
 
-	fileURI, err := r.remoteArchiveFolder(r.Project, r.Project.GetRootDir(), r.Project.GetSauceCfg().Sauceignore, r.Project.IsDryRun())
+	fileURI, err := r.remoteArchiveProject(r.Project, r.Project.GetRootDir(), r.Project.GetSauceCfg().Sauceignore, r.Project.IsDryRun())
 	if err != nil {
 		return exitCode, err
 	}

--- a/internal/saucecloud/cypress_test.go
+++ b/internal/saucecloud/cypress_test.go
@@ -124,12 +124,12 @@ func TestUploadProject(t *testing.T) {
 			ProjectUploader: uploader,
 		},
 	}
-	id, err := runner.uploadProject("/my-dummy-project.zip", "project")
+	id, err := runner.uploadProject("/my-dummy-project.zip", "project", false)
 	assert.Equal(t, "storage:fake-id", id)
 	assert.Nil(t, err)
 
 	uploader.UploadSuccess = false
-	id, err = runner.uploadProject("/my-dummy-project.zip", "project")
+	id, err = runner.uploadProject("/my-dummy-project.zip", "project", false)
 	assert.Equal(t, "", id)
 	assert.NotNil(t, err)
 

--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -34,28 +34,28 @@ type EspressoRunner struct {
 func (r *EspressoRunner) RunProject() (int, error) {
 	exitCode := 1
 
-	if r.Project.DryRun {
-		r.dryRun()
-		return 0, nil
-	}
-
-	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner); err != nil {
+	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner, r.Project.DryRun); err != nil {
 		return 1, err
 	}
 
-	appFileURI, err := r.uploadProject(r.Project.Espresso.App, appUpload)
+	appFileURI, err := r.uploadProject(r.Project.Espresso.App, appUpload, r.Project.DryRun)
 	if err != nil {
 		return exitCode, err
 	}
 
-	testAppFileURI, err := r.uploadProject(r.Project.Espresso.TestApp, testAppUpload)
+	testAppFileURI, err := r.uploadProject(r.Project.Espresso.TestApp, testAppUpload, r.Project.DryRun)
 	if err != nil {
 		return exitCode, err
 	}
 
-	otherAppsURIs, err := r.uploadProjects(r.Project.Espresso.OtherApps, otherAppsUpload)
+	otherAppsURIs, err := r.uploadProjects(r.Project.Espresso.OtherApps, otherAppsUpload, r.Project.DryRun)
 	if err != nil {
 		return exitCode, err
+	}
+
+	if r.Project.DryRun {
+		r.dryRun()
+		return 0, nil
 	}
 
 	passed := r.runSuites(appFileURI, testAppFileURI, otherAppsURIs)

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -46,7 +46,7 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 		}
 	}
 
-	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner); err != nil {
+	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner, r.Project.DryRun); err != nil {
 		return 1, err
 	}
 

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -50,7 +50,7 @@ func (r *PlaywrightRunner) RunProject() (int, error) {
 		return 1, err
 	}
 
-	fileURI, err := r.remoteArchiveFolder(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore, r.Project.DryRun)
+	fileURI, err := r.remoteArchiveProject(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore, r.Project.DryRun)
 	if err != nil {
 		return exitCode, err
 	}

--- a/internal/saucecloud/replay.go
+++ b/internal/saucecloud/replay.go
@@ -36,7 +36,7 @@ func (r *ReplayRunner) RunProject() (int, error) {
 		}
 	}
 
-	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner); err != nil {
+	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner, r.Project.DryRun); err != nil {
 		return 1, err
 	}
 

--- a/internal/saucecloud/testcafe.go
+++ b/internal/saucecloud/testcafe.go
@@ -49,7 +49,7 @@ func (r *TestcafeRunner) RunProject() (int, error) {
 		return 1, err
 	}
 
-	fileURI, err := r.remoteArchiveFolder(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore, r.Project.DryRun)
+	fileURI, err := r.remoteArchiveProject(r.Project, r.Project.RootDir, r.Project.Sauce.Sauceignore, r.Project.DryRun)
 	if err != nil {
 		return exitCode, err
 	}

--- a/internal/saucecloud/testcafe.go
+++ b/internal/saucecloud/testcafe.go
@@ -45,7 +45,7 @@ func (r *TestcafeRunner) RunProject() (int, error) {
 		}
 	}
 
-	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner); err != nil {
+	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner, r.Project.DryRun); err != nil {
 		return 1, err
 	}
 

--- a/internal/saucecloud/xcuitest.go
+++ b/internal/saucecloud/xcuitest.go
@@ -26,13 +26,8 @@ type XcuitestRunner struct {
 func (r *XcuitestRunner) RunProject() (int, error) {
 	exitCode := 1
 
-	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner); err != nil {
+	if err := r.validateTunnel(r.Project.Sauce.Tunnel.Name, r.Project.Sauce.Tunnel.Owner, r.Project.DryRun); err != nil {
 		return exitCode, err
-	}
-
-	if r.Project.DryRun {
-		r.dryRun()
-		return 0, nil
 	}
 
 	appPath, testAppPath, err := archiveAppsToIpaIfRequired(r.Project.Xcuitest.App, r.Project.Xcuitest.TestApp)
@@ -40,19 +35,24 @@ func (r *XcuitestRunner) RunProject() (int, error) {
 		return exitCode, err
 	}
 
-	appFileURI, err := r.uploadProject(appPath, appUpload)
+	appFileURI, err := r.uploadProject(appPath, appUpload, r.Project.DryRun)
 	if err != nil {
 		return exitCode, err
 	}
 
-	testAppFileURI, err := r.uploadProject(testAppPath, testAppUpload)
+	testAppFileURI, err := r.uploadProject(testAppPath, testAppUpload, r.Project.DryRun)
 	if err != nil {
 		return exitCode, err
 	}
 
-	otherAppsURIs, err := r.uploadProjects(r.Project.Xcuitest.OtherApps, otherAppsUpload)
+	otherAppsURIs, err := r.uploadProjects(r.Project.Xcuitest.OtherApps, otherAppsUpload, r.Project.DryRun)
 	if err != nil {
 		return exitCode, err
+	}
+
+	if r.Project.DryRun {
+		r.dryRun()
+		return 0, nil
 	}
 
 	passed := r.runSuites(appFileURI, testAppFileURI, otherAppsURIs)


### PR DESCRIPTION
## Proposed changes
Treat node_modules as a separate payload.
This improves cache hits, which in turn improves execution time for projects where code changes more often than dependencies do.