### PR TITLE
Add init for ImageRunner mode

### DIFF
--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -159,6 +159,7 @@ func Run(cmd *cobra.Command, initCfg *initConfig) error {
 		return err
 	}
 	displaySummary(files)
+	displayExtraInfo(initCfg.frameworkName)
 	return nil
 }
 
@@ -217,5 +218,6 @@ func batchMode(cmd *cobra.Command, initCfg *initConfig) error {
 		return err
 	}
 	displaySummary(files)
+	displayExtraInfo(initCfg.frameworkName)
 	return nil
 }

--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/cypress"
 	"github.com/saucelabs/saucectl/internal/espresso"
 	"github.com/saucelabs/saucectl/internal/flags"
+	"github.com/saucelabs/saucectl/internal/imagerunner"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/playwright"
 	"github.com/saucelabs/saucectl/internal/puppeteer"
@@ -39,6 +40,7 @@ type initConfig struct {
 	frameworkName    string
 	frameworkVersion string
 	cypressJSON      string
+	dockerImage      string
 	app              string
 	testApp          string
 	otherApps        []string
@@ -95,6 +97,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVarP(&initCfg.frameworkName, "framework", "f", "", "framework to configure")
 	cmd.Flags().StringVarP(&initCfg.frameworkVersion, "frameworkVersion", "v", "", "framework version to be used")
 	cmd.Flags().StringVar(&initCfg.cypressJSON, "cypress.config", "", "path to cypress.json file (cypress only)")
+	cmd.Flags().StringVar(&initCfg.dockerImage, "dockerImage", "", "docker image to use (imagerunner only)")
 	cmd.Flags().StringVar(&initCfg.app, "app", "", "path to application to test (espresso/xcuitest only)")
 	cmd.Flags().StringVarP(&initCfg.testApp, "testApp", "t", "", "path to test application (espresso/xcuitest only)")
 	cmd.Flags().StringSliceVarP(&initCfg.otherApps, "otherApps", "o", []string{}, "path to other applications (espresso/xcuitest only)")
@@ -183,6 +186,8 @@ func batchMode(cmd *cobra.Command, initCfg *initConfig) error {
 		initCfg, errs = ini.initializeBatchTestcafe(initCfg)
 	case xcuitest.Kind:
 		initCfg, errs = ini.initializeBatchXcuitest(cmd.Flags(), initCfg)
+	case imagerunner.Kind:
+		initCfg, errs = ini.initializeBatchImageRunner(initCfg)
 	default:
 		println()
 		color.HiRed("Invalid framework selected")

--- a/internal/cmd/ini/common.go
+++ b/internal/cmd/ini/common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -19,12 +20,13 @@ import (
 )
 
 var configurators = map[string]func(cfg *initConfig) interface{}{
-	"cypress":    configureCypress,
-	"espresso":   configureEspresso,
-	"playwright": configurePlaywright,
-	"puppeteer":  configurePuppeteer,
-	"testcafe":   configureTestcafe,
-	"xcuitest":   configureXCUITest,
+	"cypress":     configureCypress,
+	"espresso":    configureEspresso,
+	"playwright":  configurePlaywright,
+	"puppeteer":   configurePuppeteer,
+	"testcafe":    configureTestcafe,
+	"xcuitest":    configureXCUITest,
+	"imagerunner": configureImageRunner,
 }
 
 var sauceignores = map[string]string{
@@ -133,6 +135,17 @@ func extValidator(framework, frameworkVersion string) survey.Validator {
 			return fmt.Errorf("%s: %v", val, err)
 		}
 		return nil
+	}
+}
+
+func dockerImageValidator() survey.Validator {
+	re := regexp.MustCompile("^([\\w.\\-_]+((:\\d+|)(/[a-z0-9._-]+/[a-z0-9._-]+))|)(/|)([a-z0-9.\\-_]+(/[a-z0-9.\\-_]+|))(:([\\w.\\-_]{1,127})|)$")
+	return func(s interface{}) error {
+		str := s.(string)
+		if re.MatchString(str) {
+			return nil
+		}
+		return fmt.Errorf("%s is not a valid docker image", str)
 	}
 }
 

--- a/internal/cmd/ini/common.go
+++ b/internal/cmd/ini/common.go
@@ -29,6 +29,10 @@ var configurators = map[string]func(cfg *initConfig) interface{}{
 	"imagerunner": configureImageRunner,
 }
 
+var extraInfoDisplay = map[string]func(){
+	"imagerunner": displayExtraInfoImageRunner,
+}
+
 var sauceignores = map[string]string{
 	"cypress":    sauceignoreCypress,
 	"playwright": sauceignorePlaywright,
@@ -98,6 +102,14 @@ func displaySummary(files []string) {
 		color.Green("  %s", f)
 	}
 	println()
+}
+
+func displayExtraInfo(framework string) {
+	fn, present := extraInfoDisplay[framework]
+	if !present {
+		return
+	}
+	fn()
 }
 
 func completeBasic(toComplete string) []string {

--- a/internal/cmd/ini/common.go
+++ b/internal/cmd/ini/common.go
@@ -139,7 +139,7 @@ func extValidator(framework, frameworkVersion string) survey.Validator {
 }
 
 func dockerImageValidator() survey.Validator {
-	re := regexp.MustCompile("^([\\w.\\-_]+((:\\d+|)(/[a-z0-9._-]+/[a-z0-9._-]+))|)(/|)([a-z0-9.\\-_]+(/[a-z0-9.\\-_]+|))(:([\\w.\\-_]{1,127})|)$")
+	re := regexp.MustCompile(`^([\w.\-_]+((:\d+|)(/[a-z0-9._-]+/[a-z0-9._-]+))|)(/|)([a-z0-9.\-_]+(/[a-z0-9.\-_]+|))(:([\w.\-_]{1,127})|)$`)
 	return func(s interface{}) error {
 		str := s.(string)
 		if re.MatchString(str) {

--- a/internal/cmd/ini/common_test.go
+++ b/internal/cmd/ini/common_test.go
@@ -624,3 +624,57 @@ func TestCommon_getMajorVersion(t *testing.T) {
 		})
 	}
 }
+
+func Test_dockerImageValidator(t *testing.T) {
+	tests := []struct {
+		image string
+		want  error
+	}{
+		{
+			image: "alpine",
+			want:  nil,
+		},
+		{
+			image: "alpine:latest",
+			want:  nil,
+		},
+		{
+			image: "_/alpine",
+			want:  nil,
+		},
+		{
+			image: "_/alpine:latest",
+			want:  nil,
+		},
+		{
+			image: "alpine:3.7",
+			want:  nil,
+		},
+		{
+			image: "docker.example.com/gmr/alpine:3.7",
+			want:  nil,
+		},
+		{
+			image: "docker.example.com:5000/gmr/alpine:latest",
+			want:  nil,
+		},
+		{
+			image: "pse/anabroker:latest",
+			want:  nil,
+		},
+		{
+			image: "buggy::latest",
+			want:  errors.New("buggy::latest is not a valid docker image"),
+		},
+		{
+			image: "buggy:",
+			want:  errors.New("buggy: is not a valid docker image"),
+		},
+	}
+	val := dockerImageValidator()
+	for _, tt := range tests {
+		t.Run(tt.image, func(t *testing.T) {
+			assert.Equalf(t, tt.want, val(tt.image), "dockerImageValidator()")
+		})
+	}
+}

--- a/internal/cmd/ini/imagerunner.go
+++ b/internal/cmd/ini/imagerunner.go
@@ -39,7 +39,7 @@ func configureImageRunner(cfg *initConfig) interface{} {
 
 func displayExtraInfoImageRunner() {
 	println()
-	color.HiGreen("Before running your pipeline, you need to set the following environment variables:")
+	color.HiGreen("Before running your tests, you need to set the following environment variables:")
 	color.Green("  - DOCKER_USERNAME")
 	color.Green("  - DOCKER_PASSWORD")
 	println()

--- a/internal/cmd/ini/imagerunner.go
+++ b/internal/cmd/ini/imagerunner.go
@@ -19,6 +19,10 @@ func configureImageRunner(cfg *initConfig) interface{} {
 			{
 				Name:  fmt.Sprintf("imagerunner - %s", cfg.dockerImage),
 				Image: cfg.dockerImage,
+				ImagePullAuth: imagerunner.ImagePullAuth{
+					User:  "${DOCKER_USERNAME}",
+					Token: "${DOCKER_PASSWORD}",
+				},
 			},
 		},
 		Artifacts: config.Artifacts{

--- a/internal/cmd/ini/imagerunner.go
+++ b/internal/cmd/ini/imagerunner.go
@@ -2,6 +2,8 @@ package ini
 
 import (
 	"fmt"
+
+	"github.com/fatih/color"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/imagerunner"
 )
@@ -33,4 +35,12 @@ func configureImageRunner(cfg *initConfig) interface{} {
 			},
 		},
 	}
+}
+
+func displayExtraInfoImageRunner() {
+	println()
+	color.HiGreen("Before running your pipeline, you need to set the following environment variables:")
+	color.Green("  - DOCKER_USERNAME")
+	color.Green("  - DOCKER_PASSWORD")
+	println()
 }

--- a/internal/cmd/ini/imagerunner.go
+++ b/internal/cmd/ini/imagerunner.go
@@ -1,0 +1,32 @@
+package ini
+
+import (
+	"fmt"
+	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/imagerunner"
+)
+
+func configureImageRunner(cfg *initConfig) interface{} {
+	return imagerunner.Project{
+		TypeDef: config.TypeDef{
+			APIVersion: imagerunner.APIVersion,
+			Kind:       imagerunner.Kind,
+		},
+		Sauce: config.SauceConfig{
+			Region: cfg.region,
+		},
+		Suites: []imagerunner.Suite{
+			{
+				Name:  fmt.Sprintf("imagerunner - %s", cfg.dockerImage),
+				Image: cfg.dockerImage,
+			},
+		},
+		Artifacts: config.Artifacts{
+			Download: config.ArtifactDownload{
+				When:      cfg.artifactWhen,
+				Directory: "./artifacts",
+				Match:     []string{"*"},
+			},
+		},
+	}
+}

--- a/internal/msg/errormsg.go
+++ b/internal/msg/errormsg.go
@@ -36,6 +36,8 @@ const (
 	MissingPlatformName = "no platform name specified"
 	// MissingBrowserName indicates no browser name
 	MissingBrowserName = "no browser name specified"
+	// MissingDockerImage indicates no app
+	MissingDockerImage = "no image provided"
 	// MissingApp indicates no app
 	MissingApp = "no app provided"
 	// MissingTestApp indicates no testApp


### PR DESCRIPTION
## Proposed changes

Add init for ImageRunner.
Only support:
- Name
- Artifact downloads

Ouput:
```
➭ saucectl init
11:45:51 INF Start Init Command
? Select region: us-west-1
? Select framework: imagerunner
? Docker Image to use: ubuntu:latest
? Download artifacts: always

The following files have been created:
  .sauce/config.yml


Before running your tests, you need to set the following environment variables:
  - DOCKER_USERNAME
  - DOCKER_PASSWORD

➭
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->