### PR TITLE
Global Usage Tracking Flag

### DIFF
--- a/cmd/saucectl/saucectl.go
+++ b/cmd/saucectl/saucectl.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/saucelabs/saucectl/internal/cmd/storage"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"os"
 	"time"
 
@@ -54,9 +55,12 @@ func main() {
 
 	verbosity := cmd.PersistentFlags().Bool("verbose", false, "turn on verbose logging")
 	noColor := cmd.PersistentFlags().Bool("no-color", false, "disable colorized output")
+	noTracking := cmd.PersistentFlags().Bool("disable-usage-metrics", false, "Disable usage metrics collection.")
+
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		setupLogging(*verbosity, *noColor)
 		setupBacktrace()
+		segment.DefaultTracker.Enabled = !*noTracking
 	}
 
 	cmd.AddCommand(

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+// FullName returns the full command name by concatenating the command names of any parents,
+// except the name of the CLI itself.
+func FullName(cmd *cobra.Command) string {
+	name := ""
+
+	for cmd.Name() != "saucectl" {
+		// Prepending, because we are looking up names from the bottom up: cypress < run < saucectl
+		// which ends up correctly as 'run cypress' (sans saucectl).
+		name = fmt.Sprintf("%s %s", cmd.Name(), name)
+		cmd = cmd.Parent()
+	}
+
+	return strings.TrimSpace(name)
+}

--- a/internal/cmd/configure/cmd.go
+++ b/internal/cmd/configure/cmd.go
@@ -17,13 +17,12 @@ import (
 )
 
 var (
-	configureUse           = "configure"
-	configureShort         = "Configure your Sauce Labs credentials"
-	configureLong          = `Persist locally your Sauce Labs credentials`
-	configureExample       = "saucectl configure"
-	cliUsername            = ""
-	cliAccessKey           = ""
-	cliDisableUsageMetrics = false
+	configureUse     = "configure"
+	configureShort   = "Configure your Sauce Labs credentials"
+	configureLong    = `Persist locally your Sauce Labs credentials`
+	configureExample = "saucectl configure"
+	cliUsername      = ""
+	cliAccessKey     = ""
 )
 
 // Command creates the `configure` command
@@ -34,7 +33,7 @@ func Command() *cobra.Command {
 		Long:    configureLong,
 		Example: configureExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New(!cliDisableUsageMetrics)
+			tracker := segment.DefaultTracker
 
 			defer func() {
 				tracker.Collect("Configure", nil)
@@ -52,7 +51,6 @@ func Command() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&cliUsername, "username", "u", "", "username, available on your sauce labs account")
 	cmd.Flags().StringVarP(&cliAccessKey, "accessKey", "a", "", "accessKey, available on your sauce labs account")
-	cmd.Flags().BoolVar(&cliDisableUsageMetrics, "disable-usage-metrics", false, "Disable usage metrics collection.")
 	return cmd
 }
 

--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -36,26 +36,25 @@ var (
 type initConfig struct {
 	batchMode bool
 
-	frameworkName       string
-	frameworkVersion    string
-	cypressJSON         string
-	app                 string
-	testApp             string
-	otherApps           []string
-	platformName        string
-	mode                string
-	browserName         string
-	region              string
-	artifactWhen        config.When
-	artifactWhenStr     string
-	device              config.Device
-	emulator            config.Emulator
-	deviceFlag          flags.Device
-	emulatorFlag        flags.Emulator
-	concurrency         int
-	username            string
-	accessKey           string
-	disableUsageMetrics bool
+	frameworkName    string
+	frameworkVersion string
+	cypressJSON      string
+	app              string
+	testApp          string
+	otherApps        []string
+	platformName     string
+	mode             string
+	browserName      string
+	region           string
+	artifactWhen     config.When
+	artifactWhenStr  string
+	device           config.Device
+	emulator         config.Emulator
+	deviceFlag       flags.Device
+	emulatorFlag     flags.Emulator
+	concurrency      int
+	username         string
+	accessKey        string
 }
 
 var (
@@ -74,7 +73,7 @@ func Command() *cobra.Command {
 		Long:    initLong,
 		Example: initExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New(!initCfg.disableUsageMetrics)
+			tracker := segment.DefaultTracker
 
 			defer func() {
 				tracker.Collect("Init", nil)
@@ -104,7 +103,6 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&initCfg.artifactWhenStr, "artifacts.download.when", "fail", "defines when to download artifacts")
 	cmd.Flags().Var(&initCfg.emulatorFlag, "emulator", "Specifies the emulator to use for testing")
 	cmd.Flags().Var(&initCfg.deviceFlag, "device", "Specifies the device to use for testing")
-	cmd.Flags().BoolVar(&initCfg.disableUsageMetrics, "disable-usage-metrics", false, "Disable usage metrics collection.")
 	return cmd
 }
 

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -121,7 +122,7 @@ func runCypress(cmd *cobra.Command) (int, error) {
 			SetArtifacts(p.GetArtifactsCfg()).SetDocker(p.GetDocker()).SetNPM(p.GetNpm()).SetNumSuites(len(p.GetSuites())).SetJobs(captor.Default.TestResults).
 			SetSlack(p.GetNotifications().Slack).SetSharding(p.IsSharded()).SetLaunchOrder(p.GetSauceCfg().LaunchOrder)
 
-		tracker.Collect(cases.Title(language.English).String(fullCommandName(cmd)), props)
+		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()
 

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -114,7 +114,7 @@ func runCypress(cmd *cobra.Command) (int, error) {
 	insightsClient.URL = regio.APIBaseURL()
 	iamClient.URL = regio.APIBaseURL()
 	restoClient.ArtifactConfig = p.GetArtifactsCfg().Download
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	tracker := segment.DefaultTracker
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -117,7 +117,7 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags) (int, error) {
 		p.Sauce.Metadata.Tags = append(p.Sauce.Metadata.Tags, ci.GetTags()...)
 	}
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	tracker := segment.DefaultTracker
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -123,7 +124,7 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags) (int, error) {
 		props.SetFramework("espresso").SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
 			SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults).SetSlack(p.Notifications.Slack).
 			SetSharding(espresso.IsSharded(p.Suites)).SetLaunchOrder(p.Sauce.LaunchOrder)
-		tracker.Collect(cases.Title(language.English).String(fullCommandName(cmd)), props)
+		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()
 

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -142,7 +143,7 @@ func runPlaywright(cmd *cobra.Command) (int, error) {
 		props.SetFramework("playwright").SetFVersion(p.Playwright.Version).SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).
 			SetArtifacts(p.Artifacts).SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults).
 			SetSlack(p.Notifications.Slack).SetSharding(playwright.IsSharded(p.Suites)).SetLaunchOrder(p.Sauce.LaunchOrder)
-		tracker.Collect(cases.Title(language.English).String(fullCommandName(cmd)), props)
+		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()
 

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -136,7 +136,7 @@ func runPlaywright(cmd *cobra.Command) (int, error) {
 		p.Sauce.Metadata.Tags = append(p.Sauce.Metadata.Tags, ci.GetTags()...)
 	}
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	tracker := segment.DefaultTracker
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -108,7 +108,7 @@ func runPuppeteer(cmd *cobra.Command) (int, error) {
 		p.Sauce.Metadata.Tags = append(p.Sauce.Metadata.Tags, ci.GetTags()...)
 	}
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	tracker := segment.DefaultTracker
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"github.com/rs/zerolog/log"
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/text/cases"
@@ -114,7 +115,7 @@ func runPuppeteer(cmd *cobra.Command) (int, error) {
 		props.SetFramework("puppeteer").SetFVersion(p.Puppeteer.Version).SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).
 			SetArtifacts(p.Artifacts).SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults).
 			SetSlack(p.Notifications.Slack)
-		tracker.Collect(cases.Title(language.English).String(fullCommandName(cmd)), props)
+		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()
 

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -102,7 +102,7 @@ func runReplay(cmd *cobra.Command) (int, error) {
 		p.Sauce.Metadata.Tags = append(p.Sauce.Metadata.Tags, ci.GetTags()...)
 	}
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	tracker := segment.DefaultTracker
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"os"
 
 	"github.com/saucelabs/saucectl/internal/framework"
@@ -108,7 +109,7 @@ func runReplay(cmd *cobra.Command) (int, error) {
 		props.SetFramework("puppeteer-replay").SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).
 			SetArtifacts(p.Artifacts).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults).
 			SetSlack(p.Notifications.Slack).SetLaunchOrder(p.Sauce.LaunchOrder)
-		tracker.Collect(cases.Title(language.English).String(fullCommandName(cmd)), props)
+		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()
 

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -157,7 +157,6 @@ func Command() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&gFlags.selectedSuite, "select-suite", "", "Run specified test suite.")
 	cmd.PersistentFlags().BoolVar(&gFlags.testEnvSilent, "test-env-silent", false, "Skips the test environment announcement.")
-	cmd.PersistentFlags().BoolVar(&gFlags.disableUsageMetrics, "disable-usage-metrics", false, "Disable usage metrics collection.")
 	cmd.PersistentFlags().BoolVar(&gFlags.noAutoTagging, "no-auto-tagging", false, "Disable the automatic tagging of jobs with metadata, such as CI or GIT information.")
 
 	// Hide undocumented flags that the user does not need to care about.

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"syscall"
 	"time"
 
@@ -367,21 +366,6 @@ func createReporters(c config.Reporters, ntfs config.Notifications, metadata con
 	})
 
 	return reps
-}
-
-// fullCommandName returns the full command name by concatenating the command names of any parents,
-// except the name of the CLI itself.
-func fullCommandName(cmd *cobra.Command) string {
-	name := ""
-
-	for cmd.Name() != "saucectl" {
-		// Prepending, because we are looking up names from the bottom up: cypress < run < saucectl
-		// which ends up correctly as 'run cypress' (sans saucectl).
-		name = fmt.Sprintf("%s %s", cmd.Name(), name)
-		cmd = cmd.Parent()
-	}
-
-	return strings.TrimSpace(name)
 }
 
 // cleanupArtifacts removes any files in the artifact folder. Does nothing if cleanup is turned off.

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -80,15 +80,14 @@ var (
 var gFlags = globalFlags{}
 
 type globalFlags struct {
-	cfgFilePath         string
-	globalTimeout       time.Duration
-	selectedSuite       string
-	testEnvSilent       bool
-	disableUsageMetrics bool
-	async               bool
-	failFast            bool
-	appStoreTimeout     time.Duration
-	noAutoTagging       bool
+	cfgFilePath     string
+	globalTimeout   time.Duration
+	selectedSuite   string
+	testEnvSilent   bool
+	async           bool
+	failFast        bool
+	appStoreTimeout time.Duration
+	noAutoTagging   bool
 }
 
 // Command creates the `run` command
@@ -354,14 +353,13 @@ func createReporters(c config.Reporters, ntfs config.Notifications, metadata con
 	}
 
 	reps = append(reps, &slack.Reporter{
-		Channels:            ntfs.Slack.Channels,
-		Framework:           framework,
-		Metadata:            metadata,
-		TestEnv:             env,
-		TestResults:         []report.TestResult{},
-		Config:              ntfs,
-		Service:             svc,
-		DisableUsageMetrics: gFlags.disableUsageMetrics,
+		Channels:    ntfs.Slack.Channels,
+		Framework:   framework,
+		Metadata:    metadata,
+		TestEnv:     env,
+		TestResults: []report.TestResult{},
+		Config:      ntfs,
+		Service:     svc,
 	})
 
 	return reps

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -157,7 +158,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags) (int, error) {
 		props.SetFramework("testcafe").SetFVersion(p.Testcafe.Version).SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).
 			SetArtifacts(p.Artifacts).SetDocker(p.Docker).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults).
 			SetSlack(p.Notifications.Slack).SetSharding(testcafe.IsSharded(p.Suites)).SetLaunchOrder(p.Sauce.LaunchOrder)
-		tracker.Collect(cases.Title(language.English).String(fullCommandName(cmd)), props)
+		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()
 

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -151,7 +151,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags) (int, error) {
 		p.Sauce.Metadata.Tags = append(p.Sauce.Metadata.Tags, ci.GetTags()...)
 	}
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	tracker := segment.DefaultTracker
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -109,7 +109,7 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags) (int, error) {
 		p.Sauce.Metadata.Tags = append(p.Sauce.Metadata.Tags, ci.GetTags()...)
 	}
 
-	tracker := segment.New(!gFlags.disableUsageMetrics)
+	tracker := segment.DefaultTracker
 
 	defer func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -114,7 +115,7 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags) (int, error) {
 		props := usage.Properties{}
 		props.SetFramework("xcuitest").SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
 			SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults).SetSlack(p.Notifications.Slack).SetLaunchOrder(p.Sauce.LaunchOrder)
-		tracker.Collect(cases.Title(language.English).String(fullCommandName(cmd)), props)
+		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()
 

--- a/internal/cmd/storage/download.go
+++ b/internal/cmd/storage/download.go
@@ -28,7 +28,7 @@ func DownloadCommand() *cobra.Command {
 			return nil
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New(true)
+			tracker := segment.DefaultTracker
 
 			go func() {
 				tracker.Collect(

--- a/internal/cmd/storage/list.go
+++ b/internal/cmd/storage/list.go
@@ -70,7 +70,7 @@ func ListCommand() *cobra.Command {
 		},
 		Short: "Returns the list of files that have been uploaded to Sauce Storage.",
 		PreRun: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New(true)
+			tracker := segment.DefaultTracker
 
 			go func() {
 				tracker.Collect(

--- a/internal/cmd/storage/list.go
+++ b/internal/cmd/storage/list.go
@@ -7,8 +7,13 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/saucelabs/saucectl/internal/storage"
+	"github.com/saucelabs/saucectl/internal/usage"
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"os"
 	"time"
 )
@@ -64,6 +69,17 @@ func ListCommand() *cobra.Command {
 			"ls",
 		},
 		Short: "Returns the list of files that have been uploaded to Sauce Storage.",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			tracker := segment.New(true)
+
+			go func() {
+				tracker.Collect(
+					cases.Title(language.English).String(cmds.FullName(cmd)),
+					usage.Properties{}.SetFlags(cmd.Flags()),
+				)
+				_ = tracker.Close()
+			}()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			list, err := appsClient.List(storage.ListOptions{
 				Q:      query,

--- a/internal/cmd/storage/upload.go
+++ b/internal/cmd/storage/upload.go
@@ -31,7 +31,7 @@ func UploadCommand() *cobra.Command {
 			return nil
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			tracker := segment.New(true)
+			tracker := segment.DefaultTracker
 
 			go func() {
 				tracker.Collect(

--- a/internal/cmd/storage/upload.go
+++ b/internal/cmd/storage/upload.go
@@ -3,10 +3,15 @@ package storage
 import (
 	"errors"
 	"fmt"
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"github.com/saucelabs/saucectl/internal/files"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/saucelabs/saucectl/internal/storage"
+	"github.com/saucelabs/saucectl/internal/usage"
 	"github.com/schollz/progressbar/v3"
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"os"
 )
 
@@ -24,6 +29,17 @@ func UploadCommand() *cobra.Command {
 			}
 
 			return nil
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			tracker := segment.New(true)
+
+			go func() {
+				tracker.Collect(
+					cases.Title(language.English).String(cmds.FullName(cmd)),
+					usage.Properties{}.SetFlags(cmd.Flags()),
+				)
+				_ = tracker.Close()
+			}()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			file, err := os.Open(args[0])

--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -12,6 +12,9 @@ import (
 	"gopkg.in/segmentio/analytics-go.v3"
 )
 
+// DefaultTracker is the default Tracker.
+var DefaultTracker = New(true)
+
 // Tracker is the segment implementation for usage.Tracker.
 type Tracker struct {
 	client  analytics.Client


### PR DESCRIPTION
## Proposed changes
Move the usage tracking flag & instantiation to a global level, since the tracker is used across all commands (or at least, it can be used that way).

Also removed the obsolete usage tracking of slack events. Aside from being obsolete, the usage tracker was never meant to track individual events or features within saucectl. Its purpose is to track command usage (things that you can't necessarily see on the server side).