### PR TITLE
Refactor iam and credentials

### DIFF
--- a/internal/cmd/configure/cmd.go
+++ b/internal/cmd/configure/cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/backtrace"
 	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/iam"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/spf13/cobra"
@@ -54,7 +55,7 @@ func Command() *cobra.Command {
 	return cmd
 }
 
-func printCreds(creds credentials.Credentials) {
+func printCreds(creds iam.Credentials) {
 	println()
 
 	labelStyle := color.New(color.Bold)
@@ -69,7 +70,7 @@ func printCreds(creds credentials.Credentials) {
 }
 
 // interactiveConfiguration expect user to manually type-in its credentials
-func interactiveConfiguration() (credentials.Credentials, error) {
+func interactiveConfiguration() (iam.Credentials, error) {
 	overwrite := true
 	var err error
 
@@ -143,13 +144,13 @@ func interactiveConfiguration() (credentials.Credentials, error) {
 
 // Run starts the configure command
 func Run() error {
-	var creds credentials.Credentials
+	var creds iam.Credentials
 	var err error
 
 	if cliUsername == "" && cliAccessKey == "" {
 		creds, err = interactiveConfiguration()
 	} else {
-		creds = credentials.Credentials{
+		creds = iam.Credentials{
 			Username:  cliUsername,
 			AccessKey: cliAccessKey,
 		}

--- a/internal/cmd/configure/cmd.go
+++ b/internal/cmd/configure/cmd.go
@@ -76,7 +76,7 @@ func interactiveConfiguration() (iam.Credentials, error) {
 
 	creds := credentials.Get()
 
-	if creds.IsValid() {
+	if creds.IsSet() {
 		printCreds(creds)
 
 		qs := &survey.Confirm{
@@ -89,7 +89,7 @@ func interactiveConfiguration() (iam.Credentials, error) {
 	}
 
 	if overwrite {
-		if !creds.IsValid() {
+		if !creds.IsSet() {
 			fmt.Println(msg.SignupMessage)
 		}
 
@@ -159,7 +159,7 @@ func Run() error {
 		return err
 	}
 
-	if !creds.IsValid() {
+	if !creds.IsSet() {
 		log.Error().Msg("The provided credentials appear to be invalid and will NOT be saved.")
 		return fmt.Errorf(msg.InvalidCredentials)
 	}

--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -114,7 +114,7 @@ func Run(cmd *cobra.Command, initCfg *initConfig) error {
 	stdio := terminal.Stdio{In: os.Stdin, Out: os.Stdout, Err: os.Stderr}
 
 	creds := credentials.Get()
-	if !creds.IsValid() {
+	if !creds.IsSet() {
 		var err error
 		creds, err = askCredentials(stdio)
 		if err != nil {
@@ -162,7 +162,7 @@ func Run(cmd *cobra.Command, initCfg *initConfig) error {
 func batchMode(cmd *cobra.Command, initCfg *initConfig) error {
 	stdio := terminal.Stdio{In: os.Stdin, Out: os.Stdout, Err: os.Stderr}
 	creds := credentials.Get()
-	if !creds.IsValid() {
+	if !creds.IsSet() {
 		return errors.New(msg.EmptyCredentials)
 	}
 

--- a/internal/cmd/ini/initializer.go
+++ b/internal/cmd/ini/initializer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/fatih/color"
 	"github.com/saucelabs/saucectl/internal/config"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/devices"
 	"github.com/saucelabs/saucectl/internal/espresso"
@@ -49,7 +48,7 @@ type initializer struct {
 }
 
 // newInitializer creates a new initializer instance.
-func newInitializer(stdio terminal.Stdio, creds credentials.Credentials, regio string) *initializer {
+func newInitializer(stdio terminal.Stdio, creds iam.Credentials, regio string) *initializer {
 	r := region.FromString(regio)
 	tc := http.NewTestComposer(r.APIBaseURL(), creds, testComposerTimeout)
 	rc := http.NewRDCService(r.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout, config.ArtifactDownload{})
@@ -89,8 +88,8 @@ func (ini *initializer) configure() (*initConfig, error) {
 	}
 }
 
-func askCredentials(stdio terminal.Stdio) (credentials.Credentials, error) {
-	creds := credentials.Credentials{}
+func askCredentials(stdio terminal.Stdio) (iam.Credentials, error) {
+	creds := iam.Credentials{}
 	q := &survey.Input{Message: "SauceLabs username:"}
 
 	err := survey.AskOne(q, &creds.Username,

--- a/internal/cmd/ini/initializer_test.go
+++ b/internal/cmd/ini/initializer_test.go
@@ -22,7 +22,6 @@ import (
 	"gotest.tools/v3/fs"
 
 	"github.com/saucelabs/saucectl/internal/config"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/devices"
 	"github.com/saucelabs/saucectl/internal/espresso"
@@ -939,7 +938,7 @@ func TestAskCredentials(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
-				expect := &credentials.Credentials{Username: "dummy-user", AccessKey: "dummy-access-key"}
+				expect := &iam.Credentials{Username: "dummy-user", AccessKey: "dummy-access-key"}
 				if reflect.DeepEqual(creds, expect) {
 					t.Fatalf("got: %v, want: %v", creds, expect)
 				}

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -183,7 +183,7 @@ func preRun() error {
 	go awaitGlobalTimeout()
 
 	creds := credentials.Get()
-	if !creds.IsValid() {
+	if !creds.IsSet() {
 		color.Red("\nSauceCTL requires a valid Sauce Labs account!\n\n")
 		fmt.Println(`Set up your credentials by running:
 > saucectl configure`)

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -2,18 +2,18 @@ package credentials
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/yaml"
 	yamlbase "gopkg.in/yaml.v2"
-	"os"
-	"path/filepath"
 )
 
 // Credentials contains a set of Username + AccessKey for SauceLabs.
 type Credentials struct {
 	Username  string `yaml:"username"`
 	AccessKey string `yaml:"accessKey"`
-	Source    string `yaml:"-"`
 }
 
 // Get returns the configured credentials.
@@ -35,7 +35,6 @@ func FromEnv() Credentials {
 	return Credentials{
 		Username:  os.Getenv("SAUCE_USERNAME"),
 		AccessKey: os.Getenv("SAUCE_ACCESS_KEY"),
-		Source:    "environment variables",
 	}
 }
 

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -18,7 +18,7 @@ import (
 //  1. Environment variables (see FromEnv)
 //  2. Credentials file (see FromFile)
 func Get() iam.Credentials {
-	if c := FromEnv(); c.IsValid() {
+	if c := FromEnv(); c.IsSet() {
 		return c
 	}
 

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -11,6 +11,15 @@ import (
 	yamlbase "gopkg.in/yaml.v2"
 )
 
+func init() {
+	homeDir, _ := os.UserHomeDir()
+	DefaultCredsPath = filepath.Join(homeDir, ".sauce", "credentials.yml")
+}
+
+// DefaultCredsPath returns the default location of the credentials file.
+// It's under the user's home directory, if defined, otherwise under the current working directory.
+var DefaultCredsPath = ""
+
 // Get returns the configured credentials.
 // Effectively a convenience wrapper around FromEnv, followed by a call to FromFile.
 //
@@ -35,7 +44,7 @@ func FromEnv() iam.Credentials {
 
 // FromFile reads the credentials that stored in the default file location.
 func FromFile() iam.Credentials {
-	return fromFile(defaultFilepath())
+	return fromFile(DefaultCredsPath)
 }
 
 // fromFile reads the credentials from path.
@@ -63,7 +72,7 @@ func fromFile(path string) iam.Credentials {
 
 // ToFile stores the provided credentials in the default file location.
 func ToFile(c iam.Credentials) error {
-	return toFile(c, defaultFilepath())
+	return toFile(c, DefaultCredsPath)
 }
 
 // toFile stores the provided credentials into the file at path.
@@ -72,11 +81,4 @@ func toFile(c iam.Credentials, path string) error {
 		return fmt.Errorf("unable to create configuration folder")
 	}
 	return yaml.WriteFile(path, c, 0600)
-}
-
-// defaultFilepath returns the default location of the credentials file.
-// It will be based on the user home directory, if defined, or under the current working directory otherwise.
-func defaultFilepath() string {
-	homeDir, _ := os.UserHomeDir()
-	return filepath.Join(homeDir, ".sauce", "credentials.yml")
 }

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Get returns the configured credentials.
-// Effectively a covenience wrapper around FromEnv, followed by a call to FromFile.
+// Effectively a convenience wrapper around FromEnv, followed by a call to FromFile.
 //
 // The lookup order is:
 //  1. Environment variables (see FromEnv)

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -5,13 +5,15 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/saucelabs/saucectl/internal/iam"
 )
 
 func TestFromEnv(t *testing.T) {
 	tests := []struct {
 		name       string
 		beforeTest func()
-		want       Credentials
+		want       iam.Credentials
 	}{
 		{
 			name: "env vars exist",
@@ -19,7 +21,7 @@ func TestFromEnv(t *testing.T) {
 				_ = os.Setenv("SAUCE_USERNAME", "saucebot")
 				_ = os.Setenv("SAUCE_ACCESS_KEY", "123")
 			},
-			want: Credentials{
+			want: iam.Credentials{
 				Username:  "saucebot",
 				AccessKey: "123",
 			},
@@ -30,7 +32,7 @@ func TestFromEnv(t *testing.T) {
 				_ = os.Unsetenv("SAUCE_USERNAME")
 				_ = os.Unsetenv("SAUCE_ACCESS_KEY")
 			},
-			want: Credentials{},
+			want: iam.Credentials{},
 		},
 	}
 	for _, tt := range tests {
@@ -85,7 +87,7 @@ func TestCredentials_IsValid(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Credentials{
+			c := &iam.Credentials{
 				Username:  tt.fields.Username,
 				AccessKey: tt.fields.AccessKey,
 			}
@@ -113,7 +115,7 @@ func TestFromFile(t *testing.T) {
 		name       string
 		args       args
 		beforeTest func()
-		want       Credentials
+		want       iam.Credentials
 	}{
 		{
 			name: "creds exist",
@@ -121,7 +123,7 @@ func TestFromFile(t *testing.T) {
 				path: filepath.Join(tempDir, "credilicious.yml"),
 			},
 			beforeTest: func() {
-				c := Credentials{
+				c := iam.Credentials{
 					Username:  "saucebot",
 					AccessKey: "123",
 				}
@@ -129,7 +131,7 @@ func TestFromFile(t *testing.T) {
 					t.Errorf("Failed to create credentials file: %v", err)
 				}
 			},
-			want: Credentials{
+			want: iam.Credentials{
 				Username:  "saucebot",
 				AccessKey: "123",
 			},
@@ -140,7 +142,7 @@ func TestFromFile(t *testing.T) {
 				path: filepath.Join(tempDir, "you-shall-not-find-me.yml"),
 			},
 			beforeTest: func() {},
-			want:       Credentials{},
+			want:       iam.Credentials{},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -22,7 +22,6 @@ func TestFromEnv(t *testing.T) {
 			want: Credentials{
 				Username:  "saucebot",
 				AccessKey: "123",
-				Source:    "environment variables",
 			},
 		},
 		{
@@ -31,9 +30,7 @@ func TestFromEnv(t *testing.T) {
 				_ = os.Unsetenv("SAUCE_USERNAME")
 				_ = os.Unsetenv("SAUCE_ACCESS_KEY")
 			},
-			want: Credentials{
-				Source: "environment variables",
-			},
+			want: Credentials{},
 		},
 	}
 	for _, tt := range tests {
@@ -50,7 +47,6 @@ func TestCredentials_IsValid(t *testing.T) {
 	type fields struct {
 		Username  string
 		AccessKey string
-		Source    string
 	}
 	tests := []struct {
 		name   string
@@ -92,7 +88,6 @@ func TestCredentials_IsValid(t *testing.T) {
 			c := &Credentials{
 				Username:  tt.fields.Username,
 				AccessKey: tt.fields.AccessKey,
-				Source:    tt.fields.Source,
 			}
 			if got := c.IsValid(); got != tt.want {
 				t.Errorf("IsValid() = %v, want %v", got, tt.want)

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -91,8 +91,8 @@ func TestCredentials_IsValid(t *testing.T) {
 				Username:  tt.fields.Username,
 				AccessKey: tt.fields.AccessKey,
 			}
-			if got := c.IsValid(); got != tt.want {
-				t.Errorf("IsValid() = %v, want %v", got, tt.want)
+			if got := c.IsSet(); got != tt.want {
+				t.Errorf("IsSet() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -172,7 +172,7 @@ func Test_defaultFilepath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := defaultFilepath(); got != tt.want {
+			if got := DefaultCredsPath; got != tt.want {
 				t.Errorf("defaultFilepath() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -13,17 +13,17 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/iam"
 	"github.com/saucelabs/saucectl/internal/imagerunner"
 )
 
 type ImageRunner struct {
 	Client *retryablehttp.Client
 	URL    string
-	Creds  credentials.Credentials
+	Creds  iam.Credentials
 }
 
-func NewImageRunner(url string, creds credentials.Credentials, timeout time.Duration) ImageRunner {
+func NewImageRunner(url string, creds iam.Credentials, timeout time.Duration) ImageRunner {
 	return ImageRunner{
 		Client: NewRetryableClient(timeout),
 		URL:    url,

--- a/internal/http/insightsservice.go
+++ b/internal/http/insightsservice.go
@@ -15,7 +15,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/insights"
 
 	"github.com/saucelabs/saucectl/internal/config"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/iam"
 )
 
@@ -51,14 +50,14 @@ const AutomaticRunMode = "automatic"
 type InsightsService struct {
 	HTTPClient  *http.Client
 	URL         string
-	Credentials credentials.Credentials
+	Credentials iam.Credentials
 }
 
 var LaunchOptions = map[config.LaunchOrder]string{
 	config.LaunchOrderFailRate: "fail_rate",
 }
 
-func NewInsightsService(url string, creds credentials.Credentials, timeout time.Duration) InsightsService {
+func NewInsightsService(url string, creds iam.Credentials, timeout time.Duration) InsightsService {
 	return InsightsService{
 		HTTPClient:  &http.Client{Timeout: timeout},
 		URL:         url,

--- a/internal/http/insightsservice_test.go
+++ b/internal/http/insightsservice_test.go
@@ -2,11 +2,12 @@ package http
 
 import (
 	"context"
-	"github.com/saucelabs/saucectl/internal/credentials"
-	"github.com/saucelabs/saucectl/internal/insights"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/saucelabs/saucectl/internal/iam"
+	"github.com/saucelabs/saucectl/internal/insights"
 )
 
 func TestInsightsService_PostTestRun(t *testing.T) {
@@ -49,7 +50,7 @@ func TestInsightsService_PostTestRun(t *testing.T) {
 			c := &InsightsService{
 				HTTPClient:  ts.Client(),
 				URL:         ts.URL,
-				Credentials: credentials.Credentials{AccessKey: "accessKey", Username: "username"},
+				Credentials: iam.Credentials{AccessKey: "accessKey", Username: "username"},
 			}
 			if err := c.PostTestRun(context.Background(), tt.runs); (err != nil) != tt.wantErr {
 				t.Errorf("PostTestRun() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/http/testcomposer.go
+++ b/internal/http/testcomposer.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/framework"
+	"github.com/saucelabs/saucectl/internal/iam"
 	"github.com/saucelabs/saucectl/internal/job"
 )
 
@@ -21,7 +21,7 @@ import (
 type TestComposer struct {
 	HTTPClient  *http.Client
 	URL         string // e.g.) https://api.<region>.saucelabs.net
-	Credentials credentials.Credentials
+	Credentials iam.Credentials
 }
 
 // FrameworkResponse represents the response body for framework information.
@@ -49,7 +49,7 @@ type runner struct {
 	GitRelease         string `json:"gitRelease"`
 }
 
-func NewTestComposer(url string, creds credentials.Credentials, timeout time.Duration) TestComposer {
+func NewTestComposer(url string, creds iam.Credentials, timeout time.Duration) TestComposer {
 	return TestComposer{
 		HTTPClient:  &http.Client{Timeout: timeout},
 		URL:         url,

--- a/internal/http/testcomposer_test.go
+++ b/internal/http/testcomposer_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/framework"
+	"github.com/saucelabs/saucectl/internal/iam"
 	"github.com/saucelabs/saucectl/internal/job"
 )
 
@@ -112,7 +112,7 @@ func TestTestComposer_GetSlackToken(t *testing.T) {
 	type fields struct {
 		HTTPClient  *http.Client
 		URL         string
-		Credentials credentials.Credentials
+		Credentials iam.Credentials
 	}
 	tests := []struct {
 		name       string
@@ -179,7 +179,7 @@ func TestTestComposer_Search(t *testing.T) {
 	type fields struct {
 		HTTPClient  *http.Client
 		URL         string
-		Credentials credentials.Credentials
+		Credentials iam.Credentials
 	}
 	type args struct {
 		ctx  context.Context
@@ -300,7 +300,7 @@ func TestTestComposer_UploadAsset(t *testing.T) {
 			client: TestComposer{
 				HTTPClient:  ts.Client(),
 				URL:         ts.URL,
-				Credentials: credentials.Credentials{Username: "test", AccessKey: "123"},
+				Credentials: iam.Credentials{Username: "test", AccessKey: "123"},
 			},
 			args: args{
 				jobID:       "1",
@@ -315,7 +315,7 @@ func TestTestComposer_UploadAsset(t *testing.T) {
 			client: TestComposer{
 				HTTPClient:  ts.Client(),
 				URL:         ts.URL,
-				Credentials: credentials.Credentials{Username: "test", AccessKey: "123"},
+				Credentials: iam.Credentials{Username: "test", AccessKey: "123"},
 			},
 			args: args{
 				jobID:       "2",
@@ -330,7 +330,7 @@ func TestTestComposer_UploadAsset(t *testing.T) {
 			client: TestComposer{
 				HTTPClient:  ts.Client(),
 				URL:         ts.URL,
-				Credentials: credentials.Credentials{Username: "test", AccessKey: "123"},
+				Credentials: iam.Credentials{Username: "test", AccessKey: "123"},
 			},
 			args: args{
 				jobID:       "3",
@@ -398,7 +398,7 @@ func TestTestComposer_Frameworks(t *testing.T) {
 			c := &TestComposer{
 				HTTPClient:  http.DefaultClient,
 				URL:         ts.URL,
-				Credentials: credentials.Credentials{Username: "test", AccessKey: "123"},
+				Credentials: iam.Credentials{Username: "test", AccessKey: "123"},
 			}
 			got, err := c.Frameworks(context.Background())
 			if (err != nil) != tt.wantErr {
@@ -434,7 +434,7 @@ func TestTestComposer_Versions(t *testing.T) {
 	c := &TestComposer{
 		HTTPClient:  ts.Client(),
 		URL:         ts.URL,
-		Credentials: credentials.Credentials{Username: "test", AccessKey: "123"},
+		Credentials: iam.Credentials{Username: "test", AccessKey: "123"},
 	}
 	type args struct {
 		frameworkName string

--- a/internal/http/userservice.go
+++ b/internal/http/userservice.go
@@ -8,17 +8,16 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/iam"
 )
 
 type UserService struct {
 	HTTPClient  *http.Client
 	URL         string
-	Credentials credentials.Credentials
+	Credentials iam.Credentials
 }
 
-func NewUserService(url string, creds credentials.Credentials, timeout time.Duration) UserService {
+func NewUserService(url string, creds iam.Credentials, timeout time.Duration) UserService {
 	return UserService{
 		HTTPClient:  &http.Client{Timeout: timeout},
 		URL:         url,

--- a/internal/http/webdriver.go
+++ b/internal/http/webdriver.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/iam"
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/slice"
 	"github.com/saucelabs/saucectl/internal/version"
@@ -20,7 +20,7 @@ import (
 type Webdriver struct {
 	HTTPClient  *http.Client
 	URL         string
-	Credentials credentials.Credentials
+	Credentials iam.Credentials
 }
 
 // SessionRequest represents the webdriver session request.
@@ -84,7 +84,7 @@ type sessionStartResponse struct {
 	} `json:"value,omitempty"`
 }
 
-func NewWebdriver(url string, creds credentials.Credentials, timeout time.Duration) Webdriver {
+func NewWebdriver(url string, creds iam.Credentials, timeout time.Duration) Webdriver {
 	return Webdriver{
 		HTTPClient: &http.Client{
 			Timeout: timeout,

--- a/internal/iam/auth.go
+++ b/internal/iam/auth.go
@@ -1,0 +1,18 @@
+package iam
+
+// Credentials contains a set of Username + AccessKey for SauceLabs.
+type Credentials struct {
+	Username  string `yaml:"username"`
+	AccessKey string `yaml:"accessKey"`
+}
+
+// IsEmpty checks whether the credentials, i.e. username and access key are not empty.
+// Returns false if even one of the credentials is empty.
+func (c *Credentials) IsEmpty() bool {
+	return c.AccessKey == "" || c.Username == ""
+}
+
+// IsValid validates that the credentials are valid.
+func (c *Credentials) IsValid() bool {
+	return !c.IsEmpty()
+}

--- a/internal/iam/auth.go
+++ b/internal/iam/auth.go
@@ -1,6 +1,6 @@
 package iam
 
-// Credentials contains a set of Username + AccessKey for SauceLabs.
+// Credentials holds the credentials for accessing Sauce Labs.
 type Credentials struct {
 	Username  string `yaml:"username"`
 	AccessKey string `yaml:"accessKey"`

--- a/internal/iam/auth.go
+++ b/internal/iam/auth.go
@@ -6,13 +6,8 @@ type Credentials struct {
 	AccessKey string `yaml:"accessKey"`
 }
 
-// IsEmpty checks whether the credentials, i.e. username and access key are not empty.
+// IsSet checks whether the credentials, i.e. username and access key are not empty.
 // Returns false if even one of the credentials is empty.
-func (c *Credentials) IsEmpty() bool {
-	return c.AccessKey == "" || c.Username == ""
-}
-
-// IsValid validates that the credentials are valid.
-func (c *Credentials) IsValid() bool {
-	return !c.IsEmpty()
+func (c *Credentials) IsSet() bool {
+	return c.AccessKey != "" && c.Username != ""
 }


### PR DESCRIPTION
## Proposed changes

Minor refactor that separates out the definition of `credentials` by moving it to the `iam` package, which is where it likely belongs.

Implementation details for the retrieval of stored credentials (env + filesystem) will remain in the `credentials` package. Creating a full blown "CredentialsProvider" felt a bit over-engineered to me compared the convenience that the `credentials` package right now provides.