### PR TITLE
HTTP Cleanup

### DIFF
--- a/internal/cmd/ini/initializer.go
+++ b/internal/cmd/ini/initializer.go
@@ -4,18 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	http2 "github.com/saucelabs/saucectl/internal/http"
 	"sort"
 	"strings"
-
-	"github.com/saucelabs/saucectl/internal/cypress"
-	"github.com/saucelabs/saucectl/internal/espresso"
-	"github.com/saucelabs/saucectl/internal/msg"
-	"github.com/saucelabs/saucectl/internal/playwright"
-	"github.com/saucelabs/saucectl/internal/puppeteer"
-	"github.com/saucelabs/saucectl/internal/testcafe"
-	"github.com/saucelabs/saucectl/internal/xcuitest"
-	"github.com/spf13/pflag"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
@@ -23,10 +13,19 @@ import (
 	"github.com/saucelabs/saucectl/internal/concurrency"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/devices"
+	"github.com/saucelabs/saucectl/internal/espresso"
 	"github.com/saucelabs/saucectl/internal/framework"
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/saucelabs/saucectl/internal/msg"
+	"github.com/saucelabs/saucectl/internal/playwright"
+	"github.com/saucelabs/saucectl/internal/puppeteer"
 	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/testcafe"
 	"github.com/saucelabs/saucectl/internal/vmd"
+	"github.com/saucelabs/saucectl/internal/xcuitest"
+	"github.com/spf13/pflag"
 )
 
 var androidDevicesPatterns = []string{
@@ -51,11 +50,9 @@ type initializer struct {
 // newInitializer creates a new initializer instance.
 func newInitializer(stdio terminal.Stdio, creds credentials.Credentials, regio string) *initializer {
 	r := region.FromString(regio)
-	tc := http2.NewTestComposer(r.APIBaseURL(), creds, testComposerTimeout)
-
-	rc := http2.NewRDCService(r.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout, config.ArtifactDownload{})
-
-	rs := http2.NewResto(r.APIBaseURL(), creds.Username, creds.AccessKey, restoTimeout)
+	tc := http.NewTestComposer(r.APIBaseURL(), creds, testComposerTimeout)
+	rc := http.NewRDCService(r.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout, config.ArtifactDownload{})
+	rs := http.NewResto(r.APIBaseURL(), creds.Username, creds.AccessKey, restoTimeout)
 
 	return &initializer{
 		stdio:        stdio,

--- a/internal/cmd/jobs/cmd.go
+++ b/internal/cmd/jobs/cmd.go
@@ -2,12 +2,11 @@ package jobs
 
 import (
 	"errors"
-	http2 "github.com/saucelabs/saucectl/internal/http"
-	"net/http"
 	"time"
 
 	"github.com/saucelabs/saucectl/internal/cmd/jobs/job"
 	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/saucelabs/saucectl/internal/saucecloud"
 	"github.com/spf13/cobra"
@@ -37,12 +36,8 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 
 			creds := credentials.Get()
 			url := region.FromString(regio).APIBaseURL()
-			insightsClient := http2.NewInsightsService(url, creds, insightsTimeout)
-			iamClient := http2.UserService{
-				HTTPClient:  &http.Client{Timeout: iamTimeout},
-				URL:         url,
-				Credentials: creds,
-			}
+			insightsClient := http.NewInsightsService(url, creds, insightsTimeout)
+			iamClient := http.NewUserService(url, creds, iamTimeout)
 
 			jobSvc = saucecloud.JobCommandService{
 				Reader:      &insightsClient,

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -3,35 +3,34 @@ package run
 import (
 	"errors"
 	"fmt"
-	http2 "github.com/saucelabs/saucectl/internal/http"
 	"os"
 	"path/filepath"
 	"runtime"
 	"syscall"
 	"time"
 
-	"github.com/saucelabs/saucectl/internal/apitest"
-	"github.com/saucelabs/saucectl/internal/cucumber"
-	"github.com/saucelabs/saucectl/internal/imagerunner"
-	"github.com/saucelabs/saucectl/internal/puppeteer/replay"
-
 	"github.com/fatih/color"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/saucelabs/saucectl/internal/apitest"
 	"github.com/saucelabs/saucectl/internal/backtrace"
 	"github.com/saucelabs/saucectl/internal/build"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/cucumber"
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/espresso"
 	"github.com/saucelabs/saucectl/internal/flags"
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/saucelabs/saucectl/internal/imagerunner"
 	"github.com/saucelabs/saucectl/internal/junit"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/notification/slack"
 	"github.com/saucelabs/saucectl/internal/playwright"
 	"github.com/saucelabs/saucectl/internal/puppeteer"
+	"github.com/saucelabs/saucectl/internal/puppeteer/replay"
 	"github.com/saucelabs/saucectl/internal/report"
 	"github.com/saucelabs/saucectl/internal/report/buildtable"
 	"github.com/saucelabs/saucectl/internal/report/captor"
@@ -56,15 +55,15 @@ var (
 
 	typeDef config.TypeDef
 
-	testcompClient    http2.TestComposer
-	webdriverClient   http2.Webdriver
-	restoClient       http2.Resto
-	appsClient        http2.AppStore
-	rdcClient         http2.RDCService
-	insightsClient    http2.InsightsService
-	iamClient         http2.UserService
-	apitestingClient  http2.APITester
-	imageRunnerClient http2.ImageRunner
+	testcompClient    http.TestComposer
+	webdriverClient   http.Webdriver
+	restoClient       http.Resto
+	appsClient        http.AppStore
+	rdcClient         http.RDCService
+	insightsClient    http.InsightsService
+	iamClient         http.UserService
+	apitestingClient  http.APITester
+	imageRunnerClient http.ImageRunner
 
 	// ErrEmptySuiteName is thrown when a flag is specified that has a dependency on the --name flag.
 	ErrEmptySuiteName = errors.New(msg.EmptyAdhocSuiteName)
@@ -198,23 +197,15 @@ func preRun() error {
 	}
 	typeDef = d
 
-	testcompClient = http2.NewTestComposer("", creds, testComposerTimeout)
-
-	webdriverClient = http2.NewWebdriver("", creds, webdriverTimeout)
-
-	restoClient = http2.NewResto("", creds.Username, creds.AccessKey, 0)
-
-	rdcClient = http2.NewRDCService("", creds.Username, creds.AccessKey, rdcTimeout, config.ArtifactDownload{})
-
-	appsClient = *http2.NewAppStore("", creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
-
-	insightsClient = http2.NewInsightsService("", creds, insightsTimeout)
-
-	iamClient = http2.NewUserService("", creds, iamTimeout)
-
-	apitestingClient = http2.NewAPITester("", creds.Username, creds.AccessKey, apitestingTimeout)
-
-	imageRunnerClient = http2.NewImageRunner("", creds, imgExecTimeout)
+	testcompClient = http.NewTestComposer("", creds, testComposerTimeout)
+	webdriverClient = http.NewWebdriver("", creds, webdriverTimeout)
+	restoClient = http.NewResto("", creds.Username, creds.AccessKey, 0)
+	rdcClient = http.NewRDCService("", creds.Username, creds.AccessKey, rdcTimeout, config.ArtifactDownload{})
+	appsClient = *http.NewAppStore("", creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
+	insightsClient = http.NewInsightsService("", creds, insightsTimeout)
+	iamClient = http.NewUserService("", creds, iamTimeout)
+	apitestingClient = http.NewAPITester("", creds.Username, creds.AccessKey, apitestingTimeout)
+	imageRunnerClient = http.NewImageRunner("", creds, imgExecTimeout)
 
 	return nil
 }
@@ -296,7 +287,7 @@ func awaitGlobalTimeout() {
 
 // checkForUpdates check if there is a saucectl update available.
 func checkForUpdates() {
-	v, err := http2.DefaultGitHub.IsUpdateAvailable(version.Version)
+	v, err := http.DefaultGitHub.IsUpdateAvailable(version.Version)
 	if err != nil {
 		return
 	}

--- a/internal/cmd/storage/cmd.go
+++ b/internal/cmd/storage/cmd.go
@@ -2,16 +2,16 @@ package storage
 
 import (
 	"errors"
+	"time"
+
 	"github.com/saucelabs/saucectl/internal/credentials"
-	http2 "github.com/saucelabs/saucectl/internal/http"
+	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/spf13/cobra"
-	"net/http"
-	"time"
 )
 
 var (
-	appsClient http2.AppStore
+	appsClient http.AppStore
 )
 
 func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
@@ -30,12 +30,9 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 				return errors.New("invalid region")
 			}
 
-			appsClient = http2.AppStore{
-				HTTPClient: &http.Client{Timeout: 15 * time.Minute},
-				URL:        region.FromString(regio).APIBaseURL(),
-				Username:   credentials.Get().Username,
-				AccessKey:  credentials.Get().AccessKey,
-			}
+			appsClient = *http.NewAppStore(region.FromString(regio).APIBaseURL(),
+				credentials.Get().Username, credentials.Get().AccessKey,
+				15*time.Minute)
 
 			return nil
 		},

--- a/internal/http/apitester.go
+++ b/internal/http/apitester.go
@@ -6,15 +6,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/saucelabs/saucectl/internal/apitest"
 	"io"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/saucelabs/saucectl/internal/apitest"
+
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/msg"
-	"github.com/saucelabs/saucectl/internal/requesth"
 )
 
 // APITester describes an interface to the api-testing rest endpoints.
@@ -43,7 +43,7 @@ func NewAPITester(url string, username string, accessKey string, timeout time.Du
 // GetProject returns Project metadata for a given hookID.
 func (c *APITester) GetProject(ctx context.Context, hookID string) (apitest.ProjectMeta, error) {
 	url := fmt.Sprintf("%s/api-testing/rest/v4/%s", c.URL, hookID)
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return apitest.ProjectMeta{}, err
 	}
@@ -73,7 +73,7 @@ func (c *APITester) GetProject(ctx context.Context, hookID string) (apitest.Proj
 
 func (c *APITester) GetEventResult(ctx context.Context, hookID string, eventID string) (apitest.TestResult, error) {
 	url := fmt.Sprintf("%s/api-testing/rest/v4/%s/insights/events/%s", c.URL, hookID, eventID)
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return apitest.TestResult{}, err
 	}
@@ -103,7 +103,7 @@ func (c *APITester) GetEventResult(ctx context.Context, hookID string, eventID s
 
 func (c *APITester) GetTest(ctx context.Context, hookID string, testID string) (apitest.Test, error) {
 	url := fmt.Sprintf("%s/api-testing/rest/v4/%s/tests/%s", c.URL, hookID, testID)
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return apitest.Test{}, err
 	}
@@ -167,7 +167,7 @@ func (c *APITester) composeURL(path string, buildID string, format string, tunne
 // GetProjects returns the list of Project available.
 func (c *APITester) GetProjects(ctx context.Context) ([]apitest.ProjectMeta, error) {
 	url := fmt.Sprintf("%s/api-testing/api/project", c.URL)
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return []apitest.ProjectMeta{}, err
 	}
@@ -198,7 +198,7 @@ func (c *APITester) GetProjects(ctx context.Context) ([]apitest.ProjectMeta, err
 // GetHooks returns the list of hooks available.
 func (c *APITester) GetHooks(ctx context.Context, projectID string) ([]apitest.Hook, error) {
 	url := fmt.Sprintf("%s/api-testing/api/project/%s/hook", c.URL, projectID)
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return []apitest.Hook{}, err
 	}
@@ -236,7 +236,7 @@ func (c *APITester) RunAllAsync(ctx context.Context, hookID string, buildID stri
 	}
 	payloadReader := bytes.NewReader(payload)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodPost, url, payloadReader)
+	req, err := NewRequestWithContext(ctx, http.MethodPost, url, payloadReader)
 	if err != nil {
 		return apitest.AsyncResponse{}, err
 	}
@@ -260,7 +260,7 @@ func (c *APITester) RunEphemeralAsync(ctx context.Context, hookID string, buildI
 	}
 	payloadReader := bytes.NewReader(payload)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodPost, url, payloadReader)
+	req, err := NewRequestWithContext(ctx, http.MethodPost, url, payloadReader)
 	if err != nil {
 		return apitest.AsyncResponse{}, err
 	}
@@ -284,7 +284,7 @@ func (c *APITester) RunTestAsync(ctx context.Context, hookID string, testID stri
 	}
 	payloadReader := bytes.NewReader(payload)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodPost, url, payloadReader)
+	req, err := NewRequestWithContext(ctx, http.MethodPost, url, payloadReader)
 	if err != nil {
 		return apitest.AsyncResponse{}, err
 	}
@@ -309,7 +309,7 @@ func (c *APITester) RunTagAsync(ctx context.Context, hookID string, testTag stri
 	}
 	payloadReader := bytes.NewReader(payload)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodPost, url, payloadReader)
+	req, err := NewRequestWithContext(ctx, http.MethodPost, url, payloadReader)
 	if err != nil {
 		return apitest.AsyncResponse{}, err
 	}

--- a/internal/http/appstore.go
+++ b/internal/http/appstore.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/saucelabs/saucectl/internal/multipartext"
 
-	"github.com/saucelabs/saucectl/internal/requesth"
 	"github.com/saucelabs/saucectl/internal/storage"
 )
 
@@ -66,7 +65,7 @@ func NewAppStore(url, username, accessKey string, timeout time.Duration) *AppSto
 
 // Download downloads a file with the given id. It's the caller's responsibility to close the reader.
 func (s *AppStore) Download(id string) (io.ReadCloser, int64, error) {
-	req, err := requesth.New(http.MethodGet, fmt.Sprintf("%s/v1/storage/download/%s", s.URL, id), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/storage/download/%s", s.URL, id), nil)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -94,7 +93,7 @@ func (s *AppStore) Download(id string) (io.ReadCloser, int64, error) {
 
 // DownloadURL downloads a file from the url. It's the caller's responsibility to close the reader.
 func (s *AppStore) DownloadURL(url string) (io.ReadCloser, int64, error) {
-	req, err := requesth.New(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -120,7 +119,7 @@ func (s *AppStore) UploadStream(filename, description string, reader io.Reader) 
 		return storage.Item{}, err
 	}
 
-	req, err := requesth.New(http.MethodPost, fmt.Sprintf("%s/v1/storage/upload", s.URL), multipartReader)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/v1/storage/upload", s.URL), multipartReader)
 	if err != nil {
 		return storage.Item{}, err
 	}
@@ -178,7 +177,7 @@ func (s *AppStore) List(opts storage.ListOptions) (storage.List, error) {
 
 	uri.RawQuery = query.Encode()
 
-	req, err := requesth.New(http.MethodGet, uri.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, uri.String(), nil)
 	if err != nil {
 		return storage.List{}, err
 	}

--- a/internal/http/github.go
+++ b/internal/http/github.go
@@ -3,11 +3,11 @@ package http
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/saucelabs/saucectl/internal/requesth"
-	"golang.org/x/mod/semver"
 	"net/http"
 	"strings"
 	"time"
+
+	"golang.org/x/mod/semver"
 )
 
 // DefaultGitHub is a preconfigured instance of GitHub.
@@ -24,7 +24,7 @@ type GitHub struct {
 
 // IsUpdateAvailable returns the latest version if it's semantically higher than the given one.
 func (c *GitHub) IsUpdateAvailable(version string) (string, error) {
-	req, err := requesth.New(http.MethodGet, fmt.Sprintf("%s/repos/saucelabs/saucectl/releases/latest", c.URL), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/repos/saucelabs/saucectl/releases/latest", c.URL), nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -5,15 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/saucelabs/saucectl/internal/credentials"
-	"github.com/saucelabs/saucectl/internal/imagerunner"
-	"github.com/saucelabs/saucectl/internal/requesth"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/imagerunner"
 )
 
 type ImageRunner struct {
@@ -38,7 +38,7 @@ func (c *ImageRunner) TriggerRun(ctx context.Context, spec imagerunner.RunnerSpe
 	if err != nil {
 		return runner, err
 	}
-	req, err := requesth.NewWithContext(ctx, http.MethodPost, url, &b)
+	req, err := NewRequestWithContext(ctx, http.MethodPost, url, &b)
 	if err != nil {
 		return runner, err
 	}
@@ -68,7 +68,7 @@ func (c *ImageRunner) GetStatus(ctx context.Context, id string) (imagerunner.Run
 	var r imagerunner.Runner
 	url := fmt.Sprintf("%s/v1alpha1/hosted/image/runners/%s/status", c.URL, id)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return r, err
 	}
@@ -96,7 +96,7 @@ func (c *ImageRunner) GetStatus(ctx context.Context, id string) (imagerunner.Run
 func (c *ImageRunner) StopRun(ctx context.Context, runID string) error {
 	url := fmt.Sprintf("%s/v1alpha1/hosted/image/runners/%s", c.URL, runID)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodDelete, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (c *ImageRunner) StopRun(ctx context.Context, runID string) error {
 func (c *ImageRunner) ListArtifacts(ctx context.Context, id string) ([]string, error) {
 	url := fmt.Sprintf("%s/v1alpha1/hosted/image/runners/%s/artifacts", c.URL, id)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return []string{}, err
 	}
@@ -149,7 +149,7 @@ func (c *ImageRunner) ListArtifacts(ctx context.Context, id string) ([]string, e
 func (c *ImageRunner) DownloadArtifact(ctx context.Context, id, name, dir string) error {
 	url := fmt.Sprintf("%s/v1alpha1/hosted/image/runners/%s/artifacts/single/%s/download", c.URL, id, name)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func (c *ImageRunner) DownloadArtifact(ctx context.Context, id, name, dir string
 func (c *ImageRunner) GetLogs(ctx context.Context, id string) (string, error) {
 	url := fmt.Sprintf("%s/v1alpha1/hosted/image/runners/%s/logs/url", c.URL, id)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", err
 	}
@@ -208,7 +208,7 @@ func (c *ImageRunner) GetLogs(ctx context.Context, id string) (string, error) {
 }
 
 func (c *ImageRunner) doGetStr(ctx context.Context, url string) (string, error) {
-	urlReq, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	urlReq, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/http/insightsservice.go
+++ b/internal/http/insightsservice.go
@@ -5,18 +5,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/saucelabs/saucectl/internal/cmd/jobs/job"
-	"github.com/saucelabs/saucectl/internal/insights"
 	"io"
 	"net/http"
 	"reflect"
 	"strconv"
 	"time"
 
+	"github.com/saucelabs/saucectl/internal/cmd/jobs/job"
+	"github.com/saucelabs/saucectl/internal/insights"
+
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/iam"
-	"github.com/saucelabs/saucectl/internal/requesth"
 )
 
 const (
@@ -73,7 +73,7 @@ func (c *InsightsService) GetHistory(ctx context.Context, user iam.User, launchO
 
 	var jobHistory insights.JobHistory
 	url := fmt.Sprintf("%s/v2/insights/vdc/test-cases", c.URL)
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return jobHistory, err
 	}
@@ -155,7 +155,7 @@ func (c *InsightsService) PostTestRun(ctx context.Context, runs []insights.TestR
 		return err
 	}
 	payloadReader := bytes.NewReader(payload)
-	req, err := requesth.NewWithContext(ctx, http.MethodPost, url, payloadReader)
+	req, err := NewRequestWithContext(ctx, http.MethodPost, url, payloadReader)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func (c *InsightsService) ListJobs(ctx context.Context, userID, jobSource string
 	var jobList job.List
 
 	url := fmt.Sprintf("%s/v2/archives/jobs", c.URL)
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return jobList, err
 	}
@@ -287,7 +287,7 @@ func (c *InsightsService) readJob(ctx context.Context, jobID string, jobSource s
 
 	url := fmt.Sprintf("%s/v2/archives/%s/jobs/%s", c.URL, jobSource, jobID)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return j, err
 	}

--- a/internal/http/rdcservice.go
+++ b/internal/http/rdcservice.go
@@ -6,13 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/saucelabs/saucectl/internal/slice"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/saucelabs/saucectl/internal/slice"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/rs/zerolog/log"
@@ -22,7 +23,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/espresso"
 	"github.com/saucelabs/saucectl/internal/fpath"
 	"github.com/saucelabs/saucectl/internal/job"
-	"github.com/saucelabs/saucectl/internal/requesth"
 	"github.com/saucelabs/saucectl/internal/xcuitest"
 )
 
@@ -103,7 +103,7 @@ func NewRDCService(url, username, accessKey string, timeout time.Duration, artif
 
 // ReadAllowedCCY returns the allowed (max) concurrency for the current account.
 func (c *RDCService) ReadAllowedCCY(ctx context.Context) (int, error) {
-	req, err := requesth.NewWithContext(ctx, http.MethodGet,
+	req, err := NewRequestWithContext(ctx, http.MethodGet,
 		fmt.Sprintf("%s/v1/rdc/concurrency", c.URL), nil)
 	if err != nil {
 		return 0, err
@@ -178,7 +178,7 @@ func (c *RDCService) StartJob(ctx context.Context, opts job.StartOptions) (jobID
 		return
 	}
 
-	req, err := requesth.NewWithContext(ctx, http.MethodPost, url, &b)
+	req, err := NewRequestWithContext(ctx, http.MethodPost, url, &b)
 	if err != nil {
 		return
 	}
@@ -218,7 +218,7 @@ func (c *RDCService) ReadJob(ctx context.Context, id string, realDevice bool) (j
 		return job.Job{}, errors.New("the RDC client does not support virtual device jobs")
 	}
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet,
+	req, err := NewRequestWithContext(ctx, http.MethodGet,
 		fmt.Sprintf("%s/v1/rdc/jobs/%s", c.URL, id), nil)
 	if err != nil {
 		return job.Job{}, err
@@ -305,7 +305,7 @@ func (c *RDCService) GetJobAssetFileNames(ctx context.Context, jobID string, rea
 		return nil, errors.New("the RDC client does not support virtual device jobs")
 	}
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet,
+	req, err := NewRequestWithContext(ctx, http.MethodGet,
 		fmt.Sprintf("%s/v1/rdc/jobs/%s", c.URL, jobID), nil)
 	if err != nil {
 		return []string{}, err
@@ -376,7 +376,7 @@ func (c *RDCService) GetJobAssetFileContent(ctx context.Context, jobID, fileName
 		acceptHeader = "text/plain"
 	}
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet,
+	req, err := NewRequestWithContext(ctx, http.MethodGet,
 		fmt.Sprintf("%s/v1/rdc/jobs/%s/%s", c.URL, jobID, URIFileName), nil)
 	if err != nil {
 		return nil, err
@@ -453,7 +453,7 @@ func (c *RDCService) downloadArtifact(targetDir, jobID, fileName string, realDev
 
 // GetDevices returns the list of available devices using a specific operating system.
 func (c *RDCService) GetDevices(ctx context.Context, OS string) ([]devices.Device, error) {
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/rdc/devices/filtered", c.URL), nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/rdc/devices/filtered", c.URL), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -1,4 +1,4 @@
-package requesth
+package http
 
 import (
 	"context"
@@ -8,9 +8,9 @@ import (
 	"github.com/saucelabs/saucectl/internal/version"
 )
 
-// NewWithContext is a wrapper around http.NewRequestWithContext that modifies the request by adding additional
+// NewRequestWithContext is a wrapper around http.NewRequestWithContext that modifies the request by adding additional
 // headers.
-func NewWithContext(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
+func NewRequestWithContext(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
 	r, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return r, err

--- a/internal/http/request_test.go
+++ b/internal/http/request_test.go
@@ -1,4 +1,4 @@
-package requesth
+package http
 
 import (
 	"context"
@@ -34,9 +34,9 @@ func TestNewWithContext(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewWithContext(tt.args.ctx, tt.args.method, tt.args.url, tt.args.body)
+			got, err := NewRequestWithContext(tt.args.ctx, tt.args.method, tt.args.url, tt.args.body)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("NewWithContext() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("NewRequestWithContext() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got.Header, tt.wantHeaders) {

--- a/internal/http/request_test.go
+++ b/internal/http/request_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestNewWithContext(t *testing.T) {
+func TestNewRequestWithContext(t *testing.T) {
 	type args struct {
 		ctx    context.Context
 		method string

--- a/internal/http/resto.go
+++ b/internal/http/resto.go
@@ -21,7 +21,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/build"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/job"
-	"github.com/saucelabs/saucectl/internal/requesth"
 	tunnels "github.com/saucelabs/saucectl/internal/tunnel"
 	"github.com/saucelabs/saucectl/internal/vmd"
 )
@@ -77,7 +76,7 @@ func (c *Resto) ReadJob(ctx context.Context, id string, realDevice bool) (job.Jo
 		return job.Job{}, errors.New("the VDC client does not support real device jobs")
 	}
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet,
+	req, err := NewRequestWithContext(ctx, http.MethodGet,
 		fmt.Sprintf("%s/rest/v1.1/%s/jobs/%s", c.URL, c.Username, id), nil)
 	if err != nil {
 		return job.Job{}, err
@@ -157,7 +156,7 @@ func (c *Resto) GetJobAssetFileNames(ctx context.Context, jobID string, realDevi
 		return nil, errors.New("the VDC client does not support real device jobs")
 	}
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet,
+	req, err := NewRequestWithContext(ctx, http.MethodGet,
 		fmt.Sprintf("%s/rest/v1/%s/jobs/%s/assets", c.URL, c.Username, jobID), nil)
 	if err != nil {
 		return nil, err
@@ -213,7 +212,7 @@ func (c *Resto) GetJobAssetFileContent(ctx context.Context, jobID, fileName stri
 		return nil, errors.New("the VDC client does not support real device jobs")
 	}
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet,
+	req, err := NewRequestWithContext(ctx, http.MethodGet,
 		fmt.Sprintf("%s/rest/v1/%s/jobs/%s/assets/%s", c.URL, c.Username, jobID, fileName), nil)
 	if err != nil {
 		return nil, err
@@ -250,7 +249,7 @@ func (c *Resto) GetJobAssetFileContent(ctx context.Context, jobID, fileName stri
 
 // ReadAllowedCCY returns the allowed (max) concurrency for the current account.
 func (c *Resto) ReadAllowedCCY(ctx context.Context) (int, error) {
-	req, err := requesth.NewWithContext(ctx, http.MethodGet,
+	req, err := NewRequestWithContext(ctx, http.MethodGet,
 		fmt.Sprintf("%s/rest/v1.2/users/%s/concurrency", c.URL, c.Username), nil)
 	if err != nil {
 		return 0, err
@@ -292,7 +291,7 @@ func (c *Resto) IsTunnelRunning(ctx context.Context, id, owner string, filter tu
 }
 
 func (c *Resto) isTunnelRunning(ctx context.Context, id, owner string, filter tunnels.Filter) error {
-	req, err := requesth.NewWithContext(ctx, http.MethodGet,
+	req, err := NewRequestWithContext(ctx, http.MethodGet,
 		fmt.Sprintf("%s/rest/v1/%s/tunnels", c.URL, c.Username), nil)
 	if err != nil {
 		return err
@@ -356,7 +355,7 @@ func (c *Resto) StopJob(ctx context.Context, jobID string, realDevice bool) (job
 		return job.Job{}, errors.New("the VDC client does not support real device jobs")
 	}
 
-	req, err := requesth.NewWithContext(ctx, http.MethodPut,
+	req, err := NewRequestWithContext(ctx, http.MethodPut,
 		fmt.Sprintf("%s/rest/v1/%s/jobs/%s/stop", c.URL, c.Username, jobID), nil)
 	if err != nil {
 		return job.Job{}, err
@@ -431,7 +430,7 @@ func (c *Resto) downloadArtifact(targetDir, jobID, fileName string) error {
 
 // GetVirtualDevices returns the list of available virtual devices.
 func (c *Resto) GetVirtualDevices(ctx context.Context, kind string) ([]vmd.VirtualDevice, error) {
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/rest/v1.1/info/platforms/all", c.URL), nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/rest/v1.1/info/platforms/all", c.URL), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +486,7 @@ func (c *Resto) GetVirtualDevices(ctx context.Context, kind string) ([]vmd.Virtu
 }
 
 func (c *Resto) GetBuildID(ctx context.Context, jobID string, buildSource build.Source) (string, error) {
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v2/builds/%s/jobs/%s/build/", c.URL, buildSource, jobID), nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v2/builds/%s/jobs/%s/build/", c.URL, buildSource, jobID), nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/http/testcomposer.go
+++ b/internal/http/testcomposer.go
@@ -15,7 +15,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/job"
-	"github.com/saucelabs/saucectl/internal/requesth"
 )
 
 // TestComposer service
@@ -62,7 +61,7 @@ func NewTestComposer(url string, creds credentials.Credentials, timeout time.Dur
 func (c *TestComposer) GetSlackToken(ctx context.Context) (string, error) {
 	url := fmt.Sprintf("%s/v1/testcomposer/users/%s/settings/slack", c.URL, c.Credentials.Username)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", err
 	}
@@ -88,7 +87,7 @@ func (c *TestComposer) StartJob(ctx context.Context, opts job.StartOptions) (job
 	if err != nil {
 		return
 	}
-	req, err := requesth.NewWithContext(ctx, http.MethodPost, url, &b)
+	req, err := NewRequestWithContext(ctx, http.MethodPost, url, &b)
 	if err != nil {
 		return
 	}
@@ -140,7 +139,7 @@ func (c *TestComposer) doJSONResponse(req *http.Request, expectStatus int, v int
 func (c *TestComposer) Search(ctx context.Context, opts framework.SearchOptions) (framework.Metadata, error) {
 	url := fmt.Sprintf("%s/v1/testcomposer/frameworks/%s", c.URL, opts.Name)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return framework.Metadata{}, err
 	}
@@ -185,7 +184,7 @@ func (c *TestComposer) UploadAsset(jobID string, realDevice bool, fileName strin
 		return err
 	}
 
-	req, err := requesth.NewWithContext(context.Background(), http.MethodPut,
+	req, err := NewRequestWithContext(context.Background(), http.MethodPut,
 		fmt.Sprintf("%s/v1/testcomposer/jobs/%s/assets", c.URL, jobID), &b)
 	if err != nil {
 		return err
@@ -229,7 +228,7 @@ func (c *TestComposer) UploadAsset(jobID string, realDevice bool, fileName strin
 func (c *TestComposer) Frameworks(ctx context.Context) ([]framework.Framework, error) {
 	url := fmt.Sprintf("%s/v1/testcomposer/frameworks", c.URL)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return []framework.Framework{}, err
 	}
@@ -246,7 +245,7 @@ func (c *TestComposer) Frameworks(ctx context.Context) ([]framework.Framework, e
 func (c *TestComposer) Versions(ctx context.Context, frameworkName string) ([]framework.Metadata, error) {
 	url := fmt.Sprintf("%s/v1/testcomposer/frameworks/%s/versions", c.URL, frameworkName)
 
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return []framework.Metadata{}, err
 	}

--- a/internal/http/userservice.go
+++ b/internal/http/userservice.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/iam"
-	"github.com/saucelabs/saucectl/internal/requesth"
 )
 
 type UserService struct {
@@ -31,7 +30,7 @@ func (c *UserService) GetUser(ctx context.Context) (iam.User, error) {
 	url := fmt.Sprintf("%s/team-management/v1/users/me", c.URL)
 
 	var user iam.User
-	req, err := requesth.NewWithContext(ctx, http.MethodGet, url, nil)
+	req, err := NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return user, err
 	}

--- a/internal/http/webdriver.go
+++ b/internal/http/webdriver.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/job"
-	"github.com/saucelabs/saucectl/internal/requesth"
 	"github.com/saucelabs/saucectl/internal/slice"
 	"github.com/saucelabs/saucectl/internal/version"
 )
@@ -155,7 +154,7 @@ func (c *Webdriver) StartJob(ctx context.Context, opts job.StartOptions) (jobID 
 		return
 	}
 
-	req, err := requesth.NewWithContext(ctx, http.MethodPost, url, &b)
+	req, err := NewRequestWithContext(ctx, http.MethodPost, url, &b)
 	if err != nil {
 		return
 	}

--- a/internal/requesth/request.go
+++ b/internal/requesth/request.go
@@ -2,9 +2,10 @@ package requesth
 
 import (
 	"context"
-	"github.com/saucelabs/saucectl/internal/version"
 	"io"
 	"net/http"
+
+	"github.com/saucelabs/saucectl/internal/version"
 )
 
 // NewWithContext is a wrapper around http.NewRequestWithContext that modifies the request by adding additional
@@ -17,9 +18,4 @@ func NewWithContext(ctx context.Context, method, url string, body io.Reader) (*h
 	r.Header.Set("User-Agent", "saucectl/"+version.Version)
 
 	return r, err
-}
-
-// New is a wrapper around NewWithConext.
-func New(method, url string, body io.Reader) (*http.Request, error) {
-	return NewWithContext(context.Background(), method, url, body)
 }

--- a/internal/requesth/request_test.go
+++ b/internal/requesth/request_test.go
@@ -45,39 +45,3 @@ func TestNewWithContext(t *testing.T) {
 		})
 	}
 }
-
-func TestNew(t *testing.T) {
-	type args struct {
-		method string
-		url    string
-		body   io.Reader
-	}
-	tests := []struct {
-		name        string
-		args        args
-		wantHeaders http.Header
-		wantErr     bool
-	}{
-		{
-			name: "expect headers",
-			args: args{
-				method: "GET",
-				url:    "http://localhost",
-				body:   nil,
-			},
-			wantHeaders: http.Header{"User-Agent": []string{"saucectl/0.0.0+unknown"}},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(tt.args.method, tt.args.url, tt.args.body)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got.Header, tt.wantHeaders) {
-				t.Errorf("Headers got = %v, want %v", got, tt.wantHeaders)
-			}
-		})
-	}
-}


### PR DESCRIPTION
## Proposed changes

Now that the majority of HTTP dependencies have been consolidated, it's time to clean up the imports ✨ 
The package `requesth` becomes obsolete as well, since all calls to it originate from the `http` package, which is where it belongs to.