### PR TITLE
Reduce memory footprint during uploads

### DIFF
--- a/internal/appstore/appstore_test.go
+++ b/internal/appstore/appstore_test.go
@@ -1,14 +1,12 @@
 package appstore
 
 import (
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path"
 	"reflect"
 	"testing"
 	"time"
@@ -18,61 +16,6 @@ import (
 
 	"gotest.tools/v3/fs"
 )
-
-func TestAppStore_Upload(t *testing.T) {
-	dir := fs.NewDir(t, "bundles",
-		fs.WithFile("bundle-1.zip", "bundle-1-content", fs.WithMode(0644)),
-		fs.WithFile("bundle-2.zip", "bundle-2-content", fs.WithMode(0644)))
-	b1 := sha256.New()
-	b1.Write([]byte("bundle-1-content"))
-	b1Hash := fmt.Sprintf("%x", b1.Sum(nil))
-	defer dir.Remove()
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if fmt.Sprintf("sha256=%s&per_page=1", b1Hash) == r.URL.RawQuery {
-			w.WriteHeader(200)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{
-				"items": [
-					{
-						"id": "matching-id",
-						"sha256": "%s"
-					}
-				],
-				"total_items": 1
-			}`, b1Hash)))
-			return
-		}
-		w.WriteHeader(200)
-		_, _ = w.Write([]byte(`{
-			"items": [
-			],
-			"total_items": 0
-		}`))
-	}))
-	defer ts.Close()
-
-	testCases := []struct {
-		look    string
-		want    string
-		wantErr error
-	}{
-		{look: path.Join(dir.Path(), "bundle-2.zip"), want: "", wantErr: nil},
-		{look: path.Join(dir.Path(), "bundle-1.zip"), want: "matching-id", wantErr: nil},
-		{look: "", want: "", wantErr: nil},
-	}
-
-	as := New(ts.URL, "fake-username", "fake-access-key", 15*time.Second)
-	for _, tt := range testCases {
-		artifact, err := as.Find(tt.look)
-
-		if !reflect.DeepEqual(err, tt.wantErr) {
-			t.Errorf("Error: want: %v, got: %v", tt.wantErr, err)
-		}
-		if artifact.ID != tt.want {
-			t.Errorf("StorageID: want: %v, got: %v", tt.want, artifact.ID)
-		}
-	}
-}
 
 func TestAppStore_UploadStream(t *testing.T) {
 	// mock test values

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -700,10 +700,15 @@ func (r *CloudRunner) uploadProject(filename, description string, pType uploadTy
 	if err != nil {
 		return "", nil
 	}
-	progress.Show("Uploading %s %s", pType, filename)
+	file, err := os.Open(filename)
+	if err != nil {
+		return "", fmt.Errorf("project upload: %w", err)
+	}
+	defer file.Close()
 
+	progress.Show("Uploading %s %s", pType, filename)
 	start := time.Now()
-	resp, err := r.ProjectUploader.Upload(filename, description)
+	resp, err := r.ProjectUploader.UploadStream(filepath.Base(filename), description, file)
 	progress.Stop()
 	if err != nil {
 		return "", err

--- a/internal/saucecloud/cypress_test.go
+++ b/internal/saucecloud/cypress_test.go
@@ -2,7 +2,6 @@ package saucecloud
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -13,7 +12,6 @@ import (
 	j "github.com/saucelabs/saucectl/internal/cmd/jobs/job"
 	"github.com/saucelabs/saucectl/internal/config"
 	v1 "github.com/saucelabs/saucectl/internal/cypress/v1"
-	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/insights"
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/mocks"
@@ -129,119 +127,4 @@ func TestRunSuites(t *testing.T) {
 	}
 	ret := runner.runSuites("dummy-file-id")
 	assert.True(t, ret)
-}
-
-func TestUploadProject(t *testing.T) {
-	uploader := &mocks.FakeProjectUploader{
-		UploadSuccess: true,
-	}
-	runner := CypressRunner{
-		CloudRunner: CloudRunner{
-			ProjectUploader: uploader,
-		},
-	}
-	id, err := runner.uploadProject("/my-dummy-project.zip", "", "project", false)
-	assert.Equal(t, "storage:fake-id", id)
-	assert.Nil(t, err)
-
-	uploader.UploadSuccess = false
-	id, err = runner.uploadProject("/my-dummy-project.zip", "", "project", false)
-	assert.Equal(t, "", id)
-	assert.NotNil(t, err)
-
-}
-
-func TestRunProject(t *testing.T) {
-	err := os.Mkdir("./test-arch/", 0755)
-	if err != nil {
-		t.Errorf("failed to create test-arch directory: %v", err)
-	}
-	httpmock.Activate()
-	defer func() {
-		os.RemoveAll("./test-arch/")
-		httpmock.DeactivateAndReset()
-	}()
-
-	ccyReader := mocks.CCYReader{ReadAllowedCCYfn: func(ctx context.Context) (int, error) {
-		return 1, nil
-	}}
-	uploader := &mocks.FakeProjectUploader{
-		UploadSuccess: true,
-	}
-
-	mdService := &mocks.FakeFrameworkInfoReader{
-		VersionsFn: func(ctx context.Context, frameworkName string) ([]framework.Metadata, error) {
-			return []framework.Metadata{{
-				FrameworkName:    "cypress",
-				FrameworkVersion: "5.6.0",
-			}}, nil
-		},
-	}
-
-	runner := CypressRunner{
-		CloudRunner: CloudRunner{
-			JobService: JobService{
-				VDCStarter: &mocks.FakeJobStarter{
-					StartJobFn: func(ctx context.Context, opts job.StartOptions) (jobID string, isRDC bool, err error) {
-						return "fake-job-id", false, nil
-					},
-				},
-				VDCReader: &mocks.FakeJobReader{
-					PollJobFn: func(ctx context.Context, id string, interval time.Duration, timeout time.Duration) (job.Job, error) {
-						return job.Job{ID: id, Passed: true}, nil
-					},
-					GetJobAssetFileNamesFn: func(ctx context.Context, jobID string) ([]string, error) {
-						return []string{"file1", "file2"}, nil
-					},
-					GetJobAssetFileContentFn: func(ctx context.Context, jobID, fileName string) ([]byte, error) {
-						return []byte("file content"), nil
-					},
-				},
-				VDCWriter: &mocks.FakeJobWriter{
-					UploadAssetFn: func(jobID string, fileName string, contentType string, content []byte) error {
-						return nil
-					},
-				},
-				VDCDownloader: &mocks.FakeArtifactDownloader{
-					DownloadArtifactFn: func(jobID, suiteName string) []string {
-						return []string{}
-					},
-				},
-			},
-			BuildService: &mocks.FakeBuildReader{
-				GetBuildIDFn: func(ctx context.Context, jobID string, buildSource build.Source) (string, error) {
-					return "build-id", nil
-				},
-			},
-			InsightsService: mocks.FakeInsightService{
-				PostTestRunFn: func(ctx context.Context, runs []insights.TestRun) error {
-					return nil
-				},
-				ReadJobFn: func(ctx context.Context, id string) (j.Job, error) {
-					return j.Job{}, nil
-				},
-			},
-			CCYReader:              ccyReader,
-			ProjectUploader:        uploader,
-			MetadataService:        mdService,
-			MetadataSearchStrategy: framework.ExactStrategy{},
-		},
-		Project: &v1.Project{
-			RootDir: ".",
-			Cypress: v1.Cypress{
-				Version:    "5.6.0",
-				ConfigFile: "../../tests/e2e/cypress.json",
-			},
-			Suites: []v1.Suite{
-				{Name: "dummy-suite"},
-			},
-			Sauce: config.SauceConfig{
-				Concurrency: 1,
-			},
-		},
-	}
-
-	cnt, err := runner.RunProject()
-	assert.Nil(t, err)
-	assert.Equal(t, cnt, 0)
 }

--- a/internal/saucecloud/espresso_test.go
+++ b/internal/saucecloud/espresso_test.go
@@ -1,19 +1,10 @@
 package saucecloud
 
 import (
-	"context"
-	"testing"
-	"time"
-
-	"github.com/jarcoal/httpmock"
-	"github.com/saucelabs/saucectl/internal/build"
-	j "github.com/saucelabs/saucectl/internal/cmd/jobs/job"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/espresso"
-	"github.com/saucelabs/saucectl/internal/insights"
-	"github.com/saucelabs/saucectl/internal/job"
-	"github.com/saucelabs/saucectl/internal/mocks"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestEspresso_GetSuiteNames(t *testing.T) {
@@ -108,95 +99,4 @@ func TestEspressoRunner_CalculateJobCount(t *testing.T) {
 
 		assert.Equal(t, runner.calculateJobsCount(runner.Project.Suites), tt.wants)
 	}
-}
-
-func TestEspressoRunner_RunProject(t *testing.T) {
-	httpmock.Activate()
-	defer func() {
-		httpmock.DeactivateAndReset()
-	}()
-
-	ccyReader := mocks.CCYReader{ReadAllowedCCYfn: func(ctx context.Context) (int, error) {
-		return 1, nil
-	}}
-	uploader := &mocks.FakeProjectUploader{
-		UploadSuccess: true,
-	}
-
-	var startOpts job.StartOptions
-	runner := &EspressoRunner{
-		CloudRunner: CloudRunner{
-			JobService: JobService{
-				VDCStarter: &mocks.FakeJobStarter{
-					StartJobFn: func(ctx context.Context, opts job.StartOptions) (jobID string, isRDC bool, err error) {
-						startOpts = opts
-						return "fake-job-id", false, nil
-					},
-				},
-				VDCReader: &mocks.FakeJobReader{
-					PollJobFn: func(ctx context.Context, id string, interval time.Duration, timeout time.Duration) (job.Job, error) {
-						return job.Job{ID: id, Passed: true}, nil
-					},
-					GetJobAssetFileNamesFn: func(ctx context.Context, jobID string) ([]string, error) {
-						return []string{"file1", "file2"}, nil
-					},
-					GetJobAssetFileContentFn: func(ctx context.Context, jobID, fileName string) ([]byte, error) {
-						return []byte("file content"), nil
-					},
-				},
-				VDCWriter: &mocks.FakeJobWriter{
-					UploadAssetFn: func(jobID string, fileName string, contentType string, content []byte) error {
-						return nil
-					},
-				},
-				VDCDownloader: &mocks.FakeArtifactDownloader{
-					DownloadArtifactFn: func(jobID, suiteName string) []string { return []string{} },
-				},
-			},
-			BuildService: &mocks.FakeBuildReader{
-				GetBuildIDFn: func(ctx context.Context, jobID string, buildSource build.Source) (string, error) {
-					return "build-id", nil
-				},
-			},
-			CCYReader:       ccyReader,
-			ProjectUploader: uploader,
-			InsightsService: mocks.FakeInsightService{
-				PostTestRunFn: func(ctx context.Context, runs []insights.TestRun) error {
-					return nil
-				},
-				ReadJobFn: func(ctx context.Context, id string) (j.Job, error) {
-					return j.Job{}, nil
-				},
-			},
-		},
-		Project: espresso.Project{
-			Espresso: espresso.Espresso{
-				App:     "/path/to/app.apk",
-				TestApp: "/path/to/testApp.apk",
-			},
-			Suites: []espresso.Suite{
-				{
-					Name: "my espresso project",
-					Emulators: []config.Emulator{
-						{
-							Name:             "Android GoogleApi Emulator",
-							Orientation:      "landscape",
-							PlatformVersions: []string{"11.0"},
-						},
-					},
-					TestOptions: map[string]interface{}{
-						"notAnnotation": "my.annotation",
-					},
-				},
-			},
-			Sauce: config.SauceConfig{
-				Concurrency: 1,
-			},
-		},
-	}
-	cnt, err := runner.RunProject()
-	assert.Nil(t, err)
-	assert.Equal(t, cnt, 0)
-	assert.Equal(t, "landscape", startOpts.DeviceOrientation)
-	assert.Equal(t, "my.annotation", startOpts.TestOptions["notAnnotation"])
 }

--- a/internal/saucecloud/xcuitest_test.go
+++ b/internal/saucecloud/xcuitest_test.go
@@ -2,123 +2,19 @@ package saucecloud
 
 import (
 	"archive/zip"
-	"context"
+	"gotest.tools/v3/fs"
 	"io"
 	"os"
 	"path"
 	"reflect"
 	"regexp"
 	"testing"
-	"time"
 
-	"gotest.tools/v3/fs"
-
-	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/saucelabs/saucectl/internal/build"
-	j "github.com/saucelabs/saucectl/internal/cmd/jobs/job"
 	"github.com/saucelabs/saucectl/internal/config"
-	"github.com/saucelabs/saucectl/internal/insights"
-	"github.com/saucelabs/saucectl/internal/job"
-	"github.com/saucelabs/saucectl/internal/mocks"
 	"github.com/saucelabs/saucectl/internal/xcuitest"
 )
-
-func TestXcuitestRunner_RunProject(t *testing.T) {
-	httpmock.Activate()
-	defer func() {
-		httpmock.DeactivateAndReset()
-	}()
-	ccyReader := mocks.CCYReader{ReadAllowedCCYfn: func(ctx context.Context) (int, error) {
-		return 1, nil
-	}}
-	uploader := &mocks.FakeProjectUploader{
-		UploadSuccess: true,
-	}
-	insightsSvc := mocks.FakeInsightService{
-		PostTestRunFn: func(ctx context.Context, runs []insights.TestRun) error {
-			return nil
-		},
-		ReadJobFn: func(ctx context.Context, id string) (j.Job, error) {
-			return j.Job{}, nil
-		},
-	}
-
-	var startOpts job.StartOptions
-	runner := &XcuitestRunner{
-		CloudRunner: CloudRunner{
-			JobService: JobService{
-				RDCStarter: &mocks.FakeJobStarter{
-					StartJobFn: func(ctx context.Context, opts job.StartOptions) (jobID string, isRDC bool, err error) {
-						startOpts = opts
-						return "fake-job-id", false, nil
-					},
-				},
-				RDCReader: &mocks.FakeJobReader{
-					PollJobFn: func(ctx context.Context, id string, interval time.Duration, timeout time.Duration) (job.Job, error) {
-						return job.Job{ID: id, Passed: true, Status: job.StatePassed}, nil
-					},
-					GetJobAssetFileNamesFn: func(ctx context.Context, jobID string) ([]string, error) {
-						return []string{"file1", "file2"}, nil
-					},
-					GetJobAssetFileContentFn: func(ctx context.Context, jobID, fileName string) ([]byte, error) {
-						return []byte("file content"), nil
-					},
-				},
-				VDCWriter: &mocks.FakeJobWriter{
-					UploadAssetFn: func(jobID string, fileName string, contentType string, content []byte) error {
-						return nil
-					},
-				},
-				VDCDownloader: &mocks.FakeArtifactDownloader{
-					DownloadArtifactFn: func(jobID, suiteName string) []string { return []string{} },
-				},
-				VDCReader: &mocks.FakeJobReader{
-					GetJobAssetFileNamesFn: func(ctx context.Context, jobID string) ([]string, error) {
-						return []string{}, nil
-					},
-				},
-			},
-			BuildService: &mocks.FakeBuildReader{
-				GetBuildIDFn: func(ctx context.Context, jobID string, buildSource build.Source) (string, error) {
-					return "build-id", nil
-				},
-			},
-			CCYReader:       ccyReader,
-			ProjectUploader: uploader,
-			InsightsService: insightsSvc,
-		},
-		Project: xcuitest.Project{
-			Xcuitest: xcuitest.Xcuitest{
-				App:     "/path/to/app.ipa",
-				TestApp: "/path/to/testApp.ipa",
-			},
-			Suites: []xcuitest.Suite{
-				{
-					Name:    "my xcuitest project",
-					TestApp: "/path/to/testApp.ipa",
-					Devices: []config.Device{
-						{
-							Name:            "iPhone 11",
-							PlatformName:    "iOS",
-							PlatformVersion: "14.3",
-						},
-					},
-				},
-			},
-			Sauce: config.SauceConfig{
-				Concurrency: 1,
-			},
-		},
-	}
-	cnt, err := runner.RunProject()
-	assert.Nil(t, err)
-	assert.Equal(t, 0, cnt)
-	assert.Equal(t, "iPhone 11", startOpts.DeviceName)
-	assert.Equal(t, "iOS", startOpts.PlatformName)
-	assert.Equal(t, "14.3", startOpts.PlatformVersion)
-}
 
 func TestCalculateJobsCount(t *testing.T) {
 	runner := &XcuitestRunner{

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -57,8 +57,6 @@ func (s *ServerError) Error() string {
 
 // AppService is the interface for interacting with the Sauce application storage.
 type AppService interface {
-	// Deprecated: Use UploadStream.
-	Upload(name, description string) (Item, error)
 	// UploadStream uploads the contents of reader and stores them under the given filename.
 	UploadStream(filename, description string, reader io.Reader) (Item, error)
 	Download(id string) (io.ReadCloser, int64, error)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -60,7 +60,5 @@ type AppService interface {
 	// UploadStream uploads the contents of reader and stores them under the given filename.
 	UploadStream(filename, description string, reader io.Reader) (Item, error)
 	Download(id string) (io.ReadCloser, int64, error)
-	// Deprecated: Use List instead.
-	Find(name string) (Item, error)
 	List(opts ListOptions) (List, error)
 }


### PR DESCRIPTION
## Proposed changes

Utilize the previously introduced `storage.UploadStream` method to upload project files (before it was only used by the `saucectl storage` command) and remove deprecated methods.

This change greatly reduces the memory footprint during project uploads.

Some stats with our espresso-example repo before this change:

![saucectl mem before](https://user-images.githubusercontent.com/1869292/218174345-fbb1868e-b047-457e-8530-cf590186d90a.png)

And after:

![saucectl mem after](https://user-images.githubusercontent.com/1869292/218174366-5cd0b61a-2842-42ad-87dc-e8bb33ed4dd7.png)


