### PR TITLE
fix: ImageRunner errors management

### DIFF
--- a/internal/cmd/artifacts/download.go
+++ b/internal/cmd/artifacts/download.go
@@ -22,7 +22,7 @@ func DownloadCommand() *cobra.Command {
 	var out string
 
 	cmd := &cobra.Command{
-		Use:   "download <jobID> <filename>",
+		Use:   "download <jobID> <file-pattern>",
 		Short: "Downloads the specified artifacts from the given job. Supports glob pattern.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {

--- a/internal/cmd/imagerunner/artifacts.go
+++ b/internal/cmd/imagerunner/artifacts.go
@@ -80,7 +80,7 @@ func downloadCommand() *cobra.Command {
 	var out string
 
 	cmd := &cobra.Command{
-		Use:   "download <jobID> <filename>",
+		Use:   "download <runID> <file-pattern>",
 		Short: "Downloads the specified artifacts from the given run. Supports glob pattern.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {

--- a/internal/cmd/imagerunner/artifacts.go
+++ b/internal/cmd/imagerunner/artifacts.go
@@ -80,7 +80,7 @@ func downloadCommand() *cobra.Command {
 	var out string
 
 	cmd := &cobra.Command{
-		Use:   "download",
+		Use:   "download <jobID> <filename>",
 		Short: "Downloads the specified artifacts from the given run. Supports glob pattern.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {

--- a/internal/cmd/imagerunner/logs.go
+++ b/internal/cmd/imagerunner/logs.go
@@ -2,6 +2,7 @@ package imagerunner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
@@ -18,6 +19,12 @@ func LogsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs <runID>",
 		Short: "Fetch the logs for an imagerunner run",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || args[0] == "" {
+				return errors.New("no run ID specified")
+			}
+			return nil
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			err := http.CheckProxy()
 			if err != nil {


### PR DESCRIPTION
## Proposed changes

- Updates usage message for `saucectl imagerunner artifacts download -h` to display expected positional args.
- Fix panic() when `saucectl imagerunner logs` does not provides a `runID`.


## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->