### PR TITLE
Remove deprecated flag tunnel-parent

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -136,7 +136,6 @@ func Command() *cobra.Command {
 	sc.Int("ccy", "sauce::concurrency", 2, "Concurrency specifies how many suites are run at the same time.")
 	sc.String("tunnel-id", "sauce::tunnel::id", "", "Sets the sauce-connect tunnel ID to be used for the run.")
 	sc.String("tunnel-name", "sauce::tunnel::name", "", "Sets the sauce-connect tunnel name to be used for the run.")
-	sc.String("tunnel-parent", "sauce::tunnel::parent", "", "Sets the sauce-connect tunnel parent to be used for the run.")
 	sc.String("tunnel-owner", "sauce::tunnel::owner", "", "Sets the sauce-connect tunnel owner to be used for the run.")
 	sc.String("runner-version", "runnerVersion", "", "Overrides the automatically determined runner version.")
 	sc.String("sauceignore", "sauce::sauceignore", ".sauceignore", "Specifies the path to the .sauceignore file.")
@@ -173,7 +172,6 @@ func Command() *cobra.Command {
 
 	// Deprecated flags
 	_ = sc.Fset.MarkDeprecated("tunnel-id", "please use --tunnel-name instead")
-	_ = sc.Fset.MarkDeprecated("tunnel-parent", "please use --tunnel-owner instead")
 
 	sc.BindAll()
 


### PR DESCRIPTION
## Proposed changes

Remove the deprecated flag `tunnel-parent`. Usage stats indicate that this flag is not used anymore (unlike `tunnel-id`).
The config level setting will remain.