### PR TITLE
API-Testing: Rely on ProjectName instead of HookID

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -2379,6 +2379,14 @@
                   "description": "Your project's hook ID, which you can create and/or retrieve from your project's Webhooks tab.",
                   "type": "string"
                 },
+                "projectName": {
+                  "description": "Your project's name.",
+                  "type": "string"
+                },
+                "testMatch": {
+                  "description": "",
+                  "type": "array"
+                },
                 "tests": {
                   "description": "A list of test IDs to run for the project defined by hookId.",
                   "type": "array"
@@ -2388,9 +2396,20 @@
                   "type": "array"
                 }
               },
+              "oneOf": [
+                {
+                  "required": [
+                    "projectName"
+                  ]
+                },
+                {
+                  "required": [
+                    "hookId"
+                  ]
+                }
+              ],
               "required": [
-                "name",
-                "hookId"
+                "name"
               ],
               "additionalProperties": false
             }

--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -2394,6 +2394,10 @@
                 "tags": {
                   "description": "A test tag to run for the project defined by hookId.",
                   "type": "array"
+                },
+                "useRemoteTests": {
+                  "description": "Use tests stored in the cloud instead of the local ones.",
+                  "type": "boolean"
                 }
               },
               "oneOf": [

--- a/api/v1alpha/framework/apitest.schema.json
+++ b/api/v1alpha/framework/apitest.schema.json
@@ -46,6 +46,10 @@
           "tags": {
             "description": "A test tag to run for the project defined by hookId.",
             "type": "array"
+          },
+          "useRemoteTests": {
+            "description": "Use tests stored in the cloud instead of the local ones.",
+            "type": "boolean"
           }
         },
         "oneOf": [

--- a/api/v1alpha/framework/apitest.schema.json
+++ b/api/v1alpha/framework/apitest.schema.json
@@ -30,6 +30,15 @@
             "description": "Your project's hook ID, which you can create and/or retrieve from your project's Webhooks tab.",
             "type": "string"
           },
+          "projectName": {
+            "description": "Your project's name.",
+            "type": "string"
+          },
+          "testMatch": {
+            "description": "Paths to the api-testing test folders. Regex values are supported to indicate all folders of a certain directories, etc.",
+            "description": "",
+            "type": "array"
+          },
           "tests": {
             "description": "A list of test IDs to run for the project defined by hookId.",
             "type": "array"
@@ -39,9 +48,20 @@
             "type": "array"
           }
         },
+        "oneOf": [
+          {
+            "required": [
+              "projectName"
+            ]
+          },
+          {
+            "required": [
+              "hookId"
+            ]
+          }
+        ],
         "required": [
-          "name",
-          "hookId"
+          "name"
         ],
         "additionalProperties": false
       }

--- a/internal/apitest/config.go
+++ b/internal/apitest/config.go
@@ -88,11 +88,11 @@ func Validate(p Project) error {
 
 func validateSuite(suite Suite) error {
 	if suite.ProjectName == "" && suite.HookID == "" {
-		return errors.New("suites must have a projectName defined")
+		return errors.New(msg.NoProjectName)
 	}
 
 	if suite.ProjectName != "" && suite.HookID != "" {
-		return errors.New("suites must not have a projectName and a hookId defined")
+		return errors.New(msg.ProjectNameHookIDConflict)
 	}
 	return nil
 }

--- a/internal/apitest/config.go
+++ b/internal/apitest/config.go
@@ -30,6 +30,7 @@ type Project struct {
 type Suite struct {
 	Timeout        time.Duration `yaml:"timeout,omitempty"`
 	Name           string        `yaml:"name,omitempty"`
+	ProjectName    string        `yaml:"projectName,omitempty"`
 	HookID         string        `yaml:"hookId,omitempty"`
 	UseRemoteTests bool          `yaml:"useRemoteTests,omitempty"`
 	Tests          []string      `yaml:"tests,omitempty"`
@@ -86,8 +87,12 @@ func Validate(p Project) error {
 }
 
 func validateSuite(suite Suite) error {
-	if suite.HookID == "" {
-		return errors.New("suites must have a hookId defined")
+	if suite.ProjectName == "" && suite.HookID == "" {
+		return errors.New("suites must have a projectName defined")
+	}
+
+	if suite.ProjectName != "" && suite.HookID != "" {
+		return errors.New("suites must not have a projectName and a hookId defined")
 	}
 	return nil
 }

--- a/internal/apitest/runner.go
+++ b/internal/apitest/runner.go
@@ -279,7 +279,7 @@ func (r *Runner) runSuites() bool {
 }
 
 func (r *Runner) buildLocalTestDetails(hookID string, eventIDs []string, testNames []string, results chan []apitesting.TestResult) {
-	project, _ := r.Client.GetProject(context.Background(), hookID)
+	project, _ := r.Client.GetProjectByHookID(context.Background(), hookID)
 	for _, eventID := range eventIDs {
 		reportURL := fmt.Sprintf("%s/api-testing/project/%s/event/%s", r.Region.AppBaseURL(), project.ID, eventID)
 		log.Info().
@@ -301,7 +301,7 @@ func (r *Runner) buildLocalTestDetails(hookID string, eventIDs []string, testNam
 }
 
 func (r *Runner) fetchTestDetails(hookID string, eventIDs []string, testIDs []string, results chan []apitesting.TestResult) {
-	project, _ := r.Client.GetProject(context.Background(), hookID)
+	project, _ := r.Client.GetProjectByHookID(context.Background(), hookID)
 	for _, eventID := range eventIDs {
 		reportURL := fmt.Sprintf("%s/api-testing/project/%s/event/%s", r.Region.AppBaseURL(), project.ID, eventID)
 		log.Info().
@@ -324,7 +324,7 @@ func (r *Runner) fetchTestDetails(hookID string, eventIDs []string, testIDs []st
 }
 
 func (r *Runner) startPollingAsyncResponse(hookID string, eventIDs []string, results chan []apitesting.TestResult, pollMaximumWait time.Duration) {
-	project, _ := r.Client.GetProject(context.Background(), hookID)
+	project, _ := r.Client.GetProjectByHookID(context.Background(), hookID)
 
 	for _, eventID := range eventIDs {
 		go func(lEventID string) {

--- a/internal/apitest/runner.go
+++ b/internal/apitest/runner.go
@@ -474,7 +474,7 @@ func (r *Runner) ResolveHookIDs() error {
 			hooks, err := r.Client.GetHooks(context.Background(), project.ID)
 
 			if err != nil {
-				log.Error().Str("suiteName", s.Name).Err(err).Msg(msg.HookQueryFailure)
+				log.Err(err).Str("suiteName", s.Name).Msg(msg.HookQueryFailure)
 				hasErrors = true
 				continue
 			}

--- a/internal/apitest/runner.go
+++ b/internal/apitest/runner.go
@@ -281,7 +281,7 @@ func (r *Runner) runSuites() bool {
 }
 
 func (r *Runner) buildLocalTestDetails(hookID string, eventIDs []string, testNames []string, results chan []apitesting.TestResult) {
-	project, _ := r.Client.GetProjectByHookID(context.Background(), hookID)
+	project, _ := r.Client.GetProject(context.Background(), hookID)
 	for _, eventID := range eventIDs {
 		reportURL := fmt.Sprintf("%s/api-testing/project/%s/event/%s", r.Region.AppBaseURL(), project.ID, eventID)
 		log.Info().
@@ -303,7 +303,7 @@ func (r *Runner) buildLocalTestDetails(hookID string, eventIDs []string, testNam
 }
 
 func (r *Runner) fetchTestDetails(hookID string, eventIDs []string, testIDs []string, results chan []apitesting.TestResult) {
-	project, _ := r.Client.GetProjectByHookID(context.Background(), hookID)
+	project, _ := r.Client.GetProject(context.Background(), hookID)
 	for _, eventID := range eventIDs {
 		reportURL := fmt.Sprintf("%s/api-testing/project/%s/event/%s", r.Region.AppBaseURL(), project.ID, eventID)
 		log.Info().
@@ -326,7 +326,7 @@ func (r *Runner) fetchTestDetails(hookID string, eventIDs []string, testIDs []st
 }
 
 func (r *Runner) startPollingAsyncResponse(hookID string, eventIDs []string, results chan []apitesting.TestResult, pollMaximumWait time.Duration) {
-	project, _ := r.Client.GetProjectByHookID(context.Background(), hookID)
+	project, _ := r.Client.GetProject(context.Background(), hookID)
 
 	for _, eventID := range eventIDs {
 		go func(lEventID string) {

--- a/internal/apitest/runner.go
+++ b/internal/apitest/runner.go
@@ -447,7 +447,7 @@ func buildTestName(project apitesting.Project, test apitesting.Test) string {
 
 // ResolveHookIDs resolve, for each suite, the matching hookID.
 func (r *Runner) ResolveHookIDs() error {
-	hookIdMappings := map[string]apitesting.Hook{}
+	hookIDMappings := map[string]apitesting.Hook{}
 	hasErrors := false
 
 	projects, err := r.Client.GetProjects(context.Background())
@@ -468,7 +468,7 @@ func (r *Runner) ResolveHookIDs() error {
 			continue
 		}
 
-		hook := hookIdMappings[project.ID]
+		hook := hookIDMappings[project.ID]
 
 		if hook.Identifier == "" {
 			hooks, err := r.Client.GetHooks(context.Background(), project.ID)
@@ -485,7 +485,7 @@ func (r *Runner) ResolveHookIDs() error {
 			}
 
 			hook = hooks[0]
-			hookIdMappings[project.ID] = hooks[0]
+			hookIDMappings[project.ID] = hooks[0]
 		}
 
 		log.Info().Msgf(msg.HookUsedForSuite, hook.Identifier, s.Name)

--- a/internal/apitest/runner_test.go
+++ b/internal/apitest/runner_test.go
@@ -2,6 +2,7 @@ package apitest
 
 import (
 	"github.com/saucelabs/saucectl/internal/apitesting"
+	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/saucelabs/saucectl/internal/report"
 	"github.com/saucelabs/saucectl/internal/tunnel"
@@ -448,7 +449,7 @@ func TestRunner_ResolveHookIDs(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "failed to get some suites associated hookIDs",
+			wantErr: msg.FailedToPrepareSuites,
 		},
 		{
 			name: "Project with single Hooks",
@@ -518,7 +519,7 @@ func TestRunner_ResolveHookIDs(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "failed to get some suites associated hookIDs",
+			wantErr: msg.FailedToPrepareSuites,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/apitest/runner_test.go
+++ b/internal/apitest/runner_test.go
@@ -2,6 +2,9 @@ package apitest
 
 import (
 	"github.com/saucelabs/saucectl/internal/apitesting"
+	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/report"
+	"github.com/saucelabs/saucectl/internal/tunnel"
 	"github.com/stretchr/testify/assert"
 	"gotest.tools/v3/fs"
 	"net/http"
@@ -386,4 +389,162 @@ func TestRunner_runLocalTests(t *testing.T) {
 			ExecutionTimeSeconds: 31,
 		},
 	}, results)
+}
+
+func TestRunner_ResolveHookIDs(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		switch r.URL.Path {
+		case "/api-testing/api/project":
+			completeStatusResp := []byte(`[{"id":"noHooks","name":"Project NoHooks"},{"id":"single","name":"Project SingleHook"},{"id":"multiple","name":"Project MultipleHooks"},{"id":"buggy","name":"Project BuggyHooks"}]`)
+			_, err = w.Write(completeStatusResp)
+		case "/api-testing/api/project/noHooks/hook":
+			completeStatusResp := []byte(`[]`)
+			_, err = w.Write(completeStatusResp)
+		case "/api-testing/api/project/single/hook":
+			completeStatusResp := []byte(`[{"id":"hook1","identifier":"uuid1","name":"name1","description":"description1"}]`)
+			_, err = w.Write(completeStatusResp)
+		case "/api-testing/api/project/multiple/hook":
+			completeStatusResp := []byte(`[{"id":"hook1","identifier":"uuid1","name":"name1","description":"description1"},{"id":"hook2","identifier":"uuid2","name":"name2","description":"description2"}]`)
+			_, err = w.Write(completeStatusResp)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+
+		if err != nil {
+			t.Errorf("failed to respond: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	type fields struct {
+		Project       Project
+		Client        apitesting.Client
+		Region        region.Region
+		Reporters     []report.Reporter
+		Async         bool
+		TunnelService tunnel.Service
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    Project
+		wantErr string
+	}{
+		{
+			name: "Project with no Hooks",
+			fields: fields{
+				Client: apitesting.Client{
+					HTTPClient: ts.Client(),
+					URL:        ts.URL,
+				},
+				Project: Project{
+					Suites: []Suite{
+						{
+							Name:        "Suite #1",
+							ProjectName: "Project NoHooks",
+						},
+					},
+				},
+			},
+			wantErr: "failed to get some suites associated hookIDs",
+		},
+		{
+			name: "Project with single Hooks",
+			fields: fields{
+				Client: apitesting.Client{
+					HTTPClient: ts.Client(),
+					URL:        ts.URL,
+				},
+				Project: Project{
+					Suites: []Suite{
+						{
+							Name:        "Suite #1",
+							ProjectName: "Project SingleHook",
+						},
+					},
+				},
+			},
+			want: Project{
+				Suites: []Suite{
+					{
+						Name:        "Suite #1",
+						ProjectName: "Project SingleHook",
+						HookID:      "uuid1",
+					},
+				},
+			},
+		},
+		{
+			name: "Project with multiple Hooks",
+			fields: fields{
+				Client: apitesting.Client{
+					HTTPClient: ts.Client(),
+					URL:        ts.URL,
+				},
+				Project: Project{
+					Suites: []Suite{
+						{
+							Name:        "Suite #1",
+							ProjectName: "Project MultipleHooks",
+						},
+					},
+				},
+			},
+			want: Project{
+				Suites: []Suite{
+					{
+						Name:        "Suite #1",
+						ProjectName: "Project MultipleHooks",
+						HookID:      "uuid1",
+					},
+				},
+			},
+		},
+		{
+			name: "Project with Buggy Hooks",
+			fields: fields{
+				Client: apitesting.Client{
+					HTTPClient: ts.Client(),
+					URL:        ts.URL,
+				},
+				Project: Project{
+					Suites: []Suite{
+						{
+							Name:        "Suite #1",
+							ProjectName: "Project BuggyHooks",
+						},
+					},
+				},
+			},
+			wantErr: "failed to get some suites associated hookIDs",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Runner{
+				Project:       tt.fields.Project,
+				Client:        tt.fields.Client,
+				Region:        tt.fields.Region,
+				Reporters:     tt.fields.Reporters,
+				Async:         tt.fields.Async,
+				TunnelService: tt.fields.TunnelService,
+			}
+
+			err := r.ResolveHookIDs()
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr, "ResolveHookIDs(): got %v, want %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveHookIDs(): got err: %v", err)
+				return
+			}
+
+			if !reflect.DeepEqual(tt.want, tt.fields.Project) {
+				t.Errorf("ResolveHookIDs(): got %v, want %v", tt.fields.Project, tt.want)
+			}
+		})
+	}
 }

--- a/internal/apitesting/client.go
+++ b/internal/apitesting/client.go
@@ -54,6 +54,7 @@ type Project struct {
 // Hook describes the metadata for a hook.
 type Hook struct {
 	Identifier string `json:"identifier,omitempty"`
+	Name       string `json:"name,omitempty"`
 }
 
 // New returns a apitesting.Client

--- a/internal/apitesting/client.go
+++ b/internal/apitesting/client.go
@@ -212,7 +212,7 @@ func (c *Client) GetProjects(ctx context.Context) ([]Project, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return []Project{}, fmt.Errorf("request failed; unexpected response code:'%d', msg:'%v'", resp.StatusCode, string(body))
+		return []Project{}, fmt.Errorf("request failed; unexpected response code:'%d', msg:'%s'", resp.StatusCode, body)
 	}
 
 	var projects []Project
@@ -243,7 +243,7 @@ func (c *Client) GetHooks(ctx context.Context, projectID string) ([]Hook, error)
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return []Hook{}, fmt.Errorf("request failed; unexpected response code:'%d', msg:'%v'", resp.StatusCode, string(body))
+		return []Hook{}, fmt.Errorf("request failed; unexpected response code:'%d', msg:'%s'", resp.StatusCode, body)
 	}
 
 	var hooks []Hook

--- a/internal/apitesting/client.go
+++ b/internal/apitesting/client.go
@@ -67,8 +67,8 @@ func New(url string, username string, accessKey string, timeout time.Duration) C
 	}
 }
 
-// GetProjectByHookID returns Project metadata for a given hookID.
-func (c *Client) GetProjectByHookID(ctx context.Context, hookID string) (Project, error) {
+// GetProject returns Project metadata for a given hookID.
+func (c *Client) GetProject(ctx context.Context, hookID string) (Project, error) {
 	url := fmt.Sprintf("%s/api-testing/rest/v4/%s", c.URL, hookID)
 	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/internal/apitesting/client_test.go
+++ b/internal/apitesting/client_test.go
@@ -160,7 +160,7 @@ func TestClient_GetProject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.GetProjectByHookID(tt.args.ctx, tt.args.hookID)
+			got, err := c.GetProject(tt.args.ctx, tt.args.hookID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetProject() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/apitesting/client_test.go
+++ b/internal/apitesting/client_test.go
@@ -2,7 +2,9 @@ package apitesting
 
 import (
 	"context"
+	"fmt"
 	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -157,7 +159,7 @@ func TestClient_GetProject(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.GetProject(tt.args.ctx, tt.args.hookID)
+			got, err := c.GetProjectByHookID(tt.args.ctx, tt.args.hookID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetProject() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -317,6 +319,55 @@ func TestClient_composeURL(t *testing.T) {
 			if got := c.composeURL(tt.args.path, tt.args.buildID, tt.args.format, tt.args.tunnel, tt.args.taskID); got != tt.want {
 				t.Errorf("composeURL() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestClient_GetProjects(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    []Project
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Fetching Projects Test",
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return err != nil
+			},
+			want: []Project{},
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		switch r.URL.Path {
+		case "/api-testing/api/project":
+			completeStatusResp := []byte(`[{"id":"63dbe9d6f48c8412fe79220d","name":"Demo Project","teamId":null,"description":"","tags":[],"notes":"","type":"project","emailNotifications":[],"connectorNotifications":[]}]`)
+			_, err = w.Write(completeStatusResp)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+
+		if err != nil {
+			t.Errorf("failed to respond: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	c := &Client{
+		HTTPClient: ts.Client(),
+		URL:        ts.URL,
+		Username:   "dummy",
+		AccessKey:  "accesskey",
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := c.GetProjects(context.Background())
+			if !tt.wantErr(t, err, fmt.Sprintf("GetProjects(%v)", context.Background())) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetProjects(%v)", context.Background())
 		})
 	}
 }

--- a/internal/apitesting/client_test.go
+++ b/internal/apitesting/client_test.go
@@ -401,9 +401,11 @@ func TestClient_GetHooks(t *testing.T) {
 			want: []Hook{
 				{
 					Identifier: "e291c7c5-d091-4bae-8293-7315fc15cc4c",
+					Name:       "name1",
 				},
 				{
 					Identifier: "4d66f4d0-a29a-43a1-a787-94f7b8cc2e21",
+					Name:       "name2",
 				},
 			},
 		},

--- a/internal/apitesting/client_test.go
+++ b/internal/apitesting/client_test.go
@@ -375,7 +375,7 @@ func TestClient_GetProjects(t *testing.T) {
 
 func TestClient_GetHooks(t *testing.T) {
 	type params struct {
-		projectId string
+		projectID string
 	}
 
 	tests := []struct {
@@ -387,7 +387,7 @@ func TestClient_GetHooks(t *testing.T) {
 		{
 			name: "Projects with no hooks",
 			params: params{
-				projectId: "noHooks",
+				projectID: "noHooks",
 			},
 			wantErr: nil,
 			want:    []Hook{},
@@ -395,7 +395,7 @@ func TestClient_GetHooks(t *testing.T) {
 		{
 			name: "Projects with multiple hooks",
 			params: params{
-				projectId: "multipleHooks",
+				projectID: "multipleHooks",
 			},
 			wantErr: nil,
 			want: []Hook{
@@ -412,7 +412,7 @@ func TestClient_GetHooks(t *testing.T) {
 		{
 			name: "Invalid Project",
 			params: params{
-				projectId: "invalidProject",
+				projectID: "invalidProject",
 			},
 			wantErr: errors.New(`request failed; unexpected response code:'404', msg:'{"status":"error","message":"Not Found"}'`),
 			want:    []Hook{},
@@ -451,12 +451,12 @@ func TestClient_GetHooks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.GetHooks(context.Background(), tt.params.projectId)
+			got, err := c.GetHooks(context.Background(), tt.params.projectID)
 			if !reflect.DeepEqual(err, tt.wantErr) {
-				t.Errorf("GetHooks(%v, %s): got %v want %v", context.Background(), tt.params.projectId, err, tt.wantErr)
+				t.Errorf("GetHooks(%v, %s): got %v want %v", context.Background(), tt.params.projectID, err, tt.wantErr)
 				return
 			}
-			assert.Equalf(t, tt.want, got, "GetHooks(%v, %s)", context.Background(), tt.params.projectId)
+			assert.Equalf(t, tt.want, got, "GetHooks(%v, %s)", context.Background(), tt.params.projectID)
 		})
 	}
 }

--- a/internal/cmd/run/apitest.go
+++ b/internal/cmd/run/apitest.go
@@ -45,6 +45,10 @@ func runApitest(isCLIDriven bool) (int, error) {
 		TunnelService: &restoClient,
 	}
 
+	if err := r.ResolveHookIDs(); err != nil {
+		return 1, err
+	}
+
 	return r.RunProject()
 }
 

--- a/internal/msg/errormsg.go
+++ b/internal/msg/errormsg.go
@@ -108,6 +108,22 @@ const (
 	InvalidPassThreshold = "passThreshold should not be greater than retries+1"
 )
 
+// apitesting config settings
+const (
+	// ProjectListFailure indicates failure to get the list of projects
+	ProjectListFailure = "unable to list projects"
+	// ProjectNotFound indicates the project was not found
+	ProjectNotFound = `Project "%s" was not found`
+	// HookQueryFailure indicates failure when fetching the hooks
+	HookQueryFailure = "unable to query for hooks"
+	// NoHookForProject indicates the absence of available hook
+	NoHookForProject = `No hooks found for project "%s"`
+	// HookUsedForSuite indicates which hook will be used for a suite
+	HookUsedForSuite = `Using hook "%s" for suite "%s"`
+	// FailedToPrepareSuites indicates failure of preliminary steps for api-testing
+	FailedToPrepareSuites = "failed to get some suites associated hookIDs"
+)
+
 // cypress config settings
 const (
 	// MissingCypressVersion indicates no valid cypress version provided

--- a/internal/msg/errormsg.go
+++ b/internal/msg/errormsg.go
@@ -110,6 +110,10 @@ const (
 
 // apitesting config settings
 const (
+	// NoProjectName indicates the absence of a project name in a suite
+	NoProjectName = "suites must have a projectName defined"
+	// ProjectNameHookIDConflict indicates a conflict between project name and hookID
+	ProjectNameHookIDConflict = "suites must not have a projectName and a hookId defined"
 	// ProjectListFailure indicates failure to get the list of projects
 	ProjectListFailure = "unable to list projects"
 	// ProjectNotFound indicates the project was not found


### PR DESCRIPTION
## Proposed changes

To enhance usability and easiness of configuration, API Testing will be configure through `ProjectName` instead of `HookID`.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->