### PR TITLE
[DEVX-1842] Fix dependencies uploading with empty node_modules folder

### DIFF
--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -489,6 +489,9 @@ func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher
 	// does the user only want a subset of dependencies?
 	if hasMods && wantMods {
 		reqs := node.Requirements(filepath.Join(rootDir, "node_modules"), r.NPMDependencies...)
+		if len(reqs) == 0 {
+			return "", fmt.Errorf("unable to find required dependencies. Please check 'node_modules' folder and make sure the dependencies exist")
+		}
 		log.Info().Msgf("Found a total of %d related npm dependencies", len(reqs))
 		for _, v := range reqs {
 			files = append(files, filepath.Join(rootDir, "node_modules", v))

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -490,7 +490,7 @@ func (r *CloudRunner) archiveNodeModules(tempDir string, rootDir string, matcher
 	if hasMods && wantMods {
 		reqs := node.Requirements(filepath.Join(rootDir, "node_modules"), r.NPMDependencies...)
 		if len(reqs) == 0 {
-			return "", fmt.Errorf("unable to find required dependencies. Please check 'node_modules' folder and make sure the dependencies exist")
+			return "", fmt.Errorf("unable to find required dependencies; please check 'node_modules' folder and make sure the dependencies exist")
 		}
 		log.Info().Msgf("Found a total of %d related npm dependencies", len(reqs))
 		for _, v := range reqs {

--- a/internal/saucecloud/cloud_test.go
+++ b/internal/saucecloud/cloud_test.go
@@ -451,7 +451,7 @@ func TestCloudRunner_archiveNodeModules(t *testing.T) {
 			},
 			"",
 			func(t assert.TestingT, err error, args ...interface{}) bool {
-				return assert.EqualError(t, err, "unable to find required dependencies. Please check 'node_modules' folder and make sure the dependencies exist", args)
+				return assert.EqualError(t, err, "unable to find required dependencies; please check 'node_modules' folder and make sure the dependencies exist", args)
 			},
 		},
 	}

--- a/internal/saucecloud/cloud_test.go
+++ b/internal/saucecloud/cloud_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/saucelabs/saucectl/internal/sauceignore"
-	"gotest.tools/v3/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/saucelabs/saucectl/internal/sauceignore"
+	"gotest.tools/v3/fs"
 
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/mocks"
@@ -334,6 +335,9 @@ func TestCloudRunner_archiveNodeModules(t *testing.T) {
 			),
 		),
 		fs.WithDir("no-mods"),
+		fs.WithDir("empty-mods",
+			fs.WithDir(("node_modules")),
+		),
 	)
 	defer projectsDir.Remove()
 
@@ -434,6 +438,21 @@ func TestCloudRunner_archiveNodeModules(t *testing.T) {
 			},
 			filepath.Join(tempDir, "node_modules.zip"),
 			assert.NoError,
+		},
+		{
+			"want mods, but node_modules folder is empty",
+			fields{
+				NPMDependencies: []string{"mod1"},
+			},
+			args{
+				tempDir: tempDir,
+				rootDir: "empty-mods",
+				matcher: sauceignore.NewMatcher([]sauceignore.Pattern{}),
+			},
+			"",
+			func(t assert.TestingT, err error, args ...interface{}) bool {
+				return assert.EqualError(t, err, "unable to find required dependencies. Please check 'node_modules' folder and make sure the dependencies exist", args)
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
If `node_modules` is empty while the dependencies are required in the config, it will upload an empty dependencies folder which causes the failure. This PR is to fix it.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->