### PR TITLE
fix: JunitRetrier: Check if map is nil before updating it

### DIFF
--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -62,6 +62,9 @@ func (b *JunitRetrier) retryOnlyFailedClasses(reader job.Reader, jobOpts chan<- 
 		Str("attempt", fmt.Sprintf("%d of %d", opt.Attempt+1, opt.Retries+1)).
 		Msgf(msg.RetryWithClasses, strings.Join(classes, ","))
 
+	if opt.TestOptions == nil {
+		opt.TestOptions = map[string]interface{}{}
+	}
 	opt.TestOptions["class"] = classes
 	jobOpts <- opt
 }


### PR DESCRIPTION
## Proposed changes

Prevent `panic: assignment to entry in nil map` when there is no `TestOptions` define in the config.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->