### PR TITLE
ImageRunner: Add Artifact download support

### DIFF
--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -135,7 +135,7 @@ func (c *ImageRunner) GetArtifacts(ctx context.Context, id string) ([]imagerunne
 	}
 
 	type response struct {
-		Url string `json:"url"`
+		URL string `json:"url"`
 	}
 
 	var urlLink response
@@ -143,7 +143,7 @@ func (c *ImageRunner) GetArtifacts(ctx context.Context, id string) ([]imagerunne
 		return []imagerunner.Artifact{}, fmt.Errorf("failed to decode server response: %w", err)
 	}
 
-	return c.downloadAndUnpack(ctx, urlLink.Url)
+	return c.downloadAndUnpack(ctx, urlLink.URL)
 }
 
 func (c *ImageRunner) downloadAndUnpack(ctx context.Context, url string) ([]imagerunner.Artifact, error) {

--- a/internal/http/imagerunner_test.go
+++ b/internal/http/imagerunner_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 )
 
@@ -38,17 +37,12 @@ func TestImageRunner_GetArtifacts(t *testing.T) {
 				id:  "run-id-1",
 			},
 			want: func(t assert.TestingT, i interface{}, input ...interface{}) bool {
-				id := i.(string)
-				fd, err := os.Open(id)
-				defer func(fd *os.File) {
-					err := fd.Close()
-					assert.Equal(t, err, nil)
-				}(fd)
+				rd := i.(io.ReadCloser)
+				buf, err := io.ReadAll(rd)
 				if err != nil {
 					return false
 				}
-				body, _ := io.ReadAll(fd)
-				return string(body) == "expected-run-1"
+				return string(buf) == "expected-run-1"
 			},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return err == nil

--- a/internal/http/imagerunner_test.go
+++ b/internal/http/imagerunner_test.go
@@ -1,0 +1,106 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/saucelabs/saucectl/internal/iam"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestImageRunner_GetArtifacts(t *testing.T) {
+	type fields struct {
+		Client *retryablehttp.Client
+		URL    string
+		Creds  iam.Credentials
+	}
+	type args struct {
+		ctx context.Context
+		id  string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    assert.ValueAssertionFunc
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:   "Empty Payload",
+			fields: fields{},
+			args: args{
+				ctx: context.Background(),
+				id:  "run-id-1",
+			},
+			want: func(t assert.TestingT, i interface{}, input ...interface{}) bool {
+				id := i.(string)
+				fd, err := os.Open(id)
+				defer fd.Close()
+				if err != nil {
+					return false
+				}
+				body, _ := io.ReadAll(fd)
+				return string(body) == "expected-run-1"
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				if err == nil {
+					return true
+				}
+				return false
+			},
+		},
+	}
+	ta := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		switch r.URL.Path {
+		case "/artifacts/run-id-1":
+			w.WriteHeader(200)
+			_, err = w.Write([]byte("expected-run-1"))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+
+		if err != nil {
+			t.Errorf("failed to respond: %v", err)
+		}
+	}))
+	defer ta.Close()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		switch r.URL.Path {
+		case "/v1alpha1/hosted/image/runners/run-id-1/artifacts/url":
+			w.WriteHeader(200)
+			_, err = w.Write([]byte(fmt.Sprintf(`{"url":"%s/artifacts/run-id-1"}`, ta.URL)))
+			break
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+
+		if err != nil {
+			t.Errorf("failed to respond: %v", err)
+		}
+	}))
+	defer ts.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ImageRunner{
+				Client: retryablehttp.NewClient(),
+				URL:    ts.URL,
+				Creds:  tt.fields.Creds,
+			}
+			got, err := c.DownloadArtifacts(tt.args.ctx, tt.args.id)
+			if err != nil {
+			}
+			if !tt.wantErr(t, err, fmt.Sprintf("GetArtifacts(%v, %v)", tt.args.ctx, tt.args.id)) {
+				return
+			}
+			tt.want(t, got, fmt.Sprintf("GetArtifacts(%v, %v)", tt.args.ctx, tt.args.id))
+		})
+	}
+}

--- a/internal/imagerunner/imagerunner.go
+++ b/internal/imagerunner/imagerunner.go
@@ -68,3 +68,8 @@ type Runner struct {
 	TerminationTime   int64  `json:"termination_time,omitempty"`
 	TerminationReason string `json:"termination_reason,omitempty"`
 }
+
+type Artifact struct {
+	Name    string
+	Content []byte
+}

--- a/internal/imagerunner/imagerunner.go
+++ b/internal/imagerunner/imagerunner.go
@@ -68,8 +68,3 @@ type Runner struct {
 	TerminationTime   int64  `json:"termination_time,omitempty"`
 	TerminationReason string `json:"termination_reason,omitempty"`
 }
-
-type Artifact struct {
-	Name    string
-	Content []byte
-}

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -363,7 +363,7 @@ func (r *ImgRunner) DownloadArtifacts(runnerID, suiteName, status string, passed
 	log.Info().Msg("Downloading artifacts archive")
 	fileName, err := r.RunnerService.DownloadArtifacts(r.ctx, runnerID)
 	if err != nil {
-		log.Err(err).Str("suite", suiteName).Msg("Failed to fetch up artifacts.")
+		log.Err(err).Str("suite", suiteName).Msg("Failed to fetch artifacts.")
 		return
 	}
 

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -14,7 +14,9 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -317,6 +319,15 @@ func (r *ImgRunner) PollRun(ctx context.Context, id string, lastStatus string) (
 
 func extractFile(artifactFolder string, file *zip.File) error {
 	fullPath := path.Join(artifactFolder, file.Name)
+
+	relPath, err := filepath.Rel(artifactFolder, fullPath)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(relPath, "..") {
+		return errors.New(fmt.Sprintf("file %s is relative to an outside folder", file.Name))
+	}
+
 	folder := path.Dir(fullPath)
 	if err := os.MkdirAll(folder, 0755); err != nil {
 		return err

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -337,6 +337,7 @@ func extractFile(artifactFolder string, file *zip.File) error {
 	if err != nil {
 		return err
 	}
+	defer fd.Close()
 
 	rd, err := file.Open()
 	if err != nil {

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -337,19 +337,20 @@ func extractFile(artifactFolder string, file *zip.File) error {
 	if err != nil {
 		return err
 	}
-	defer fd.Close()
 
 	rd, err := file.Open()
 	if err != nil {
+		fd.Close()
 		return err
 	}
 	defer rd.Close()
 
 	_, err = io.Copy(fd, rd)
 	if err != nil {
+		fd.Close()
 		return err
 	}
-	return nil
+	return fd.Close()
 }
 
 func saveToTempFile(closer io.ReadCloser) (string, error) {

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -358,12 +358,11 @@ func saveToTempFile(closer io.ReadCloser) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer closer.Close()
+
 	_, err = io.Copy(fd, closer)
 	if err != nil {
-		return "", err
-	}
-
-	if err = closer.Close(); err != nil {
+		fd.Close()
 		return "", err
 	}
 	return fd.Name(), fd.Close()

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -342,6 +342,8 @@ func extractFile(artifactFolder string, file *zip.File) error {
 	if err != nil {
 		return err
 	}
+	defer rd.Close()
+
 	_, err = io.Copy(fd, rd)
 	if err != nil {
 		return err
@@ -349,10 +351,9 @@ func extractFile(artifactFolder string, file *zip.File) error {
 	return nil
 }
 
-func saveToFile(closer io.ReadCloser) (string, error) {
+func saveToTempFile(closer io.ReadCloser) (string, error) {
 	fd, err := os.CreateTemp("", "")
 	if err != nil {
-		//log.Err(err).Str("suite", suiteName).Msg("Failed to fetch artifacts.")
 		return "", err
 	}
 	_, err = io.Copy(fd, closer)
@@ -383,7 +384,7 @@ func (r *ImgRunner) DownloadArtifacts(runnerID, suiteName, status string, passed
 		log.Err(err).Str("suite", suiteName).Msg("Failed to fetch artifacts.")
 		return
 	}
-	fileName, err := saveToFile(reader)
+	fileName, err := saveToTempFile(reader)
 	if err != nil {
 		log.Err(err).Str("suite", suiteName).Msg("Failed to download artifacts content.")
 		return

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -337,32 +337,31 @@ func extractFile(artifactFolder string, file *zip.File) error {
 	if err != nil {
 		return err
 	}
+	defer fd.Close()
 
 	rd, err := file.Open()
 	if err != nil {
-		fd.Close()
 		return err
 	}
 	defer rd.Close()
 
 	_, err = io.Copy(fd, rd)
 	if err != nil {
-		fd.Close()
 		return err
 	}
 	return fd.Close()
 }
 
 func saveToTempFile(closer io.ReadCloser) (string, error) {
+	defer closer.Close()
 	fd, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", err
 	}
-	defer closer.Close()
+	defer fd.Close()
 
 	_, err = io.Copy(fd, closer)
 	if err != nil {
-		fd.Close()
 		return "", err
 	}
 	return fd.Name(), fd.Close()

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -390,11 +390,13 @@ func (r *ImgRunner) DownloadArtifacts(runnerID, suiteName, status string, passed
 		log.Err(err).Str("suite", suiteName).Msg("Failed to download artifacts content.")
 		return
 	}
+	defer os.Remove(fileName)
 
 	zf, err := zip.OpenReader(fileName)
 	if err != nil {
 		return
 	}
+	defer zf.Close()
 	for _, f := range zf.File {
 		for _, pattern := range r.Project.Artifacts.Download.Match {
 			if glob.Glob(pattern, f.Name) {

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -346,6 +346,7 @@ func (r *ImgRunner) DownloadArtifacts(runnerID, suiteName, status string, passed
 	files, err := r.RunnerService.GetArtifacts(r.ctx, runnerID)
 	if err != nil {
 		log.Err(err).Str("suite", suiteName).Msg("Failed to look up artifacts.")
+		return
 	}
 	for _, f := range files {
 		for _, pattern := range r.Project.Artifacts.Download.Match {

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -328,6 +328,9 @@ func extractFile(artifactFolder string, file *zip.File) error {
 	}
 
 	rd, err := file.Open()
+	if err != nil {
+		return err
+	}
 	_, err = io.Copy(fd, rd)
 	if err != nil {
 		return err

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -325,7 +325,7 @@ func extractFile(artifactFolder string, file *zip.File) error {
 		return err
 	}
 	if strings.Contains(relPath, "..") {
-		return errors.New(fmt.Sprintf("file %s is relative to an outside folder", file.Name))
+		return fmt.Errorf("file %s is relative to an outside folder", file.Name)
 	}
 
 	folder := path.Dir(fullPath)


### PR DESCRIPTION
## Proposed changes

Implement artifact downloads for jobs triggered by `ImageRunner` mode.

Potential issues:
- If payload is huge, it may take a long time to download and consume a lot of RAM.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->