### PR TITLE
Improve archive cache hits

### DIFF
--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -14,8 +14,9 @@ import (
 
 // Writer is a wrapper around zip.Writer and implements zip archiving for archive.Writer.
 type Writer struct {
-	W *zip.Writer
-	M sauceignore.Matcher
+	W       *zip.Writer
+	M       sauceignore.Matcher
+	zipFile *os.File
 }
 
 // NewFileWriter returns a new Writer that archives files to name.
@@ -25,7 +26,7 @@ func NewFileWriter(name string, matcher sauceignore.Matcher) (Writer, error) {
 		return Writer{}, err
 	}
 
-	w := Writer{W: zip.NewWriter(f), M: matcher}
+	w := Writer{W: zip.NewWriter(f), M: matcher, zipFile: f}
 
 	return w, nil
 }
@@ -48,9 +49,9 @@ func (w *Writer) Add(src, dst string) (int, error) {
 	if w.M.Match(strings.Split(src, string(os.PathSeparator)), finfo.IsDir()) {
 		return 0, nil
 	}
-	log.Debug().Str("name", src).Msg("Adding to archive")
 
 	if !finfo.IsDir() {
+		log.Debug().Str("name", src).Msg("Adding to archive")
 		w, err := w.W.Create(path.Join(dst, finfo.Name()))
 		if err != nil {
 			return 0, err
@@ -59,9 +60,15 @@ func (w *Writer) Add(src, dst string) (int, error) {
 		if err != nil {
 			return 0, err
 		}
-		defer f.Close()
 
-		_, err = io.Copy(w, f)
+		if _, err := io.Copy(w, f); err != nil {
+			return 0, err
+		}
+
+		if err := f.Close(); err != nil {
+			return 0, err
+		}
+
 		return 1, err
 	}
 
@@ -88,5 +95,12 @@ func (w *Writer) Add(src, dst string) (int, error) {
 
 // Close closes the archive. Adding more files to the archive is not possible after this.
 func (w *Writer) Close() error {
-	return w.W.Close()
+	if err := w.W.Close(); err != nil {
+		return err
+	}
+	if err := w.zipFile.Close(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -508,6 +509,9 @@ func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher
 func (r *CloudRunner) archiveFiles(project interface{}, name string, tempDir string, rootDir string, files []string, matcher sauceignore.Matcher) (string, error) {
 	start := time.Now()
 
+	// Keep file order stable for consistent zip archives
+	sort.Strings(files)
+
 	zipName := filepath.Join(tempDir, name+".zip")
 	z, err := zip.NewFileWriter(zipName, matcher)
 	if err != nil {
@@ -522,7 +526,6 @@ func (r *CloudRunner) archiveFiles(project interface{}, name string, tempDir str
 		if err := jsonio.WriteFile(rcPath, project); err != nil {
 			return "", err
 		}
-		log.Debug().Str("name", rcPath).Msg("Adding to archive")
 		fileCount, err := z.Add(rcPath, "")
 		if err != nil {
 			return "", err
@@ -531,7 +534,6 @@ func (r *CloudRunner) archiveFiles(project interface{}, name string, tempDir str
 	}
 
 	for _, f := range files {
-		log.Debug().Str("name", f).Msg("Adding to archive")
 		rel, err := filepath.Rel(rootDir, filepath.Dir(f))
 		if err != nil {
 			return "", err

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -509,9 +509,6 @@ func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher
 func (r *CloudRunner) archiveFiles(project interface{}, name string, tempDir string, rootDir string, files []string, matcher sauceignore.Matcher) (string, error) {
 	start := time.Now()
 
-	// Keep file order stable for consistent zip archives
-	sort.Strings(files)
-
 	zipName := filepath.Join(tempDir, name+".zip")
 	z, err := zip.NewFileWriter(zipName, matcher)
 	if err != nil {
@@ -533,6 +530,8 @@ func (r *CloudRunner) archiveFiles(project interface{}, name string, tempDir str
 		totalFileCount += fileCount
 	}
 
+	// Keep file order stable for consistent zip archives
+	sort.Strings(files)
 	for _, f := range files {
 		rel, err := filepath.Rel(rootDir, filepath.Dir(f))
 		if err != nil {


### PR DESCRIPTION
## Proposed changes
The _order_ of files added to a zip archive is persisted as metadata and therefore has an influence on the checksum.
This changes ensures that project files are always added in a certain order (alphabetical, in this case), thus creating an archive that's much more consistent checksum wise. This, in turn, increases the chance of a cache hit for an already uploaded archive.