### PR TITLE
Fix: Tunnel in API Testing

### DIFF
--- a/internal/apitesting/async_test.go
+++ b/internal/apitesting/async_test.go
@@ -106,7 +106,7 @@ func TestClient_RunEphemeralAsync(t *testing.T) {
 				test:    TestRequest{},
 			},
 			assertRequest: func(t *testing.T, r *http.Request) {
-				assert.Equal(t, "/api-testing/rest/v4/dummyHookId/tests/_exec?buildId=generatedBuildId&tunnelId=tunnelId", r.RequestURI)
+				assert.Equal(t, "/api-testing/rest/v4/dummyHookId/tests/_exec?buildId=generatedBuildId&tunnelId=dummyUser%3AtunnelId", r.RequestURI)
 			},
 			reply: []byte(`{"contextIds":["221270ac-0229-49d1-9025-251a10e9133d"],"eventIds":["c4ca4238a0b923820dcc509a"],"taskId":"6ddf80b7-9753-4802-992b-d42948cdb99f","testIds":["c20ad4d76fe97759aa27a0c9"]}`),
 			want: AsyncResponse{

--- a/internal/apitesting/client.go
+++ b/internal/apitesting/client.go
@@ -166,9 +166,11 @@ func (c *Client) composeURL(path string, buildID string, format string, tunnel c
 	}
 
 	if tunnel.Name != "" {
-		t := tunnel.Name
+		var t string
 		if tunnel.Owner != "" {
-			t = fmt.Sprintf("%s:%s", t, tunnel.Owner)
+			t = fmt.Sprintf("%s:%s", tunnel.Owner, tunnel.Name)
+		} else {
+			t = fmt.Sprintf("%s:%s", c.Username, tunnel.Name)
 		}
 
 		query.Set("tunnelId", t)

--- a/internal/apitesting/client_test.go
+++ b/internal/apitesting/client_test.go
@@ -288,7 +288,7 @@ func TestClient_composeURL(t *testing.T) {
 					Owner: "tunnelOwner",
 				},
 			},
-			want: "/dummy/path?tunnelId=tunnelId%3AtunnelOwner",
+			want: "/dummy/path?tunnelId=tunnelOwner%3AtunnelId",
 		},
 		{
 			name: "Path with tunnel without owner",
@@ -298,7 +298,7 @@ func TestClient_composeURL(t *testing.T) {
 					Name: "tunnelId",
 				},
 			},
-			want: "/dummy/path?tunnelId=tunnelId",
+			want: "/dummy/path?tunnelId=dummyUsername%3AtunnelId",
 		},
 		{
 			name: "Path with taskId",
@@ -309,7 +309,9 @@ func TestClient_composeURL(t *testing.T) {
 			want: "/dummy/path?taskId=taskId",
 		},
 	}
-	c := &Client{}
+	c := &Client{
+		Username: "dummyUsername",
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := c.composeURL(tt.args.path, tt.args.buildID, tt.args.format, tt.args.tunnel, tt.args.taskID); got != tt.want {


### PR DESCRIPTION
## Proposed changes

The current way `saucectl` is providing tunnel name to API Testing is incorrect.
It needs to be `tunnelOwner:tunnelName` instead of `tunnelName:tunnelOwner`.
Also, when no owner is specified (meaning current user), `username:tunnelName` must be provided.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->