### PR TITLE
Increase RDC timeout to accommodate large asset downloads

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -52,7 +52,7 @@ var (
 
 	// General Request Timeouts
 	testComposerTimeout = 15 * time.Minute
-	rdcTimeout          = 1 * time.Minute
+	rdcTimeout          = 15 * time.Minute
 	githubTimeout       = 2 * time.Second
 
 	typeDef config.TypeDef


### PR DESCRIPTION
## Proposed changes
Increase RDC timeout to accommodate large asset downloads.
