### PR TITLE
Fix docker doctor

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -127,7 +127,7 @@ func (handler *Handler) IsLaunchable(image string) error {
 		return err
 	}
 
-	go func() {
+	defer func() {
 		if con.ID != "" {
 			_ = handler.ContainerStop(context.Background(), con.ID)
 			_ = handler.ContainerRemove(context.Background(), con.ID)


### PR DESCRIPTION
## Proposed changes
Fix typo that causes premature removal of the test container (`saucectl doctor`).