### PR TITLE
Report the correct payload size when uploading app files

### DIFF
--- a/internal/http/appstore.go
+++ b/internal/http/appstore.go
@@ -140,6 +140,7 @@ func (s *AppStore) UploadStream(filename, description string, reader io.Reader) 
 			ID:       ur.Item.ID,
 			Name:     ur.Item.Name,
 			Uploaded: time.Unix(ur.Item.UploadTimestamp, 0),
+			Size:     ur.Item.Size,
 		}, err
 	case 401, 403:
 		return storage.Item{}, storage.ErrAccessDenied

--- a/internal/http/appstore_test.go
+++ b/internal/http/appstore_test.go
@@ -72,13 +72,14 @@ func TestAppStore_UploadStream(t *testing.T) {
 			return
 		}
 
-		_, _ = io.Copy(io.Discard, p)
+		size, _ := io.Copy(io.Discard, p)
 
 		w.WriteHeader(201)
 		_ = json.NewEncoder(w).Encode(UploadResponse{Item{
 			ID:              itemID,
 			Name:            p.FileName(),
 			UploadTimestamp: uploadTimestamp.Unix(),
+			Size:            int(size),
 		}})
 	}))
 	defer server.Close()
@@ -112,6 +113,7 @@ func TestAppStore_UploadStream(t *testing.T) {
 				ID:       itemID,
 				Name:     "hello.txt",
 				Uploaded: uploadTimestamp,
+				Size:     6,
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
## Proposed changes

Propagate the size field back from the server response when uploading to app storage.

```sh
❯ saucectl storage upload somefile.zip -o json
{"id":"REDACTED","name":"somefile.zip","size":729,"uploaded":"2023-02-22T15:08:45-08:00"}
```

Prior to this change, the `size` was reported as 0. This only affected app storage uploads when the output format was set to `json`.