### PR TITLE
Filter sharded suites by 

### DIFF
--- a/internal/code/parser.go
+++ b/internal/code/parser.go
@@ -12,13 +12,13 @@ var (
 	reSingleTagPattern = regexp.MustCompile(`tags\s*:\s*['"](.*?)["']`)
 )
 
+// TestCase describes a cypress test case parsed from a cypress spec file.
 type TestCase struct {
+	// Title is the name of the test case, the first argument to `it|test`.
 	Title string
+	// Tags is an optional list of tags. This is simply a space delimited
+	// concatenation of all tags defined for the testcase.
 	Tags  string
-}
-
-type TestFile struct {
-	TestCases []TestCase
 }
 
 // Parse takes the contents of a test file and parses testcases

--- a/internal/code/parser.go
+++ b/internal/code/parser.go
@@ -6,10 +6,10 @@ import (
 )
 
 var (
-	reTestCasePattern  = regexp.MustCompile(` *(?:it|test)(?:\.\w+)?\(([\s\S]*?,\s*\()`)
+	reTestCasePattern  = regexp.MustCompile(`(?m)^ *(?:it|test)(?:\.\w+)?\(([\s\S]*?,\s*\()`)
 	reTitlePattern     = regexp.MustCompile(`["'\x60](.*)["'\x60], *[{(]`)
-	reMultiTagPattern  = regexp.MustCompile(`tags:\s*\[([\s\S]*?)\]`)
-	reSingleTagPattern = regexp.MustCompile(`tags:\s*['"](.*?)["']`)
+	reMultiTagPattern  = regexp.MustCompile(`tags\s*:\s*\[([\s\S]*?)\]`)
+	reSingleTagPattern = regexp.MustCompile(`tags\s*:\s*['"](.*?)["']`)
 )
 
 type TestCase struct {

--- a/internal/code/parser.go
+++ b/internal/code/parser.go
@@ -5,14 +5,20 @@ import (
 	"strings"
 )
 
+// Functions to parse cypress spec files for testcases and their metadata (e.g.
+// test titles and tags).
+// The general strategy is to parse in multiple passes; the first pass extracts
+// testcase definitions (e.g. it('some test title', { tags: '@tag' }, () => ...)
+// and subsequent passes extract the titles and tags.
+
 var (
-	reTestCasePattern  = regexp.MustCompile(`(?m)^ *(?:it|test)(?:\.\w+)?\(([\s\S]*?,\s*\()`)
-	reTitlePattern     = regexp.MustCompile(`["'\x60](.*)["'\x60], *[{(]`)
+	reTestCasePattern  = regexp.MustCompile(`(?m)^ *(?:it|test)(?:\.\w+)?(\([\s\S]*?,\s*(?:function)?\s*\()`)
+	reTitlePattern     = regexp.MustCompile(`\(["'\x60](.*?)["'\x60],\s*?(?:function)?|[{(]`)
 	reMultiTagPattern  = regexp.MustCompile(`tags\s*:\s*\[([\s\S]*?)\]`)
 	reSingleTagPattern = regexp.MustCompile(`tags\s*:\s*['"](.*?)["']`)
 )
 
-// TestCase describes a cypress test case parsed from a cypress spec file.
+// TestCase describes the metadata for a cypress test case parsed from a cypress spec file.
 type TestCase struct {
 	// Title is the name of the test case, the first argument to `it|test`.
 	Title string

--- a/internal/code/parser.go
+++ b/internal/code/parser.go
@@ -1,0 +1,68 @@
+package code
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	reTestCasePattern  = regexp.MustCompile(` *(?:it|test)(?:\.\w+)?\(([\s\S]*?,\s*\()`)
+	reTitlePattern     = regexp.MustCompile(`["'\x60](.*)["'\x60], *[{(]`)
+	reMultiTagPattern  = regexp.MustCompile(`tags:\s*\[([\s\S]*?)\]`)
+	reSingleTagPattern = regexp.MustCompile(`tags:\s*['"](.*?)["']`)
+)
+
+type TestCase struct {
+	Title string
+	Tags  string
+}
+
+type TestFile struct {
+	TestCases []TestCase
+}
+
+// Parse takes the contents of a test file and parses testcases
+func Parse(input string) []TestCase {
+	matches := reTestCasePattern.FindAllStringSubmatch(input, -1)
+
+	var testCases []TestCase
+	for _, m := range matches {
+		tc := TestCase{}
+		argSubMatch := m[1]
+
+		tc.Title = parseTitle(argSubMatch)
+		tc.Tags = parseTags(argSubMatch)
+
+		testCases = append(testCases, tc)
+	}
+
+	return testCases
+}
+
+func parseTitle(input string) string {
+	titleMatch := reTitlePattern.FindStringSubmatch(input)
+	if titleMatch != nil {
+		return titleMatch[1]
+	}
+
+	return ""
+}
+
+func parseTags(input string) string {
+	var tags []string
+	tagMatch := reSingleTagPattern.FindStringSubmatch(input)
+	if tagMatch == nil {
+		tagMatch = reMultiTagPattern.FindStringSubmatch(input)
+	}
+	if tagMatch != nil {
+		rawTags := strings.Split(tagMatch[1], ",")
+		for _, t := range rawTags {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				tags = append(tags, strings.Trim(t, `"'`))
+			}
+		}
+		return strings.Join(tags, " ")
+	}
+	return ""
+}

--- a/internal/code/parser_test.go
+++ b/internal/code/parser_test.go
@@ -1,0 +1,194 @@
+package code
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_parseTitle(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name: "basic title match",
+			input: `it("test title", () => {`,
+			want: "test title",
+		},
+		{
+			name: "match with test object argument",
+			input: `'test title', { tags: ['config', 'some-other-tag'] }`,
+			want: "test title",
+		},
+		{
+			name: "nested quotation marks",
+			input: `'title "with nested" quotations', { tags: ['config', 'some-other-tag'] }`,
+			want: `title "with nested" quotations`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseTitle(tt.input); got != tt.want {
+				t.Errorf("parseTitle() = \"%v\", want \"%v\"", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseTags(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name: "no tags",
+			input: `it("test title", () => {`,
+			want: "",
+		},
+		{
+			name: "multi tag",
+			input: `'test title', { tags: ['tag1', 'tag2'] }`,
+			want: "tag1 tag2",
+		},
+		{
+			name: "single tag",
+			input: `'title', { tags: 'tag' }`,
+			want: `tag`,
+		},
+		{
+			name: "multiline definition",
+			input: `
+'title "with nested" quotations', { 
+  tags: [
+    'tag1', 
+	'tag2',
+  ],
+}`,
+			want: `tag1 tag2`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseTags(tt.input); got != tt.want {
+				t.Errorf("parseTags() = \"%v\", want \"%v\"", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []TestCase
+	}{
+		{
+			name: "basic test case match",
+			input: `
+it('test title', () => {
+  expect(true).to.be.true
+})
+`,
+			want: []TestCase {
+				{
+					Title: "test title",
+					Tags: "",
+				},
+			},
+		},
+		{
+			name: "parse test case with multiple tags",
+			input: `
+it("test title", { tags: ['@tag1', "@tag2"] }, () => {
+  expect(true).to.be.true
+})
+`,
+			want: []TestCase {
+				{
+					Title: "test title",
+					Tags: "@tag1 @tag2",
+				},
+			},
+		},
+		{
+			name: "parse test case with single tag",
+			input: `
+it("test title", { tags: '@tag1' }, () => {
+  expect(true).to.be.true
+})
+`,
+			want: []TestCase {
+				{
+					Title: "test title",
+					Tags: "@tag1",
+				},
+			},
+		},
+		{
+			name: "parse test case with complex test object",
+			input: `
+it("test title", {
+  tags: [
+    '@tag1', 
+    '@tag2'
+  ],
+}, () => {
+  expect(true).to.be.true
+})
+`,
+			want: []TestCase {
+				{
+					Title: "test title",
+					Tags: "@tag1 @tag2",
+				},
+			},
+		},
+		{
+			name: "parse multiple test cases",
+			input: `
+it("test title1", {
+  tags: [
+    '@tag1', 
+    '@tag2'
+  ],
+}, () => {
+  expect(true).to.be.true
+})
+it("test title2", {
+  "quoted key": "string",
+  tags: '@tag1', 
+  field1: 1,
+  field2: {
+	nest1: 1,
+	nest2: [1, 2, 3],
+  }
+}, () => {
+  expect(true).to.be.true
+})
+
+`,
+			want: []TestCase {
+				{
+					Title: "test title1",
+					Tags: "@tag1 @tag2",
+				},
+				{
+					Title: "test title2",
+					Tags: "@tag1",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Parse(tt.input); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseTitle() = \"%v\", want \"%v\"", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cypress/grep/grep.go
+++ b/internal/cypress/grep/grep.go
@@ -1,3 +1,7 @@
+// Package grep implements functions to parse and filter spec files by cypress-grep expressions.
+//
+// See https://www.npmjs.com/package/@cypress/grep for details on the specific syntax
+// of cypress-grep expressions.
 package grep
 
 import (

--- a/internal/cypress/grep/matcher.go
+++ b/internal/cypress/grep/matcher.go
@@ -3,7 +3,6 @@ package grep
 import (
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 
 	"github.com/saucelabs/saucectl/internal/code"
 )
@@ -16,12 +15,13 @@ func Match(rootDir string, files []string, title string) []string {
 		}
 
 		testcases := code.Parse(string(b))
+		expr := ParseGrepExp(title)
+
 		for _, tc := range testcases {
-			if strings.Contains(tc.Title, title) {
+			if expr.Eval(tc.Title) {
 				matched = append(matched, f)
 			}
 		}
-
 	}
 	return matched
 }

--- a/internal/cypress/grep/matcher.go
+++ b/internal/cypress/grep/matcher.go
@@ -1,0 +1,27 @@
+package grep
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/saucelabs/saucectl/internal/code"
+)
+
+func Match(rootDir string, files []string, title string) []string {
+	var matched []string
+	for _, f := range files {
+		b, err := ioutil.ReadFile(filepath.Join(rootDir, f))	
+		if err != nil {
+		}
+
+		testcases := code.Parse(string(b))
+		for _, tc := range testcases {
+			if strings.Contains(tc.Title, title) {
+				matched = append(matched, f)
+			}
+		}
+
+	}
+	return matched
+}

--- a/internal/cypress/grep/matcher.go
+++ b/internal/cypress/grep/matcher.go
@@ -7,18 +7,27 @@ import (
 	"github.com/saucelabs/saucectl/internal/code"
 )
 
-func Match(rootDir string, files []string, title string) []string {
+func Match(rootDir string, files []string, title string, tag string) []string {
 	var matched []string
 	for _, f := range files {
 		b, err := ioutil.ReadFile(filepath.Join(rootDir, f))	
 		if err != nil {
+			continue
 		}
 
 		testcases := code.Parse(string(b))
-		expr := ParseGrepExp(title)
+		grepExp := ParseGrepExp(title)
+		grepTagsExp := ParseGrepTagsExp(tag)
 
 		for _, tc := range testcases {
-			if expr.Eval(tc.Title) {
+			include := true
+			if title != "" {
+				include = include && grepExp.Eval(tc.Title)
+			}
+			if tag != "" {
+				include = include && grepTagsExp.Eval(tc.Tags)
+			}
+			if include {
 				matched = append(matched, f)
 			}
 		}

--- a/internal/cypress/grep/matcher.go
+++ b/internal/cypress/grep/matcher.go
@@ -7,8 +7,9 @@ import (
 	"github.com/saucelabs/saucectl/internal/code"
 )
 
-func Match(rootDir string, files []string, title string, tag string) []string {
-	var matched []string
+// Match finds the files whose contents match the grep expression in the title parameter
+// and the grep tag expression in the tag parameter.
+func Match(rootDir string, files []string, title string, tag string) (matched []string, unmatched []string) {
 	for _, f := range files {
 		b, err := ioutil.ReadFile(filepath.Join(rootDir, f))	
 		if err != nil {
@@ -29,8 +30,11 @@ func Match(rootDir string, files []string, title string, tag string) []string {
 			}
 			if include {
 				matched = append(matched, f)
+			} else {
+				unmatched = append(unmatched, f)
 			}
 		}
 	}
-	return matched
+
+	return matched, unmatched
 }

--- a/internal/cypress/grep/parser.go
+++ b/internal/cypress/grep/parser.go
@@ -1,92 +1,187 @@
 package grep
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
-type Predicate interface {
-	Match(input string) bool
+var reDelimiter = regexp.MustCompile(`[ ,]`)
+
+// Expression is an interface that represents a logical statement.
+type Expression interface {
+	// Eval evaluates the Expression against the input string.
+	Eval(input string) bool
 }
 
-type Query struct {
-	Search string
+// Partial represents an expression that wraps a string to be matched
+// and evaluates to true if that string is a partial substring of the input.
+type Partial struct {
+	Query  string
 	Invert bool
 }
 
+// Exact represents an expression that wraps a string to be matched
+// and evalutates to true if that string is an exact substring of the input.
+type Exact struct {
+	Query  string
+	Invert bool
+}
+
+// Any represents a composite expression that evaluates to true if any
+// child expression evalutes to true.
 type Any struct {
-	Predicates []Predicate
+	Expressions []Expression
 }
 
-type Every struct {
-	Predicates []Predicate
+// All represents a compositite expression thave evaluates to true if all
+// child expressions evaluate to true.
+type All struct {
+	Expressions []Expression
 }
 
-func (q Query) Match(input string) bool {
+func (q Partial) Eval(input string) bool {
 	if q.Invert {
-		return !strings.Contains(input, q.Search)
+		return !strings.Contains(input, q.Query)
 	}
-	return strings.Contains(input, q.Search)
+	return strings.Contains(input, q.Query)
 }
 
-func (a Any) Match(input string) bool {
-	result := false
-	for _, p := range a.Predicates {
-		result = result || p.Match(input)
-		if result {
-			break
-		}
-	}
-	return result
-}
+func (q Exact) Eval(input string) bool {
+	words := strings.Split(input, " ")
+	contains := false
 
-func (a *Any) Add(p Predicate) {
-	a.Predicates = append(a.Predicates, p)
-}
-
-func (e Every) Match(input string) bool {
-	result := true
-	for _, p := range e.Predicates {
-		result = result && p.Match(input)
-		if !result {
+	for _, w := range words {
+		if w == q.Query {
+			contains = true
 			break
 		}
 	}
 
-	return result
+	if q.Invert {
+		return !contains
+	}
+	return contains
 }
 
-func (e *Every) Add(p Predicate) {
-	e.Predicates = append(e.Predicates, p)
+func (a Any) Eval(input string) bool {
+	for _, p := range a.Expressions {
+		if p.Eval(input) {
+			return true
+		}
+	}
+	return false
 }
 
-func Parse(expression string) Predicate {
-	strs := strings.Split(expression, ";")
-	strs = trimAll(strs)
+func (a *Any) add(p Expression) {
+	a.Expressions = append(a.Expressions, p)
+}
+
+func (e All) Eval(input string) bool {
+	for _, p := range e.Expressions {
+		if !p.Eval(input) {
+			return false
+		}
+	}
+	return true
+}
+
+func (e *All) add(p Expression) {
+	e.Expressions = append(e.Expressions, p)
+}
+
+// ParseGrepExp parses a cypress-grep expression and returns an Expression.
+//
+// The returned Expression can be used to evaluate whether a given string
+// can match the expression.
+func ParseGrepExp(expr string) Expression {
+	strs := strings.Split(expr, ";")
+	strs = normalize(strs)
 
 	substringMatches := Any{}
-	invertedMatches := Every{}
+	invertedMatches := All{}
 	for _, s := range strs {
 		if strings.HasPrefix(s, "-") {
-			invertedMatches.Add(Query{
-				Search: s[1:],
+			invertedMatches.add(Partial{
+				Query:  s[1:],
 				Invert: true,
 			})
 			continue
 		}
-		substringMatches.Add(Query{
-			Search: s,
+		substringMatches.add(Partial{
+			Query: s,
 		})
 	}
 
-	parsed := Every{}
-	parsed.Add(invertedMatches)
-	if len(substringMatches.Predicates) > 0 {
-		parsed.Add(substringMatches)
+	parsed := All{}
+	parsed.add(invertedMatches)
+	if len(substringMatches.Expressions) > 0 {
+		parsed.add(substringMatches)
 	}
 	return parsed
 }
 
-func trimAll(strs []string) []string {
+// ParseGrepTagsExp parses a cypress-grep tag expression.
+//
+// The returned Expression can be used to evaluate whether a given string
+// can match the expression.
+func ParseGrepTagsExp(expr string) Expression {
+	exprs := reDelimiter.Split(expr, -1)
+	exprs = normalize(exprs)
+
+	var parsed Any
+	var not []Expression
+
+	// Find any global inverted expressions first
+	for _, e := range exprs {
+		if strings.HasPrefix(e, "--") {
+			not = append(not, Exact{
+				Query:  e[2:],
+				Invert: true,
+			})
+		}
+	}
+
+	for _, e := range exprs {
+		if strings.HasPrefix(e, "--") {
+			continue
+		}
+
+		matcher := All{}
+		patterns := strings.Split(e, "+")
+		patterns = normalize(patterns)
+		for _, p := range patterns {
+			invert := false
+			if strings.HasPrefix(p, "-") {
+				invert = true
+				p = p[1:]
+			}
+
+			matcher.add(Exact{
+				Query:  p,
+				Invert: invert,
+			})
+		}
+
+		// Add any globally inverted expressions found above
+		for _, n := range not {
+			matcher.add(n)
+		}
+
+		parsed.add(matcher)
+	}
+
+	return parsed
+}
+
+// normalize trims leading and trailing whitespace from a slice of strings
+// and filters out any strings that contain only whitespace.
+func normalize(strs []string) []string {
 	var all []string
 	for _, s := range strs {
+		trimmed := strings.TrimSpace(s)
+		if trimmed == "" {
+			continue
+		}
 		all = append(all, strings.TrimSpace(s))
 	}
 	return all

--- a/internal/cypress/grep/parser.go
+++ b/internal/cypress/grep/parser.go
@@ -39,25 +39,25 @@ type All struct {
 	Expressions []Expression
 }
 
-func (q Partial) Eval(input string) bool {
-	if q.Invert {
-		return !strings.Contains(input, q.Query)
+func (p Partial) Eval(input string) bool {
+	if p.Invert {
+		return !strings.Contains(input, p.Query)
 	}
-	return strings.Contains(input, q.Query)
+	return strings.Contains(input, p.Query)
 }
 
-func (q Exact) Eval(input string) bool {
+func (e Exact) Eval(input string) bool {
 	words := strings.Split(input, " ")
 	contains := false
 
 	for _, w := range words {
-		if w == q.Query {
+		if w == e.Query {
 			contains = true
 			break
 		}
 	}
 
-	if q.Invert {
+	if e.Invert {
 		return !contains
 	}
 	return contains
@@ -76,8 +76,8 @@ func (a *Any) add(p Expression) {
 	a.Expressions = append(a.Expressions, p)
 }
 
-func (e All) Eval(input string) bool {
-	for _, p := range e.Expressions {
+func (a All) Eval(input string) bool {
+	for _, p := range a.Expressions {
 		if !p.Eval(input) {
 			return false
 		}
@@ -85,8 +85,8 @@ func (e All) Eval(input string) bool {
 	return true
 }
 
-func (e *All) add(p Expression) {
-	e.Expressions = append(e.Expressions, p)
+func (a *All) add(p Expression) {
+	a.Expressions = append(a.Expressions, p)
 }
 
 // ParseGrepExp parses a cypress-grep expression and returns an Expression.

--- a/internal/cypress/grep/parser.go
+++ b/internal/cypress/grep/parser.go
@@ -1,0 +1,93 @@
+package grep
+
+import "strings"
+
+type Predicate interface {
+	Match(input string) bool
+}
+
+type Query struct {
+	Search string
+	Invert bool
+}
+
+type Any struct {
+	Predicates []Predicate
+}
+
+type Every struct {
+	Predicates []Predicate
+}
+
+func (q Query) Match(input string) bool {
+	if q.Invert {
+		return !strings.Contains(input, q.Search)
+	}
+	return strings.Contains(input, q.Search)
+}
+
+func (a Any) Match(input string) bool {
+	result := false
+	for _, p := range a.Predicates {
+		result = result || p.Match(input)
+		if result {
+			break
+		}
+	}
+	return result
+}
+
+func (a *Any) Add(p Predicate) {
+	a.Predicates = append(a.Predicates, p)
+}
+
+func (e Every) Match(input string) bool {
+	result := true
+	for _, p := range e.Predicates {
+		result = result && p.Match(input)
+		if !result {
+			break
+		}
+	}
+
+	return result
+}
+
+func (e *Every) Add(p Predicate) {
+	e.Predicates = append(e.Predicates, p)
+}
+
+func Parse(expression string) Predicate {
+	strs := strings.Split(expression, ";")
+	strs = trimAll(strs)
+
+	substringMatches := Any{}
+	invertedMatches := Every{}
+	for _, s := range strs {
+		if strings.HasPrefix(s, "-") {
+			invertedMatches.Add(Query{
+				Search: s[1:],
+				Invert: true,
+			})
+			continue
+		}
+		substringMatches.Add(Query{
+			Search: s,
+		})
+	}
+
+	parsed := Every{}
+	parsed.Add(invertedMatches)
+	if len(substringMatches.Predicates) > 0 {
+		parsed.Add(substringMatches)
+	}
+	return parsed
+}
+
+func trimAll(strs []string) []string {
+	var all []string
+	for _, s := range strs {
+		all = append(all, strings.TrimSpace(s))
+	}
+	return all
+}

--- a/internal/cypress/grep/parser.go
+++ b/internal/cypress/grep/parser.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 )
 
+// Functions to parse cypress-grep expressions.
+// cypress-grep expressions can include simple logical operations (e.g.
+// NOT, AND, OR). These expressions are parsed into Expressions that are
+// logical predicates that evaluate to true or false depending if the expression matches
+// a given input string.
+
 var reDelimiter = regexp.MustCompile(`[ ,]`)
 
 // Expression is an interface that represents a logical statement.
@@ -33,7 +39,7 @@ type Any struct {
 	Expressions []Expression
 }
 
-// All represents a compositite expression thave evaluates to true if all
+// All represents a composite expression thave evaluates to true if all
 // child expressions evaluate to true.
 type All struct {
 	Expressions []Expression

--- a/internal/cypress/grep/parser.go
+++ b/internal/cypress/grep/parser.go
@@ -40,10 +40,11 @@ type All struct {
 }
 
 func (p Partial) Eval(input string) bool {
+	contains := strings.Contains(input, p.Query)
 	if p.Invert {
-		return !strings.Contains(input, p.Query)
+		return !contains
 	}
-	return strings.Contains(input, p.Query)
+	return contains
 }
 
 func (e Exact) Eval(input string) bool {

--- a/internal/cypress/grep/parser_test.go
+++ b/internal/cypress/grep/parser_test.go
@@ -1,0 +1,91 @@
+package grep
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	type testCase struct {
+		input string
+		want  bool
+	}
+	tests := []struct {
+		name       string
+		expression string
+		testCases  []testCase
+	}{
+		{
+			name:       "Simple expression",
+			expression: "title",
+			testCases: []testCase{
+				{
+					input: "a test title",
+					want:  true,
+				},
+				{
+					input: "another test",
+					want:  false,
+				},
+			},
+		},
+		{
+			name:       "Inverted expression",
+			expression: "-title",
+			testCases: []testCase{
+				{
+					input: "a test title",
+					want:  false,
+				},
+				{
+					input: "another test",
+					want:  true,
+				},
+			},
+		},
+		{
+			name:       "OR matching",
+			expression: "title; test",
+			testCases: []testCase{
+				{
+					input: "a test title",
+					want:  true,
+				},
+				{
+					input: "another test",
+					want:  true,
+				},
+				{
+					input: "should not match",
+					want:  false,
+				},
+			},
+		},
+		{
+			name:       "complex matching",
+			expression: "test; -title",
+			testCases: []testCase{
+				{
+					input: "a test title",
+					want:  false,
+				},
+				{
+					input: "another test",
+					want:  true,
+				},
+				{
+					input: "should match this test",
+					want:  true,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Parse(tt.expression)
+			for _, tc := range tt.testCases {
+				if got := p.Match(tc.input); got != tc.want {
+					t.Errorf("expression \"%s\" should match \"%s\"", tt.expression, tc.input)
+				}
+			}
+		})
+	}
+}

--- a/internal/cypress/grep/parser_test.go
+++ b/internal/cypress/grep/parser_test.go
@@ -2,7 +2,138 @@ package grep
 
 import "testing"
 
-func TestParse(t *testing.T) {
+func TestParseGrepTagsExp(t *testing.T) {
+	type testCase struct {
+		input string
+		want  bool
+	}
+	tests := []struct {
+		name       string
+		expression string
+		testCases  []testCase
+	}{
+		{
+			name:       "Simple expression",
+			expression: "@tag",
+			testCases: []testCase{
+				{
+					input: "@tag",
+					want:  true,
+				},
+				{
+					input: "@tag1",
+					want:  false,
+				},
+			},
+		},
+		{
+			name:       "AND matching",
+			expression: "@tag1+@tag2",
+			testCases: []testCase{
+				{
+					input: "@tag1",
+					want:  false,
+				},
+				{
+					input: "@tag1 @tag2",
+					want:  true,
+				},
+			},
+		},
+		{
+			name:       "OR matching",
+			expression: "@tag1 @tag2",
+			testCases: []testCase{
+				{
+					input: "@tag1 @anotherTag",
+					want:  true,
+				},
+				{
+					input: "@tag2 @anotherTag",
+					want:  true,
+				},
+				{
+					input: "@anotherTag",
+					want:  false,
+				},
+			},
+		},
+		{
+			name:       "inverted tag",
+			expression: "-@tag1",
+			testCases: []testCase{
+				{
+					input: "@tag1 @tag2",
+					want:  false,
+				},
+				{
+					input: "@tag2",
+					want:  true,
+				},
+			},
+		},
+		{
+			name:       "NOT expression",
+			// This expression is equivalent to @smoke+-@slow @e2e+-@slow
+			expression: "@smoke @e2e --@slow",
+			testCases: []testCase{
+				{
+					input: "@smoke @slow",
+					want:  false,
+				},
+				{
+					input: "@smoke",
+					want:  true,
+				},
+				{
+					input: "@slow",
+					want:  false,
+				},
+			},
+		},
+		{
+			name:       "empty expression",
+			expression: "",
+			testCases: []testCase{
+				{
+					input: "@smoke @slow",
+					want:  false,
+				},
+				{
+					input: "",
+					want:  false,
+				},
+			},
+		},
+		{
+			name:       "should handle slightly malformed expressions",
+			expression: "    +@smoke",
+			testCases: []testCase{
+				{
+					input: "@smoke @slow",
+					want:  true,
+				},
+				{
+					input: "",
+					want:  false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := ParseGrepTagsExp(tt.expression)
+			for _, tc := range tt.testCases {
+				if got := p.Eval(tc.input); got != tc.want {
+					t.Errorf("expression \"%s\" should match \"%s\"", tt.expression, tc.input)
+				}
+			}
+		})
+	}
+}
+
+func TestParseGrepExp(t *testing.T) {
 	type testCase struct {
 		input string
 		want  bool
@@ -80,9 +211,9 @@ func TestParse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := Parse(tt.expression)
+			p := ParseGrepExp(tt.expression)
 			for _, tc := range tt.testCases {
-				if got := p.Match(tc.input); got != tc.want {
+				if got := p.Eval(tc.input); got != tc.want {
 					t.Errorf("expression \"%s\" should match \"%s\"", tt.expression, tc.input)
 				}
 			}

--- a/internal/cypress/grep/parser_test.go
+++ b/internal/cypress/grep/parser_test.go
@@ -24,6 +24,10 @@ func TestParseGrepTagsExp(t *testing.T) {
 					input: "@tag1",
 					want:  false,
 				},
+				{
+					input: "",
+					want: false,
+				},
 			},
 		},
 		{
@@ -70,6 +74,10 @@ func TestParseGrepTagsExp(t *testing.T) {
 					input: "@tag2",
 					want:  true,
 				},
+				{
+					input: "",
+					want: true,
+				},
 			},
 		},
 		{
@@ -114,7 +122,7 @@ func TestParseGrepTagsExp(t *testing.T) {
 					want:  true,
 				},
 				{
-					input: "",
+					input: "@slow",
 					want:  false,
 				},
 			},

--- a/internal/cypress/v1/config.go
+++ b/internal/cypress/v1/config.go
@@ -275,9 +275,12 @@ func shardSuites(rootDir string, suites []Suite, ccy int) ([]Suite, error) {
 		if grepExists || grepTagsExists {
 			var unmatched []string
 			files, unmatched = grep.Match(rootDir, files, grepExp, grepTagsExp)
-			if len(unmatched) > 0 {
-				log.Info().Msg(fmt.Sprintf("Files filtered out by grep (\"%s\") and grepTags(\"%s\"): %s", grepExp, grepTagsExp, unmatched))
+			if len(files) == 0 {
+				log.Warn().Str("suiteName", s.Name).Str("grep", grepExp).Str("grepTags", grepTagsExp).Msg(fmt.Sprintf("No files match the configured grep and grepTags expressions"))
+			} else if len(unmatched) > 0 {
+				log.Info().Str("suiteName", s.Name).Str("grep", grepExp).Str("grepTags", grepTagsExp).Msg(fmt.Sprintf("Files filtered out by grep and grepTags: [%s]", unmatched))
 			}
+
 		}
 
 		excludedFiles, err := fpath.FindFiles(rootDir, s.Config.ExcludeSpecPattern, fpath.FindByShellPattern)

--- a/internal/cypress/v1/config.go
+++ b/internal/cypress/v1/config.go
@@ -269,12 +269,14 @@ func shardSuites(rootDir string, suites []Suite, ccy int) ([]Suite, error) {
 		}
 
 		// TODO: Opt in to grep/grepTags filtering explicitly?
-		if s.Config.Env["grep"] != "" || s.Config.Env["grepTags"] != ""{
+		grepExp, grepExists := s.Config.Env["grep"]
+		grepTagsExp, grepTagsExists := s.Config.Env["grepTags"]
+
+		if grepExists || grepTagsExists {
 			var unmatched []string
-			files, unmatched = grep.Match(rootDir, files, s.Config.Env["grep"], s.Config.Env["grepTags"])
+			files, unmatched = grep.Match(rootDir, files, grepExp, grepTagsExp)
 			if len(unmatched) > 0 {
-				// TODO: Log out what files were filtered and why
-				log.Info().Msg("")
+				log.Info().Msg(fmt.Sprintf("Files filtered out by grep (\"%s\") and grepTags(\"%s\"): %s", grepExp, grepTagsExp, unmatched))
 			}
 		}
 

--- a/internal/cypress/v1/config.go
+++ b/internal/cypress/v1/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/concurrency"
 	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/cypress/grep"
 	"github.com/saucelabs/saucectl/internal/cypress/suite"
 	"github.com/saucelabs/saucectl/internal/fpath"
 	"github.com/saucelabs/saucectl/internal/msg"
@@ -261,6 +262,11 @@ func shardSuites(rootDir string, suites []Suite, ccy int) ([]Suite, error) {
 		if err != nil {
 			return shardedSuites, err
 		}
+
+		if s.Config.Env["grep"] != "" {
+			files = grep.Match(rootDir, files, s.Config.Env["grep"])
+		}
+
 		if len(files) == 0 {
 			msg.SuiteSplitNoMatch(s.Name, rootDir, s.Config.SpecPattern)
 			return []Suite{}, fmt.Errorf("suite '%s' patterns have no matching files", s.Name)

--- a/internal/cypress/v1/config.go
+++ b/internal/cypress/v1/config.go
@@ -263,8 +263,8 @@ func shardSuites(rootDir string, suites []Suite, ccy int) ([]Suite, error) {
 			return shardedSuites, err
 		}
 
-		if s.Config.Env["grep"] != "" {
-			files = grep.Match(rootDir, files, s.Config.Env["grep"])
+		if s.Config.Env["grep"] != "" || s.Config.Env["grepTags"] != ""{
+			files = grep.Match(rootDir, files, s.Config.Env["grep"], s.Config.Env["grepTags"])
 		}
 
 		if len(files) == 0 {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
When sharding and running cypress tests against sauce with the `@cypress/grep` plugin, we don't know until test execution time whether a sharded spec will be filtered by the given cypress-grep expressions. In the case that the spec to be executed is excluded, saucectl still allocates a job that ends up performing no work.

This change will allow saucectl to parse and filter according to any cypress-grep expression provided in the config when sharding the suite. Files that don't match the grep expressions will not be allocated for execution on sauce.

As is, this behaviour is automatic for suites already configured to use `@cypress-grep`. Given this suite definition:

```yml
- name: Grepped and sharded
   browser: chrome
   platformName: Windows 11
   shard: spec
   config:
     specPattern: [ "cypress/e2e/**/*.*" ]
     env:
       grep: "dom tests"
       grepTags: "-@slow"
```

Spec files that match the pattern `cypress/e2e/**/*.*` and have `dom tests` in their title and do not have the `@slow` tag will be executed. The `grep` and `grepTags` env vars are read by the `@cypress/grep` plugin at test execution time as well.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

The big caveat here is that the way the spec files are parsed is just by regex. Since this change does not add any lexical analysis, there will be edge cases that will cause some false positives. The main one is commented out test cases will cause false positive matches. But in general, considering how difficult it is to craft regexes for this purpose, I suspect many edge cases will surface over time.

Considering the above, another issue for consideration is whether to make this behaviour opt-in with a separate config option. 