### PR TITLE
Extend JSON schema for replay

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -1697,6 +1697,15 @@
                   "description": "Relative paths to the chrome devtools recordings.",
                   "type": "array"
                 },
+                "browserName": {
+                  "$ref": "#/allOf/0/then/properties/suites/items/properties/browser",
+                  "enum": [
+                    "chrome"
+                  ]
+                },
+                "browserVersion": {
+                  "$ref": "#/allOf/0/then/properties/suites/items/properties/browserVersion"
+                },
                 "platform": {
                   "enum": [
                     "macOS 11.00",

--- a/api/v1alpha/framework/replay.schema.json
+++ b/api/v1alpha/framework/replay.schema.json
@@ -47,6 +47,15 @@
             "description": "Relative paths to the chrome devtools recordings.",
             "type": "array"
           },
+          "browserName": {
+            "$ref": "../subschema/common.schema.json#/definitions/browser",
+            "enum": [
+              "chrome"
+            ]
+          },
+          "browserVersion": {
+            "$ref": "../subschema/common.schema.json#/definitions/browserVersion"
+          },
           "platform": {
             "$ref": "../subschema/common.schema.json#/definitions/platformName",
             "enum": [


### PR DESCRIPTION
## Proposed changes
Extend JSON Schema for replay with `browserName` and `browserVersion`.
The browser name is kinda pointless, since Chrome is the only browser that this implementation supports. But I added it to be thorough and complimentary to the browser version, which, is important and properly working (with regards to chrome).