### PR TITLE
Enable additional linter rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+linters:
+  enable:
+    - revive
+    - errname

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -16,7 +16,7 @@ import (
 var (
 	reFileID            = regexp.MustCompile(`(storage:(//)?)?(?P<fileID>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$`)
 	reFilePattern       = regexp.MustCompile(`^(storage:filename=)(?P<filename>[\S][\S ]+(\.ipa|\.apk))$`)
-	reHttpSchemePattern = regexp.MustCompile(`(?i)^https?`)
+	reHTTPSchemePattern = regexp.MustCompile(`(?i)^https?`)
 )
 
 func hasValidExtension(file string, exts []string) bool {
@@ -34,7 +34,7 @@ func IsRemote(name string) bool {
 	if err != nil {
 		return false
 	}
-	return reHttpSchemePattern.MatchString(parsedURL.Scheme) && parsedURL.Host != ""
+	return reHTTPSchemePattern.MatchString(parsedURL.Scheme) && parsedURL.Host != ""
 }
 
 // IsStorageReference checks if a link is an entry of app-storage.
@@ -75,9 +75,9 @@ func Validate(kind, app string, validExt []string) error {
 	return fmt.Errorf(msg.FileNotFound, app)
 }
 
-// Download downloads a file from remoteUrl to a temp directory and returns the path to the downloaded file
-func Download(remoteUrl string) (string, error) {
-	resp, err := http.Get(remoteUrl)
+// Download downloads a file from remoteURL to a temp directory and returns the path to the downloaded file
+func Download(remoteURL string) (string, error) {
+	resp, err := http.Get(remoteURL)
 
 	if err != nil {
 		return "", err
@@ -85,7 +85,7 @@ func Download(remoteUrl string) (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("unable to download app from %s: %s", remoteUrl, resp.Status)
+		return "", fmt.Errorf("unable to download app from %s: %s", remoteURL, resp.Status)
 	}
 
 	dir, err := os.MkdirTemp("", "tmp-app")
@@ -93,7 +93,7 @@ func Download(remoteUrl string) (string, error) {
 		return "", err
 	}
 
-	tmpFilePath := path.Join(dir, path.Base(remoteUrl))
+	tmpFilePath := path.Join(dir, path.Base(remoteURL))
 
 	f, err := os.Create(tmpFilePath)
 	if err != nil {

--- a/internal/framework/search.go
+++ b/internal/framework/search.go
@@ -33,9 +33,10 @@ type MetadataSearchStrategy interface {
 type ExactStrategy struct {
 }
 
-// PackageStrategy searches for metadata of a framework from a package.json file. If the requested version is a range (e.g. ~9.0.0), it matches the most recent version that satifies the constraint.
+// PackageStrategy searches for metadata of a framework from a package.json file.
+// If the requested version is a range (e.g. ~9.0.0), it matches the most recent version that satisfies the constraint.
 type PackageStrategy struct {
-	packageJsonFilePath string
+	packageJSONFilePath string
 }
 
 func (s ExactStrategy) Find(ctx context.Context, svc MetadataService, frameworkName string, frameworkVersion string) (Metadata, error) {
@@ -87,8 +88,8 @@ var (
 	NewConstraint   = semver.NewConstraint
 )
 
-func (s PackageStrategy) Find(ctx context.Context, svc MetadataService, frameworkName string, packageJsonPath string) (Metadata, error) {
-	p, err := PackageFromFile(s.packageJsonFilePath)
+func (s PackageStrategy) Find(ctx context.Context, svc MetadataService, frameworkName string, frameworkVersion string) (Metadata, error) {
+	p, err := PackageFromFile(s.packageJSONFilePath)
 
 	if err != nil {
 		return Metadata{}, fmt.Errorf("error reading package.json: %w", err)
@@ -151,7 +152,7 @@ func (s PackageStrategy) Find(ctx context.Context, svc MetadataService, framewor
 func NewSearchStrategy(version string, rootDir string) MetadataSearchStrategy {
 	if strings.Contains(version, "package.json") {
 		return PackageStrategy{
-			packageJsonFilePath: filepath.Join(rootDir, version),
+			packageJSONFilePath: filepath.Join(rootDir, version),
 		}
 	} else {
 		return ExactStrategy{}

--- a/internal/framework/search.go
+++ b/internal/framework/search.go
@@ -154,7 +154,7 @@ func NewSearchStrategy(version string, rootDir string) MetadataSearchStrategy {
 		return PackageStrategy{
 			packageJSONFilePath: filepath.Join(rootDir, version),
 		}
-	} else {
-		return ExactStrategy{}
 	}
+
+	return ExactStrategy{}
 }

--- a/internal/framework/search.go
+++ b/internal/framework/search.go
@@ -12,14 +12,14 @@ import (
 	"github.com/saucelabs/saucectl/internal/node"
 )
 
-// FrameworkUnavailableError is an error type returned if the requested framework version is unavailable.
-type FrameworkUnavailableError struct {
+// UnavailableError is an error type returned if the requested framework version is unavailable.
+type UnavailableError struct {
 	Name    string
 	Version string
 }
 
 // Error returns the error string
-func (e *FrameworkUnavailableError) Error() string {
+func (e *UnavailableError) Error() string {
 	s := fmt.Sprintf("version %s for %s is not available", e.Version, e.Name)
 	return s
 }
@@ -60,7 +60,7 @@ func (s ExactStrategy) Find(ctx context.Context, svc MetadataService, frameworkN
 		}
 	}
 
-	return Metadata{}, &FrameworkUnavailableError{
+	return Metadata{}, &UnavailableError{
 		Name:    frameworkName,
 		Version: frameworkVersion,
 	}
@@ -142,7 +142,7 @@ func (s PackageStrategy) Find(ctx context.Context, svc MetadataService, framewor
 		}
 	}
 
-	return Metadata{}, &FrameworkUnavailableError{
+	return Metadata{}, &UnavailableError{
 		Name:    frameworkName,
 		Version: ver,
 	}

--- a/internal/framework/search_test.go
+++ b/internal/framework/search_test.go
@@ -108,7 +108,7 @@ func TestFrameworkFind_PackageStrategy(t *testing.T) {
 		ctx             context.Context
 		svc             MetadataService
 		frameworkName   string
-		packageJsonPath string
+		packageJSONPath string
 		packageFromFile func(filename string) (node.Package, error)
 		newConstraint   func(c string) (*semver.Constraints, error)
 	}{
@@ -186,7 +186,7 @@ func TestFrameworkFind_PackageStrategy(t *testing.T) {
 			PackageFromFile = tc.packageFromFile
 			NewConstraint = tc.newConstraint
 
-			_, err := PackageStrategy{}.Find(tc.ctx, tc.svc, tc.frameworkName, tc.packageJsonPath)
+			_, err := PackageStrategy{}.Find(tc.ctx, tc.svc, tc.frameworkName, tc.packageJSONPath)
 
 			if err != nil && err.Error() != tc.expectedMessage {
 				t.Errorf("Wrong error message displays:\nExpected: %s\nActual: %s", tc.expectedMessage, err.Error())

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -870,7 +870,7 @@ func (r *CloudRunner) deprecationMessage(frameworkName string, frameworkVersion 
 }
 
 func (r *CloudRunner) logFrameworkError(err error) {
-	var unavailableErr *framework.FrameworkUnavailableError
+	var unavailableErr *framework.UnavailableError
 	if errors.As(err, &unavailableErr) {
 		color.Red(fmt.Sprintf("\n%s\n\n", err.Error()))
 		fmt.Print(r.getAvailableVersionsMessage(unavailableErr.Name))


### PR DESCRIPTION
## Proposed changes
To maintain our level of code hygiene. `golint` (deprecated) had more styling rules, which carried over to `revive`.