### PR TITLE
Increase RDC timeout

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -52,7 +52,7 @@ var (
 
 	// General Request Timeouts
 	testComposerTimeout = 15 * time.Minute
-	rdcTimeout          = 15 * time.Second
+	rdcTimeout          = 1 * time.Minute
 	githubTimeout       = 2 * time.Second
 
 	typeDef config.TypeDef


### PR DESCRIPTION
## Proposed changes
Increase timeout for the RDC client. While a larger timeout has no added benefits for starting tests (RDC job creation is asynchronous from actual device assignment), it is for downloading assets.