### PR TITLE
Fix: Allow empty image credentials

### DIFF
--- a/internal/imagerunner/imagerunner.go
+++ b/internal/imagerunner/imagerunner.go
@@ -40,7 +40,7 @@ type RunnerSpec struct {
 
 type Container struct {
 	Name string `json:"name,omitempty"`
-	Auth Auth   `json:"auth,omitempty"`
+	Auth *Auth  `json:"auth,omitempty"`
 }
 
 type Auth struct {

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -165,13 +165,18 @@ func (r *ImgRunner) runSuite(suite imagerunner.Suite) (imagerunner.Runner, error
 	ctx, cancel := context.WithTimeout(r.ctx, suite.Timeout)
 	defer cancel()
 
+	var auth *imagerunner.Auth
+	if suite.ImagePullAuth.User != "" && suite.ImagePullAuth.Token != "" {
+		auth = &imagerunner.Auth{
+			User:  suite.ImagePullAuth.User,
+			Token: suite.ImagePullAuth.Token,
+		}
+	}
+
 	runner, err := r.RunnerService.TriggerRun(ctx, imagerunner.RunnerSpec{
 		Container: imagerunner.Container{
 			Name: suite.Image,
-			Auth: imagerunner.Auth{
-				User:  suite.ImagePullAuth.User,
-				Token: suite.ImagePullAuth.Token,
-			},
+			Auth: auth,
 		},
 		EntryPoint: suite.EntryPoint,
 		Env:        mapEnv(suite.Env),


### PR DESCRIPTION
## Proposed changes

The API currently requires `user` and `token` to be set if their parent field `auth` is also defined.
Credentials are optional though. Change the field to a pointer so that it's properly omitted during serialization when nil.