### PR TITLE
Remove deprecated playwright flags

### DIFF
--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -71,7 +71,6 @@ func NewPlaywrightCmd() *cobra.Command {
 	sc.String("playwright.configFile", "playwright::configFile", "", "The path to playwright config file")
 
 	// Playwright Test Options
-	sc.Bool("headed", "suite::params::headed", false, "Run tests in headed browsers")
 	sc.Bool("headless", "suite::params::headless", false, "Run tests in headless mode")
 	sc.Int("globalTimeout", "suite::params::globalTimeout", 0, "Total timeout for the whole test run in milliseconds")
 	sc.Int("testTimeout", "suite::params::timeout", 0, "Maximum timeout in milliseconds for each test")
@@ -97,9 +96,6 @@ func NewPlaywrightCmd() *cobra.Command {
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
 	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https")
-
-	// Deprecated flags
-	_ = sc.Fset.MarkDeprecated("headed", "please use --headless instead")
 
 	return cmd
 }

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -99,15 +99,6 @@ type SuiteConfig struct {
 
 	// Shard is set by saucectl (not user) based on Suite.NumShards.
 	Shard string `yaml:"-" json:"shard,omitempty"`
-
-	// Deprecated fields in v1.12+
-	HeadFul             bool `yaml:"headful,omitempty" json:"headful,omitempty"`
-	ScreenshotOnFailure bool `yaml:"screenshotOnFailure,omitempty" json:"screenshotOnFailure,omitempty"`
-	SlowMo              int  `yaml:"slowMo,omitempty" json:"slowMo,omitempty"`
-	Video               bool `yaml:"video,omitempty" json:"video,omitempty"`
-
-	// Will be deprecated since `headless` is introduced
-	Headed bool `yaml:"headed,omitempty" json:"headed,omitempty"`
 }
 
 // FromFile creates a new playwright Project based on the filepath cfgPath.

--- a/internal/playwright/config_test.go
+++ b/internal/playwright/config_test.go
@@ -116,9 +116,21 @@ func TestShardSuites(t *testing.T) {
 			wantErr:        false,
 			expectedErrMsg: "",
 			expectedSuites: []Suite{
-				{Name: "suite #1 - tests/dir1/example1.tests.js", Mode: "", Timeout: 0, PlaywrightVersion: "", TestMatch: []string{"tests/dir1/example1.tests.js"}, PlatformName: "", Params: SuiteConfig{BrowserName: "", Headed: false, GlobalTimeout: 0, Timeout: 0, Grep: "", RepeatEach: 0, Retries: 0, MaxFailures: 0, Shard: "", HeadFul: false, ScreenshotOnFailure: false, SlowMo: 0, Video: false}, ScreenResolution: "", Env: map[string]string(nil), NumShards: 0, Shard: "spec"},
-				{Name: "suite #1 - tests/dir2/example2.tests.js", Mode: "", Timeout: 0, PlaywrightVersion: "", TestMatch: []string{"tests/dir2/example2.tests.js"}, PlatformName: "", Params: SuiteConfig{BrowserName: "", Headed: false, GlobalTimeout: 0, Timeout: 0, Grep: "", RepeatEach: 0, Retries: 0, MaxFailures: 0, Shard: "", HeadFul: false, ScreenshotOnFailure: false, SlowMo: 0, Video: false}, ScreenResolution: "", Env: map[string]string(nil), NumShards: 0, Shard: "spec"},
-				{Name: "suite #1 - tests/dir3/example3.tests.js", Mode: "", Timeout: 0, PlaywrightVersion: "", TestMatch: []string{"tests/dir3/example3.tests.js"}, PlatformName: "", Params: SuiteConfig{BrowserName: "", Headed: false, GlobalTimeout: 0, Timeout: 0, Grep: "", RepeatEach: 0, Retries: 0, MaxFailures: 0, Shard: "", HeadFul: false, ScreenshotOnFailure: false, SlowMo: 0, Video: false}, ScreenResolution: "", Env: map[string]string(nil), NumShards: 0, Shard: "spec"},
+				{
+					Name:      "suite #1 - tests/dir1/example1.tests.js",
+					TestMatch: []string{"tests/dir1/example1.tests.js"},
+					Shard:     "spec",
+				},
+				{
+					Name:      "suite #1 - tests/dir2/example2.tests.js",
+					TestMatch: []string{"tests/dir2/example2.tests.js"},
+					Shard:     "spec",
+				},
+				{
+					Name:      "suite #1 - tests/dir3/example3.tests.js",
+					TestMatch: []string{"tests/dir3/example3.tests.js"},
+					Shard:     "spec",
+				},
 			},
 		},
 		{
@@ -135,7 +147,11 @@ func TestShardSuites(t *testing.T) {
 			wantErr:        true,
 			expectedErrMsg: "suite 'suite #1' patterns have no matching files",
 			expectedSuites: []Suite{
-				{Name: "suite #1", Mode: "", Timeout: 0, PlaywrightVersion: "", TestMatch: []string{"tests/dir1/example1.tests.js"}, PlatformName: "", Params: SuiteConfig{BrowserName: "", Headed: false, GlobalTimeout: 0, Timeout: 0, Grep: "", RepeatEach: 0, Retries: 0, MaxFailures: 0, Shard: "", HeadFul: false, ScreenshotOnFailure: false, SlowMo: 0, Video: false}, ScreenResolution: "", Env: map[string]string(nil), NumShards: 0, Shard: "spec"},
+				{
+					Name:      "suite #1",
+					TestMatch: []string{"tests/dir1/example1.tests.js"},
+					Shard:     "spec",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Proposed changes

Remove deprecated playwright flags. Confirmed not in use (and not supported by any of our active runners).