### PR TITLE
Refactor files package

### DIFF
--- a/internal/cmd/imagerunner/artifacts.go
+++ b/internal/cmd/imagerunner/artifacts.go
@@ -132,7 +132,7 @@ func download(ID, filePattern, targetDir, outputFormat string) error {
 		return fmt.Errorf("failed to fetch artifacts: %w", err)
 	}
 
-	fileName, err := fileio.SaveToTempFile(reader)
+	fileName, err := fileio.CreateTemp(reader)
 	if err != nil {
 		return fmt.Errorf("failed to download artifacts content: %w", err)
 	}

--- a/internal/cmd/imagerunner/artifacts.go
+++ b/internal/cmd/imagerunner/artifacts.go
@@ -131,6 +131,7 @@ func download(ID, filePattern, targetDir, outputFormat string) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch artifacts: %w", err)
 	}
+	defer reader.Close()
 
 	fileName, err := fileio.CreateTemp(reader)
 	if err != nil {

--- a/internal/cmd/imagerunner/artifacts.go
+++ b/internal/cmd/imagerunner/artifacts.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ryanuber/go-glob"
 	szip "github.com/saucelabs/saucectl/internal/archive/zip"
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
-	"github.com/saucelabs/saucectl/internal/files"
+	"github.com/saucelabs/saucectl/internal/fileio"
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/imagerunner"
 	"github.com/saucelabs/saucectl/internal/segment"
@@ -132,7 +132,7 @@ func download(ID, filePattern, targetDir, outputFormat string) error {
 		return fmt.Errorf("failed to fetch artifacts: %w", err)
 	}
 
-	fileName, err := files.SaveToTempFile(reader)
+	fileName, err := fileio.SaveToTempFile(reader)
 	if err != nil {
 		return fmt.Errorf("failed to download artifacts content: %w", err)
 	}

--- a/internal/cmd/storage/upload.go
+++ b/internal/cmd/storage/upload.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
-	"github.com/saucelabs/saucectl/internal/files"
+	"github.com/saucelabs/saucectl/internal/hashio"
 	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/saucelabs/saucectl/internal/storage"
 	"github.com/saucelabs/saucectl/internal/usage"
@@ -54,7 +54,7 @@ func UploadCommand() *cobra.Command {
 				return fmt.Errorf("failed to inspect file: %w", err)
 			}
 
-			hash, err := files.NewSHA256(args[0])
+			hash, err := hashio.SHA256(args[0])
 			if err != nil {
 				return fmt.Errorf("failed to compute checksum: %w", err)
 			}

--- a/internal/fileio/temp.go
+++ b/internal/fileio/temp.go
@@ -5,9 +5,9 @@ import (
 	"os"
 )
 
-// SaveToTempFile writes out the contents of the reader to a temp file.
+// CreateTemp writes out the contents of the reader to a temp file.
 // It's the caller's responsibility to clean up the temp file.
-func SaveToTempFile(closer io.ReadCloser) (string, error) {
+func CreateTemp(closer io.ReadCloser) (string, error) {
 	defer closer.Close()
 	fd, err := os.CreateTemp("", "")
 	if err != nil {

--- a/internal/fileio/temp.go
+++ b/internal/fileio/temp.go
@@ -1,0 +1,23 @@
+package fileio
+
+import (
+	"io"
+	"os"
+)
+
+// SaveToTempFile writes out the contents of the reader to a temp file.
+// It's the caller's responsibility to clean up the temp file.
+func SaveToTempFile(closer io.ReadCloser) (string, error) {
+	defer closer.Close()
+	fd, err := os.CreateTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	defer fd.Close()
+
+	_, err = io.Copy(fd, closer)
+	if err != nil {
+		return "", err
+	}
+	return fd.Name(), fd.Close()
+}

--- a/internal/fileio/temp.go
+++ b/internal/fileio/temp.go
@@ -7,14 +7,14 @@ import (
 
 // CreateTemp writes out the contents of the reader to a temp file.
 // It's the caller's responsibility to clean up the temp file.
-func CreateTemp(closer io.ReadCloser) (string, error) {
+func CreateTemp(r io.ReadCloser) (string, error) {
 	fd, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", err
 	}
 	defer fd.Close()
 
-	_, err = io.Copy(fd, closer)
+	_, err = io.Copy(fd, r)
 	if err != nil {
 		return "", err
 	}

--- a/internal/fileio/temp.go
+++ b/internal/fileio/temp.go
@@ -14,9 +14,9 @@ func CreateTemp(r io.Reader) (string, error) {
 	}
 	defer fd.Close()
 
-	_, err = io.Copy(fd, r)
-	if err != nil {
+	if _, err := io.Copy(fd, r); err != nil {
 		return "", err
 	}
+
 	return fd.Name(), fd.Close()
 }

--- a/internal/fileio/temp.go
+++ b/internal/fileio/temp.go
@@ -7,7 +7,7 @@ import (
 
 // CreateTemp writes out the contents of the reader to a temp file.
 // It's the caller's responsibility to clean up the temp file.
-func CreateTemp(r io.ReadCloser) (string, error) {
+func CreateTemp(r io.Reader) (string, error) {
 	fd, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", err

--- a/internal/fileio/temp.go
+++ b/internal/fileio/temp.go
@@ -8,7 +8,6 @@ import (
 // CreateTemp writes out the contents of the reader to a temp file.
 // It's the caller's responsibility to clean up the temp file.
 func CreateTemp(closer io.ReadCloser) (string, error) {
-	defer closer.Close()
 	fd, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", err

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -19,20 +19,3 @@ func NewSHA256(filename string) (string, error) {
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
-
-// SaveToTempFile writes out the contents of the reader to a temp file.
-// It's the caller's responsibility to clean up the temp file.
-func SaveToTempFile(closer io.ReadCloser) (string, error) {
-	defer closer.Close()
-	fd, err := os.CreateTemp("", "")
-	if err != nil {
-		return "", err
-	}
-	defer fd.Close()
-
-	_, err = io.Copy(fd, closer)
-	if err != nil {
-		return "", err
-	}
-	return fd.Name(), fd.Close()
-}

--- a/internal/hashio/files.go
+++ b/internal/hashio/files.go
@@ -1,4 +1,4 @@
-package files
+package hashio
 
 import (
 	"crypto/sha256"
@@ -7,8 +7,9 @@ import (
 	"os"
 )
 
-// NewSHA256 hashes the given file using crypto.SHA256 and returns the resulting string.
-func NewSHA256(filename string) (string, error) {
+// SHA256 hashes the given file with crypto.SHA256 and returns the checksum as a
+// base-16 (hex) string.
+func SHA256(filename string) (string, error) {
 	h := sha256.New()
 	file, err := os.Open(filename)
 	if err != nil {

--- a/internal/hashio/files_test.go
+++ b/internal/hashio/files_test.go
@@ -1,4 +1,4 @@
-package files
+package hashio
 
 import (
 	"testing"
@@ -6,7 +6,7 @@ import (
 	"gotest.tools/v3/fs"
 )
 
-func TestNewSHA256(t *testing.T) {
+func TestSHA256(t *testing.T) {
 	dir := fs.NewDir(t, "checksums", fs.WithFile("hello.txt", "world!"))
 	defer dir.Remove()
 
@@ -38,13 +38,13 @@ func TestNewSHA256(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewSHA256(tt.args.filename)
+			got, err := SHA256(tt.args.filename)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("NewSHA256() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("SHA256() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("NewSHA256() got = %v, want %v", got, tt.want)
+				t.Errorf("SHA256() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -24,8 +24,8 @@ import (
 	"github.com/saucelabs/saucectl/internal/build"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/espresso"
-	"github.com/saucelabs/saucectl/internal/files"
 	"github.com/saucelabs/saucectl/internal/framework"
+	"github.com/saucelabs/saucectl/internal/hashio"
 	"github.com/saucelabs/saucectl/internal/iam"
 	"github.com/saucelabs/saucectl/internal/insights"
 	"github.com/saucelabs/saucectl/internal/job"
@@ -607,7 +607,7 @@ func (r *CloudRunner) uploadProject(filename, description string, pType uploadTy
 // isFileStored calculates the checksum of the given file and looks up its existence in the Sauce Labs app storage.
 // Returns an empty string if no file was found.
 func (r *CloudRunner) isFileStored(filename string) (storageID string, err error) {
-	hash, err := files.NewSHA256(filename)
+	hash, err := hashio.SHA256(filename)
 	if err != nil {
 		return "", err
 	}

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ryanuber/go-glob"
 	szip "github.com/saucelabs/saucectl/internal/archive/zip"
 	"github.com/saucelabs/saucectl/internal/config"
-	"github.com/saucelabs/saucectl/internal/files"
+	"github.com/saucelabs/saucectl/internal/fileio"
 	"github.com/saucelabs/saucectl/internal/imagerunner"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/report"
@@ -328,7 +328,7 @@ func (r *ImgRunner) DownloadArtifacts(runnerID, suiteName, status string, passed
 		log.Err(err).Str("suite", suiteName).Msg("Failed to fetch artifacts.")
 		return
 	}
-	fileName, err := files.SaveToTempFile(reader)
+	fileName, err := fileio.SaveToTempFile(reader)
 	if err != nil {
 		log.Err(err).Str("suite", suiteName).Msg("Failed to download artifacts content.")
 		return

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -328,6 +328,8 @@ func (r *ImgRunner) DownloadArtifacts(runnerID, suiteName, status string, passed
 		log.Err(err).Str("suite", suiteName).Msg("Failed to fetch artifacts.")
 		return
 	}
+	defer reader.Close()
+
 	fileName, err := fileio.CreateTemp(reader)
 	if err != nil {
 		log.Err(err).Str("suite", suiteName).Msg("Failed to download artifacts content.")

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -328,7 +328,7 @@ func (r *ImgRunner) DownloadArtifacts(runnerID, suiteName, status string, passed
 		log.Err(err).Str("suite", suiteName).Msg("Failed to fetch artifacts.")
 		return
 	}
-	fileName, err := fileio.SaveToTempFile(reader)
+	fileName, err := fileio.CreateTemp(reader)
 	if err != nil {
 		log.Err(err).Str("suite", suiteName).Msg("Failed to download artifacts content.")
 		return


### PR DESCRIPTION
## Proposed changes

The `files` package did not end up being a good package name. The term _files_ is a commonly used variable name, causing this package to steal a good variable name from the user and thus introducing unnecessary [variable shadowing](https://en.wikipedia.org/wiki/Variable_shadowing).

Other minor improvements were done on the way.