### PR TITLE
Ensure PRs are labeled

### DIFF
--- a/.github/workflows/pull-request-linter.yml
+++ b/.github/workflows/pull-request-linter.yml
@@ -12,4 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Label
-        run: if [ "[]" == "${{ toJson(github.event.pull_request.labels.*.name) }}" ]; then echo 'Please label your PR' && exit 1; fi
+        run: |
+          if [ "[]" == "${PR_LABELS}" ]; then
+            echo 'Please label your PR' && exit 1;
+          fi

--- a/.github/workflows/pull-request-linter.yml
+++ b/.github/workflows/pull-request-linter.yml
@@ -1,0 +1,15 @@
+name: Pull Request Linter
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - opened
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Label
+        run: if [ "[]" == "${{ toJson(github.event.pull_request.labels.*.name) }}" ]; then echo 'Please label your PR' && exit 1; fi

--- a/.github/workflows/pull-request-linter.yml
+++ b/.github/workflows/pull-request-linter.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: Check Label
         run: |
-          if [ "[]" == "${PR_LABELS}" ]; then
+          if [ "[]" == "${{ toJson(github.event.pull_request.labels.*.name) }}" ]; then
             echo 'Please label your PR' && exit 1;
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,8 @@ jobs:
     steps:
       - name: Check Label
         run: |
-          echo PR has the following labels: ${{ github.event.pull_request.labels }}
-          if [ -z "${{ github.event.pull_request.labels }}" ]; then echo 'Please label your PR' && exit 1; fi
+          echo PR has the following labels: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          if [ -z "${{ toJson(github.event.pull_request.labels.*.name) }}" ]; then echo 'Please label your PR' && exit 1; fi
 
   build:
     needs: [lint, test]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ env:
   SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
   BUILD_ID: saucectl-run-${{ github.run_id }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - name: Check Label
         run: |
-          PR has the following labels: ${{ github.event.pull_request.labels }}
+          echo PR has the following labels: ${{ github.event.pull_request.labels }}
           if [ -z "${{ github.event.pull_request.labels }}" ]; then echo 'Please label your PR' && exit 1; fi
 
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,13 @@ jobs:
         working-directory: api/
         run: diff saucectl.schema.json fresh.schema.json
 
+  label:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Label
+        run: if [ -z "${{ github.event.pull_request.labels }}" ]; then echo 'Please label your PR' && exit 1; fi
+
   build:
     needs: [lint, test]
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,14 +77,6 @@ jobs:
         working-directory: api/
         run: diff saucectl.schema.json fresh.schema.json
 
-  label:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check Label
-        run: |
-          if [ "[]" == "${{ toJson(github.event.pull_request.labels.*.name) }}" ]; then echo 'Please label your PR' && exit 1; fi
-
   build:
     needs: [lint, test]
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,8 +83,7 @@ jobs:
     steps:
       - name: Check Label
         run: |
-          echo PR has the following labels: ${{ toJson(github.event.pull_request.labels.*.name) }}
-          if [ -z "${{ toJson(github.event.pull_request.labels.*.name) }}" ]; then echo 'Please label your PR' && exit 1; fi
+          if [ "[]" == "${{ toJson(github.event.pull_request.labels.*.name) }}" ]; then echo 'Please label your PR' && exit 1; fi
 
   build:
     needs: [lint, test]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Label
-        run: if [ -z "${{ github.event.pull_request.labels }}" ]; then echo 'Please label your PR' && exit 1; fi
+        run: |
+          PR has the following labels: ${{ github.event.pull_request.labels }}
+          if [ -z "${{ github.event.pull_request.labels }}" ]; then echo 'Please label your PR' && exit 1; fi
 
   build:
     needs: [lint, test]


### PR DESCRIPTION
## Proposed changes

GitHub doesn't have _labeling requirements_ as a feature in their "branch merge protection" settings. Setting labels is easily forgotten (I've done it many times) and our release note generator relies on them.

The label check will run when a PR is created and whenever a label is added or removed from the PR.