### PR TITLE
Re-queue jobs asynchronously

### DIFF
--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -330,9 +330,13 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 
 		if opts.Attempt < opts.Retries && !jobData.Passed && !skipped {
 			log.Warn().Err(err).Msg("Suite errored.")
-			opts.Attempt++
-			jobOpts <- opts
-			log.Info().Str("suite", opts.DisplayName).Str("attempt", fmt.Sprintf("%d of %d", opts.Attempt+1, opts.Retries+1)).Msg("Retrying suite.")
+			go func(opt job.StartOptions) {
+				opt.Attempt++
+				log.Info().Str("suite", opt.DisplayName).
+					Str("attempt", fmt.Sprintf("%d of %d", opt.Attempt+1, opt.Retries+1)).
+					Msg("Retrying suite.")
+				jobOpts <- opt
+			}(opts)
 			continue
 		}
 


### PR DESCRIPTION
## Proposed changes

Retrying jobs when _concurrency_ is lower than the number of queued up jobs would cause a jam/deadlock since the channel is full. With this change, jobs will be re-queued asynchronously.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
