### PR TITLE
Fix: Propagate last error after exhausting all retry attempts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/docker/distribution v2.8.0+incompatible // indirect
 	github.com/gorilla/mux v1.7.4 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.0
+	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,8 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
-github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
+github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=

--- a/internal/http/rdcservice.go
+++ b/internal/http/rdcservice.go
@@ -90,6 +90,9 @@ func NewRDCService(url, username, accessKey string, timeout time.Duration, artif
 	httpClient.HTTPClient = nativeClient
 	httpClient.Logger = nil
 	httpClient.RetryMax = retryMax
+	httpClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
+		return resp, err
+	}
 
 	return RDCService{
 		HTTPClient:     httpClient,

--- a/internal/http/rdcservice.go
+++ b/internal/http/rdcservice.go
@@ -90,9 +90,7 @@ func NewRDCService(url, username, accessKey string, timeout time.Duration, artif
 	httpClient.HTTPClient = nativeClient
 	httpClient.Logger = nil
 	httpClient.RetryMax = retryMax
-	httpClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
-		return resp, err
-	}
+	httpClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
 
 	return RDCService{
 		HTTPClient:     httpClient,

--- a/internal/http/rdcservice_test.go
+++ b/internal/http/rdcservice_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -54,7 +53,7 @@ func TestRDCService_ReadAllowedCCY(t *testing.T) {
 			name:       "error endpoint",
 			statusCode: http.StatusInternalServerError,
 			want:       0,
-			wantErr:    errors.New("giving up after 4 attempt(s)"),
+			wantErr:    errors.New("unexpected statusCode: 500"),
 		},
 	}
 
@@ -73,7 +72,7 @@ func TestRDCService_ReadAllowedCCY(t *testing.T) {
 		ccy, err := client.ReadAllowedCCY(context.Background())
 		assert.Equal(t, ccy, tt.want)
 		if err != nil {
-			assert.True(t, strings.Contains(err.Error(), tt.wantErr.Error()))
+			assert.Equal(t, tt.wantErr, err)
 		}
 
 		ts.Close()
@@ -244,7 +243,7 @@ func TestRDCService_PollJob(t *testing.T) {
 			client:       NewRDCService(ts.URL, "test", "123", timeout, config.ArtifactDownload{}),
 			jobID:        "333",
 			expectedResp: job.Job{},
-			expectedErr:  errors.New("giving up after 4 attempt(s)"),
+			expectedErr:  errors.New("internal server error"),
 		},
 		{
 			name:   "get job details with ID 5. retry 2 times and succeed",
@@ -267,7 +266,7 @@ func TestRDCService_PollJob(t *testing.T) {
 			got, err := tc.client.PollJob(context.Background(), tc.jobID, 10*time.Millisecond, 0, true)
 			assert.Equal(t, tc.expectedResp, got)
 			if err != nil {
-				assert.True(t, strings.Contains(err.Error(), tc.expectedErr.Error()))
+				assert.Equal(t, tc.expectedErr, err)
 			}
 		})
 	}

--- a/internal/http/resto.go
+++ b/internal/http/resto.go
@@ -62,6 +62,9 @@ func NewResto(url, username, accessKey string, timeout time.Duration) Resto {
 	httpClient.HTTPClient = &http.Client{Timeout: timeout}
 	httpClient.Logger = nil
 	httpClient.RetryMax = retryMax
+	httpClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
+		return resp, err
+	}
 	return Resto{
 		HTTPClient: httpClient,
 		URL:        url,

--- a/internal/http/resto.go
+++ b/internal/http/resto.go
@@ -62,9 +62,7 @@ func NewResto(url, username, accessKey string, timeout time.Duration) Resto {
 	httpClient.HTTPClient = &http.Client{Timeout: timeout}
 	httpClient.Logger = nil
 	httpClient.RetryMax = retryMax
-	httpClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
-		return resp, err
-	}
+	httpClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
 	return Resto{
 		HTTPClient: httpClient,
 		URL:        url,

--- a/internal/http/resto_test.go
+++ b/internal/http/resto_test.go
@@ -99,7 +99,7 @@ func TestResto_GetJobDetails(t *testing.T) {
 			client:       NewResto(ts.URL, "test", "123", timeout),
 			jobID:        "333",
 			expectedResp: job.Job{},
-			expectedErr:  errors.New("giving up after 4 attempt(s)"),
+			expectedErr:  errors.New("internal server error"),
 		},
 	}
 
@@ -109,7 +109,7 @@ func TestResto_GetJobDetails(t *testing.T) {
 			got, err := tc.client.ReadJob(context.Background(), tc.jobID, false)
 			assert.Equal(t, got, tc.expectedResp)
 			if err != nil {
-				assert.True(t, strings.Contains(err.Error(), tc.expectedErr.Error()))
+				assert.Equal(t, tc.expectedErr, err)
 			}
 		})
 	}
@@ -225,7 +225,7 @@ func TestResto_GetJobStatus(t *testing.T) {
 			client:       NewResto(ts.URL, "test", "123", timeout),
 			jobID:        "333",
 			expectedResp: job.Job{},
-			expectedErr:  errors.New("giving up after 4 attempt(s)"),
+			expectedErr:  errors.New("internal server error"),
 		},
 		{
 			name:   "get job details with ID 5. retry 2 times and succeed",
@@ -247,7 +247,7 @@ func TestResto_GetJobStatus(t *testing.T) {
 			got, err := tc.client.PollJob(context.Background(), tc.jobID, 10*time.Millisecond, 0, false)
 			assert.Equal(t, got, tc.expectedResp)
 			if err != nil {
-				assert.True(t, strings.Contains(err.Error(), tc.expectedErr.Error()))
+				assert.Equal(t, tc.expectedErr, err)
 			}
 		})
 	}
@@ -310,7 +310,7 @@ func TestResto_GetJobAssetFileNames(t *testing.T) {
 			client:       NewResto(ts.URL, "test", "123", timeout),
 			jobID:        "4",
 			expectedResp: nil,
-			expectedErr:  errors.New("giving up after 4 attempt(s)"),
+			expectedErr:  errors.New("internal server error"),
 		},
 	}
 	for _, tc := range testCases {
@@ -321,7 +321,7 @@ func TestResto_GetJobAssetFileNames(t *testing.T) {
 			sort.Strings(got)
 			assert.Equal(t, tc.expectedResp, got)
 			if err != nil {
-				assert.True(t, strings.Contains(err.Error(), tc.expectedErr.Error()))
+				assert.Equal(t, tc.expectedErr, err)
 			}
 		})
 	}
@@ -370,7 +370,7 @@ func TestResto_GetJobAssetFileContent(t *testing.T) {
 			client:       NewResto(ts.URL, "test", "123", timeout),
 			jobID:        "333",
 			expectedResp: nil,
-			expectedErr:  errors.New("giving up after 4 attempt(s)"),
+			expectedErr:  errors.New("internal server error"),
 		},
 		{
 			name:         "get job asset with ID 2",
@@ -394,7 +394,7 @@ func TestResto_GetJobAssetFileContent(t *testing.T) {
 			got, err := tc.client.GetJobAssetFileContent(context.Background(), tc.jobID, "console.log", false)
 			assert.Equal(t, got, tc.expectedResp)
 			if err != nil {
-				assert.True(t, strings.Contains(err.Error(), tc.expectedErr.Error()))
+				assert.Equal(t, tc.expectedErr, err)
 			}
 		})
 	}
@@ -479,7 +479,7 @@ func TestResto_TestStop(t *testing.T) {
 			client:       NewResto(ts.URL, "test", "123", timeout),
 			jobID:        "333",
 			expectedResp: job.Job{},
-			expectedErr:  errors.New("giving up after 4 attempt(s)"),
+			expectedErr:  errors.New("internal server error"),
 		},
 	}
 
@@ -489,7 +489,7 @@ func TestResto_TestStop(t *testing.T) {
 			got, err := tc.client.StopJob(context.Background(), tc.jobID, false)
 			assert.Equal(t, got, tc.expectedResp)
 			if err != nil {
-				assert.True(t, strings.Contains(err.Error(), tc.expectedErr.Error()))
+				assert.Equal(t, tc.expectedErr, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Proposed changes

The unfortunate default behavior of the `retryablehttp` client hides details/errors of the last unsuccessful attempt:
```go
	if err == nil {
		return nil, fmt.Errorf("%s %s giving up after %d attempt(s)",
			req.Method, req.URL, attempt)
	}
```

This is usually the case if the server actually responded, but with an unexpected status code. We already have code in place that handles various responses, which could not be utilized due to `retryablehttp` throwing its own error.

This PR ensures that original errors are passed through.

PS: The jury is still out on whether or not to keep use of the `retryablehttp` client.