### PR TITLE
Refactor Artifacts

### DIFF
--- a/internal/cmd/artifacts/cmd.go
+++ b/internal/cmd/artifacts/cmd.go
@@ -44,7 +44,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 			rdcClient.URL = url
 			testcompClient := http2.NewTestComposer("", creds, testComposerTimeout)
 
-			artifactSvc = saucecloud.NewArtifactService(restoClient, rdcClient, testcompClient)
+			artifactSvc = saucecloud.NewArtifactService(&restoClient, &rdcClient, &testcompClient)
 
 			return nil
 		},

--- a/internal/cmd/artifacts/cmd.go
+++ b/internal/cmd/artifacts/cmd.go
@@ -2,12 +2,12 @@ package artifacts
 
 import (
 	"errors"
-	http2 "github.com/saucelabs/saucectl/internal/http"
 	"time"
 
 	"github.com/saucelabs/saucectl/internal/artifacts"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/saucelabs/saucectl/internal/saucecloud"
 	"github.com/spf13/cobra"
@@ -38,11 +38,9 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 
 			creds := credentials.Get()
 			url := region.FromString(regio).APIBaseURL()
-			restoClient := http2.NewResto("", creds.Username, creds.AccessKey, restoTimeout)
-			restoClient.URL = url
-			rdcClient := http2.NewRDCService("", creds.Username, creds.AccessKey, rdcTimeout, config.ArtifactDownload{})
-			rdcClient.URL = url
-			testcompClient := http2.NewTestComposer("", creds, testComposerTimeout)
+			restoClient := http.NewResto(url, creds.Username, creds.AccessKey, restoTimeout)
+			rdcClient := http.NewRDCService(url, creds.Username, creds.AccessKey, rdcTimeout, config.ArtifactDownload{})
+			testcompClient := http.NewTestComposer(url, creds, testComposerTimeout)
 
 			artifactSvc = saucecloud.NewArtifactService(&restoClient, &rdcClient, &testcompClient)
 

--- a/internal/cmd/artifacts/download.go
+++ b/internal/cmd/artifacts/download.go
@@ -87,12 +87,12 @@ func download(jobID, filePattern, targetDir, outputFormat string) error {
 		if err != nil {
 			return fmt.Errorf("failed to create file: %w", err)
 		}
-		defer file.Close()
 
 		_, err = file.Write(body)
 		if err != nil {
 			return fmt.Errorf("failed to write to the file: %w", err)
 		}
+		_ = file.Close()
 	}
 	bar.Close()
 

--- a/internal/cmd/artifacts/download.go
+++ b/internal/cmd/artifacts/download.go
@@ -21,7 +21,7 @@ func DownloadCommand() *cobra.Command {
 	var out string
 
 	cmd := &cobra.Command{
-		Use:   "download artifacts",
+		Use:   "download <jobID> <filename>",
 		Short: "Downloads the specified artifacts from the given job. Supports glob pattern.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {

--- a/internal/cmd/artifacts/list.go
+++ b/internal/cmd/artifacts/list.go
@@ -60,7 +60,7 @@ func ListCommand() *cobra.Command {
 	var out string
 
 	cmd := &cobra.Command{
-		Use: "list",
+		Use: "list <jobID>",
 		Aliases: []string{
 			"ls",
 		},

--- a/internal/cmd/artifacts/upload.go
+++ b/internal/cmd/artifacts/upload.go
@@ -18,7 +18,7 @@ func UploadCommand() *cobra.Command {
 	var out string
 
 	cmd := &cobra.Command{
-		Use:   "upload",
+		Use:   "upload <jobID> <filename>",
 		Short: "Uploads an artifacts for the job.",
 		Long:  "Uploads an artifacts for the job. Real Device job is not supported.",
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/artifacts/upload.go
+++ b/internal/cmd/artifacts/upload.go
@@ -87,8 +87,8 @@ func UploadCommand() *cobra.Command {
 	return cmd
 }
 
-func newProgressBar(outputout string, size int64, description ...string) *progressbar.ProgressBar {
-	switch outputout {
+func newProgressBar(outputFormat string, size int64, description ...string) *progressbar.ProgressBar {
+	switch outputFormat {
 	case "text":
 		return progressbar.DefaultBytes(size, description...)
 	default:

--- a/internal/cmd/artifacts/upload.go
+++ b/internal/cmd/artifacts/upload.go
@@ -19,8 +19,8 @@ func UploadCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "upload <jobID> <filename>",
-		Short: "Uploads an artifacts for the job.",
-		Long:  "Uploads an artifacts for the job. Real Device job is not supported.",
+		Short: "Uploads an artifact for the job.",
+		Long:  "Uploads an artifact for the job. Real Device job is not supported.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {
 				return errors.New("no job ID specified")

--- a/internal/saucecloud/artifactservice.go
+++ b/internal/saucecloud/artifactservice.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	http2 "github.com/saucelabs/saucectl/internal/http"
 	"net/http"
 
 	"github.com/saucelabs/saucectl/internal/artifacts"
+	"github.com/saucelabs/saucectl/internal/job"
 )
 
 // ArtifactService represents artifact service
@@ -16,12 +16,12 @@ type ArtifactService struct {
 }
 
 // NewArtifactService returns an artifact service
-func NewArtifactService(restoClient http2.Resto, rdcClient http2.RDCService, testcompClient http2.TestComposer) *ArtifactService {
+func NewArtifactService(vdcReader job.Reader, rdcReader job.Reader, vdcWriter job.Writer) *ArtifactService {
 	return &ArtifactService{
 		JobService: JobService{
-			VDCReader: &restoClient,
-			RDCReader: &rdcClient,
-			VDCWriter: &testcompClient,
+			VDCReader: vdcReader,
+			RDCReader: rdcReader,
+			VDCWriter: vdcWriter,
 		},
 	}
 }


### PR DESCRIPTION
## Proposed changes
- remove implementation details (http clients) from ArtifactService
- actually fix `saucectl artifacts upload`, as it wasn't working at all
```
❯ saucectl artifacts upload 4dd90880b3d34923978b2cfb742f2057 demo.gif
Error: failed to upload file: Put "/v1/testcomposer/jobs/4dd90880b3d34923978b2cfb742f2057/assets": unsupported protocol scheme ""
```
- improve usage description
Before:
```
❯ saucectl artifacts upload -h
Uploads an artifacts for the job. Real Device job is not supported.

Usage:
  saucectl artifacts upload [flags]
```
^^ What am I supposed to do? No args?

After:
```
❯ saucectl artifacts upload -h
Uploads an artifacts for the job. Real Device job is not supported.

Usage:
  saucectl artifacts upload <jobID> <filename> [flags]
```

Clearer now.