### PR TITLE
Only permit empty titles, match strict on tags

### DIFF
--- a/internal/cypress/grep/grep.go
+++ b/internal/cypress/grep/grep.go
@@ -42,10 +42,9 @@ func MatchFiles(sys fs.FS, files []string, title string, tag string) (matched []
 }
 
 func match(titleExp Expression, tagsExp Expression, title string, tags string) bool {
-	// Be permissive if the title or tags are empty since that may be a result
-	// of a code parsing issue.
+	// Allow empty title to match. This mimics the behaviour of cypress-grep.
 	titleMatch := title == "" || titleExp.Eval(title)
-	tagMatch := tags == "" || tagsExp.Eval(tags)
+	tagMatch := tagsExp.Eval(tags)
 
 	return titleMatch && tagMatch
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Turns out allowing both empty titles **and** empty tags was too permissive and effectively does almost no filtering.

cypress-grep explicitly matches empty titles so just mimic that specific behaviour. If we want to account for parsing bugs we might want to add some kind of error state when parsing code to detect this specific case.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->