### PR TITLE
Remove obsolete termination reason check

### DIFF
--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -220,13 +220,7 @@ func (r *ImgRunner) runSuite(suite imagerunner.Suite) (imagerunner.Runner, error
 	}
 
 	if run.Status != imagerunner.StateSucceeded {
-		// TerminationReason is currently _not_ implemented on the server side. Conditional can be removed once
-		// the server always sends back a response.
-		err = fmt.Errorf("suite '%s' failed", suite.Name)
-		if run.TerminationReason != "" {
-			err = fmt.Errorf("suite '%s' failed: %s", suite.Name, run.TerminationReason)
-		}
-		return run, err
+		return run, fmt.Errorf("suite %q failed: %s", suite.Name, run.TerminationReason)
 	}
 
 	return run, err


### PR DESCRIPTION
## Proposed changes

Small cleanup. Termination reason is implemented on the server side now. The check isn't needed anymore.