### PR TITLE
Hide Usage when PreRun fails

### DIFF
--- a/cmd/saucectl/saucectl.go
+++ b/cmd/saucectl/saucectl.go
@@ -43,6 +43,7 @@ func main() {
 		Use:              cmdUse,
 		Short:            cmdShort,
 		Long:             cmdLong,
+		SilenceUsage:     true,
 		TraverseChildren: true,
 		Version:          fmt.Sprintf("%s\n(build %s)", version.Version, version.GitCommit),
 	}

--- a/internal/cmd/artifacts/cmd.go
+++ b/internal/cmd/artifacts/cmd.go
@@ -26,6 +26,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "artifacts",
 		Short:            "Interact with job artifacts",
+		SilenceUsage:     true,
 		TraverseChildren: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if preRun != nil {

--- a/internal/cmd/artifacts/download.go
+++ b/internal/cmd/artifacts/download.go
@@ -22,8 +22,9 @@ func DownloadCommand() *cobra.Command {
 	var out string
 
 	cmd := &cobra.Command{
-		Use:   "download <jobID> <file-pattern>",
-		Short: "Downloads the specified artifacts from the given job. Supports glob pattern.",
+		Use:          "download <jobID> <file-pattern>",
+		Short:        "Downloads the specified artifacts from the given job. Supports glob pattern.",
+		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {
 				return errors.New("no job ID specified")

--- a/internal/cmd/artifacts/list.go
+++ b/internal/cmd/artifacts/list.go
@@ -65,7 +65,8 @@ func ListCommand() *cobra.Command {
 		Aliases: []string{
 			"ls",
 		},
-		Short: "Returns the list of artifacts for the specified job.",
+		Short:        "Returns the list of artifacts for the specified job.",
+		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {
 				return errors.New("no job ID specified")

--- a/internal/cmd/artifacts/upload.go
+++ b/internal/cmd/artifacts/upload.go
@@ -19,9 +19,10 @@ func UploadCommand() *cobra.Command {
 	var out string
 
 	cmd := &cobra.Command{
-		Use:   "upload <jobID> <filename>",
-		Short: "Uploads an artifact for the job.",
-		Long:  "Uploads an artifact for the job. Real Device job is not supported.",
+		Use:          "upload <jobID> <filename>",
+		Short:        "Uploads an artifact for the job.",
+		Long:         "Uploads an artifact for the job. Real Device job is not supported.",
+		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {
 				return errors.New("no job ID specified")

--- a/internal/cmd/completion/cmd.go
+++ b/internal/cmd/completion/cmd.go
@@ -51,6 +51,7 @@ PowerShell:
   PS> saucectl completion powershell > saucectl.ps1
 `,
 		DisableFlagsInUseLine: true,
+		SilenceUsage:          true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Args:                  cobra.ExactValidArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/cmd/configure/cmd.go
+++ b/internal/cmd/configure/cmd.go
@@ -29,10 +29,11 @@ var (
 // Command creates the `configure` command
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     configureUse,
-		Short:   configureShort,
-		Long:    configureLong,
-		Example: configureExample,
+		Use:          configureUse,
+		Short:        configureShort,
+		Long:         configureLong,
+		Example:      configureExample,
+		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			tracker := segment.DefaultTracker
 

--- a/internal/cmd/imagerunner/artifacts.go
+++ b/internal/cmd/imagerunner/artifacts.go
@@ -64,8 +64,9 @@ var defaultTableStyle = table.Style{
 
 func ArtifactsCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "artifacts",
-		Short: "Commands for interacting with artifacts produced by the imagerunner.",
+		Use:          "artifacts",
+		Short:        "Commands for interacting with artifacts produced by the imagerunner.",
+		SilenceUsage: true,
 	}
 
 	cmd.AddCommand(
@@ -80,8 +81,9 @@ func downloadCommand() *cobra.Command {
 	var out string
 
 	cmd := &cobra.Command{
-		Use:   "download <runID> <file-pattern>",
-		Short: "Downloads the specified artifacts from the given run. Supports glob pattern.",
+		Use:          "download <runID> <file-pattern>",
+		Short:        "Downloads the specified artifacts from the given run. Supports glob pattern.",
+		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {
 				return errors.New("no run ID specified")

--- a/internal/cmd/imagerunner/cmd.go
+++ b/internal/cmd/imagerunner/cmd.go
@@ -18,8 +18,9 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 	var regio string
 
 	cmd := &cobra.Command{
-		Use:   "imagerunner",
-		Short: "Commands for interacting with imagerunner runs",
+		Use:          "imagerunner",
+		Short:        "Commands for interacting with imagerunner runs",
+		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if preRun != nil {
 				preRun(cmd, args)

--- a/internal/cmd/imagerunner/logs.go
+++ b/internal/cmd/imagerunner/logs.go
@@ -17,8 +17,9 @@ import (
 
 func LogsCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "logs <runID>",
-		Short: "Fetch the logs for an imagerunner run",
+		Use:          "logs <runID>",
+		Short:        "Fetch the logs for an imagerunner run",
+		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {
 				return errors.New("no run ID specified")

--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -71,10 +71,11 @@ func Command() *cobra.Command {
 	initCfg := &initConfig{}
 
 	cmd := &cobra.Command{
-		Use:     initUse,
-		Short:   initShort,
-		Long:    initLong,
-		Example: initExample,
+		Use:          initUse,
+		Short:        initShort,
+		Long:         initLong,
+		Example:      initExample,
+		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return preRun()
 		},

--- a/internal/cmd/jobs/cmd.go
+++ b/internal/cmd/jobs/cmd.go
@@ -24,6 +24,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "jobs",
 		Short:            "Interact with jobs",
+		SilenceUsage:     true,
 		TraverseChildren: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if preRun != nil {

--- a/internal/cmd/jobs/get.go
+++ b/internal/cmd/jobs/get.go
@@ -19,8 +19,9 @@ func GetCommand() *cobra.Command {
 	var out string
 
 	cmd := &cobra.Command{
-		Use:   "get",
-		Short: "Get job by id",
+		Use:          "get",
+		Short:        "Get job by id",
+		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {
 				return errors.New("no job ID specified")

--- a/internal/cmd/jobs/list.go
+++ b/internal/cmd/jobs/list.go
@@ -79,7 +79,8 @@ func ListCommand() *cobra.Command {
 		Aliases: []string{
 			"ls",
 		},
-		Short: "Returns the list of jobs",
+		Short:        "Returns the list of jobs",
+		SilenceUsage: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			tracker := segment.DefaultTracker
 

--- a/internal/cmd/new/cmd.go
+++ b/internal/cmd/new/cmd.go
@@ -22,11 +22,12 @@ var (
 // Command creates the `new` command
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Deprecated: deprecationMsg,
-		Use:        newUse,
-		Short:      newShort,
-		Long:       newLong,
-		Example:    newExample,
+		Deprecated:   deprecationMsg,
+		Use:          newUse,
+		Short:        newShort,
+		Long:         newLong,
+		Example:      newExample,
+		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
 		},
 	}

--- a/internal/cmd/run/cucumber.go
+++ b/internal/cmd/run/cucumber.go
@@ -33,6 +33,7 @@ func NewCucumberCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "cucumberjs",
 		Short:            "Run Cucumber test",
+		SilenceUsage:     true,
 		Hidden:           true,
 		TraverseChildren: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -37,6 +37,7 @@ func NewCypressCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "cypress",
 		Short:            "Run cypress tests",
+		SilenceUsage:     true,
 		Hidden:           true, // TODO reveal command once ready
 		TraverseChildren: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -41,6 +41,7 @@ func NewEspressoCmd() *cobra.Command {
 		Short:            "Run espresso tests",
 		Long:             "Unlike 'saucectl run', this command allows you to bypass the config file partially or entirely by configuring an adhoc suite (--name) via flags.",
 		Example:          `saucectl run espresso -c "" --name "My Suite" --app app.apk --testApp testApp.apk --otherApps=a.apk,b.apk --device name="Google Pixel.*",platformVersion=14.0,carrierConnectivity=false,deviceType=PHONE,private=false --emulator name="Android Emulator",platformVersion=8.0`,
+		SilenceUsage:     true,
 		Hidden:           true, // TODO reveal command once ready
 		TraverseChildren: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -38,6 +38,7 @@ func NewPlaywrightCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "playwright",
 		Short:            "Run playwright tests",
+		SilenceUsage:     true,
 		Hidden:           true, // TODO reveal command once ready
 		TraverseChildren: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/run/puppeteer.go
+++ b/internal/cmd/run/puppeteer.go
@@ -35,6 +35,7 @@ func NewPuppeteerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "puppeteer",
 		Short:            "Run puppeteer tests",
+		SilenceUsage:     true,
 		Hidden:           true, // TODO reveal command once ready
 		TraverseChildren: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -38,6 +38,7 @@ func NewReplayCmd() *cobra.Command {
 		Short:            "Replay chrome devtools recordings",
 		Long:             "Unlike 'saucectl run', this command allows you to bypass the config file partially or entirely by configuring an adhoc suite (--name) via flags.",
 		Example:          `saucectl run replay recording.json -c "" --name "My Suite"`,
+		SilenceUsage:     true,
 		TraverseChildren: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			sc.BindAll()

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -93,6 +93,7 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              runUse,
 		Short:            runShort,
+		SilenceUsage:     true,
 		TraverseChildren: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return preRun()

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -44,6 +44,7 @@ func NewTestcafeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "testcafe",
 		Short:            "Run testcafe tests",
+		SilenceUsage:     true,
 		Hidden:           true, // TODO reveal command once ready
 		TraverseChildren: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -40,6 +40,7 @@ func NewXCUITestCmd() *cobra.Command {
 		Short:            "Run xcuitest tests.",
 		Long:             "Unlike 'saucectl run', this command allows you to bypass the config file partially or entirely by configuring an adhoc suite (--name) via flags.",
 		Example:          `saucectl run xcuitest -c "" --name "My Suite" --app app.ipa --testApp testApp.ipa --otherApps=a.ipa,b.ipa --device name="iPhone.*",platformVersion=14.0,carrierConnectivity=false,deviceType=PHONE,private=false`,
+		SilenceUsage:     true,
 		Hidden:           true, // TODO reveal command once ready
 		TraverseChildren: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/signup/cmd.go
+++ b/internal/cmd/signup/cmd.go
@@ -19,10 +19,11 @@ var (
 // Command creates the `run` command
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     runUse,
-		Short:   runShort,
-		Long:    runLong,
-		Example: runExample,
+		Use:          runUse,
+		Short:        runShort,
+		Long:         runLong,
+		Example:      runExample,
+		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			log.Info().Msg("Start Signup Command")
 			err := Run()

--- a/internal/cmd/storage/cmd.go
+++ b/internal/cmd/storage/cmd.go
@@ -20,6 +20,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:              "storage",
 		Short:            "Interact with Sauce Storage",
+		SilenceUsage:     true,
 		TraverseChildren: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if preRun != nil {

--- a/internal/cmd/storage/download.go
+++ b/internal/cmd/storage/download.go
@@ -19,8 +19,9 @@ func DownloadCommand() *cobra.Command {
 	var filename string
 
 	cmd := &cobra.Command{
-		Use:   "download fileID",
-		Short: "Downloads an app file from Sauce Storage.",
+		Use:          "download fileID",
+		Short:        "Downloads an app file from Sauce Storage.",
+		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {
 				return errors.New("no ID specified")

--- a/internal/cmd/storage/list.go
+++ b/internal/cmd/storage/list.go
@@ -69,7 +69,8 @@ func ListCommand() *cobra.Command {
 		Aliases: []string{
 			"ls",
 		},
-		Short: "Returns the list of files that have been uploaded to Sauce Storage.",
+		Short:        "Returns the list of files that have been uploaded to Sauce Storage.",
+		SilenceUsage: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			tracker := segment.DefaultTracker
 

--- a/internal/cmd/storage/upload.go
+++ b/internal/cmd/storage/upload.go
@@ -25,6 +25,7 @@ func UploadCommand() *cobra.Command {
 		Use: "upload filename",
 		Short: "Uploads an app file to Sauce Storage and returns a unique file ID assigned to the app. " +
 			"Sauce Storage supports app files in *.apk, *.aab, *.ipa, or *.zip format.",
+		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {
 				return errors.New("no filename specified")


### PR DESCRIPTION
## Proposed changes

On error, usage display makes it really easy to miss what actually failed.
By setting `SilenceUsage`, whenever an error occurs, no usage will be displayed, allowing to keep the actual error on sight.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->