### PR TITLE
Implement artifact downloads for image runner

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -2613,6 +2613,11 @@
         "title": "saucectl image runner configuration",
         "description": "Configuration file for running container images using saucectl",
         "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/allOf/0/then/allOf/0"
+          }
+        ],
         "definitions": {
           "suite": {
             "description": "The set of properties providing details about how to run the container.",

--- a/api/v1alpha/framework/imagerunner.schema.json
+++ b/api/v1alpha/framework/imagerunner.schema.json
@@ -3,6 +3,11 @@
   "title": "saucectl image runner configuration",
   "description": "Configuration file for running container images using saucectl",
   "type": "object",
+  "allOf": [
+    {
+      "$ref": "../subschema/artifacts.schema.json"
+    }
+  ],
   "definitions": {
     "suite": {
       "description": "The set of properties providing details about how to run the container.",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -422,7 +422,9 @@ func GetSuiteArtifactFolder(suiteName string, cfg ArtifactDownload) (string, err
 	}
 	suiteName = fmt.Sprintf("%s.%d", suiteName, maxVersion+1)
 
-	return filepath.Join(cfg.Directory, suiteName), nil
+	target := filepath.Join(cfg.Directory, suiteName)
+
+	return target, os.MkdirAll(target, 0755)
 }
 
 // ValidateVisibility checks that the user specified job visibility is valid

--- a/internal/imagerunner/config.go
+++ b/internal/imagerunner/config.go
@@ -16,6 +16,7 @@ type Project struct {
 	Defaults       Defaults           `yaml:"defaults" json:"defaults"`
 	Sauce          config.SauceConfig `yaml:"sauce,omitempty" json:"sauce"` // The only field that's used within 'sauce' is region.
 	Suites         []Suite            `yaml:"suites,omitempty" json:"suites"`
+	Artifacts      config.Artifacts   `yaml:"artifacts,omitempty" json:"artifacts"`
 }
 
 type Defaults struct {

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -77,5 +77,6 @@ type Service interface {
 
 // ArtifactDownloader represents the interface for downloading artifacts.
 type ArtifactDownloader interface {
+	// DownloadArtifact downloads artifacts and returns a list of what was downloaded.
 	DownloadArtifact(jobID, suiteName string, realDevice bool) []string
 }

--- a/internal/rdc/client.go
+++ b/internal/rdc/client.go
@@ -497,10 +497,6 @@ func (c *Client) DownloadArtifact(jobID, suiteName string, realDevice bool) []st
 		log.Error().Msgf("Unable to create artifacts folder (%v)", err)
 		return []string{}
 	}
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		log.Error().Msgf("Unable to create %s to fetch artifacts (%v)", targetDir, err)
-		return []string{}
-	}
 
 	files, err := c.GetJobAssetFileNames(context.Background(), jobID, realDevice)
 	if err != nil {

--- a/internal/resto/client.go
+++ b/internal/resto/client.go
@@ -452,10 +452,6 @@ func (c *Client) DownloadArtifact(jobID, suiteName string, realDevice bool) []st
 		log.Error().Msgf("Unable to create artifacts folder (%v)", err)
 		return []string{}
 	}
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		log.Error().Msgf("Unable to create %s to fetch artifacts (%v)", targetDir, err)
-		return []string{}
-	}
 	files, err := c.GetJobAssetFileNames(context.Background(), jobID, realDevice)
 	if err != nil {
 		log.Error().Msgf("Unable to fetch artifacts list (%v)", err)


### PR DESCRIPTION
## Proposed changes
Allows the user the download artifacts at the end of a run for image based executions.
This is the same concept we already have for playwright & co.

This PR was implemented against a draft API that does not exist yet and can therefore not be fully vetted, but the general business logic should remain largely unchanged.