### PR TITLE
Remove unnecessary file check

### DIFF
--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -3,11 +3,8 @@ package apps
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"regexp"
 	"strings"
-
-	"github.com/saucelabs/saucectl/internal/msg"
 )
 
 var (
@@ -66,8 +63,5 @@ func Validate(kind, app string, validExt []string) error {
 		return fmt.Errorf("invalid %s file: %s, make sure extension is one of the following: %s", kind, app, strings.Join(validExt, ", "))
 	}
 
-	if _, err := os.Stat(app); err == nil {
-		return nil
-	}
-	return fmt.Errorf(msg.FileNotFound, app)
+	return nil
 }

--- a/internal/apps/apps_test.go
+++ b/internal/apps/apps_test.go
@@ -2,20 +2,12 @@ package apps
 
 import (
 	"fmt"
-	"path/filepath"
 	"testing"
-
-	"gotest.tools/v3/fs"
 )
 
 func TestValidate(t *testing.T) {
-	dir := fs.NewDir(t, "xcuitest-config",
-		fs.WithFile("test.ipa", "", fs.WithMode(0655)),
-		fs.WithFile("test.zip", "", fs.WithMode(0655)))
-	defer dir.Remove()
-	appIPA := filepath.Join(dir.Path(), "test.ipa")
-	appZIP := filepath.Join(dir.Path(), "test.zip")
-	badAppIPA := filepath.Join(dir.Path(), "bad-test.ipa")
+	appIPA := "test.ipa"
+	appZIP := "test.zip"
 
 	type args struct {
 		kind     string
@@ -53,15 +45,6 @@ func TestValidate(t *testing.T) {
 				validExt: []string{".ipa"},
 			},
 			wantErr: nil,
-		},
-		{
-			name: "Non-existing file",
-			args: args{
-				kind:     "application",
-				app:      badAppIPA,
-				validExt: []string{".ipa"},
-			},
-			wantErr: fmt.Errorf("%s: file not found", badAppIPA),
 		},
 		{
 			name: "Invalid file extension",

--- a/internal/msg/errormsg.go
+++ b/internal/msg/errormsg.go
@@ -2,11 +2,7 @@ package msg
 
 // appstore uploading
 const (
-	// FailedToUpload indicates the upload failure
-	FailedToUpload = "failed to upload project"
-	// FileNotFound indicates file not found
-	FileNotFound = "%s: file not found"
-	// UploadingTimeout is a the message to warn the user that its upload reach the timeout.
+	// UploadingTimeout is a message to warn the user that the upload timed out.
 	UploadingTimeout = `Failed to upload the project because it took too long. `
 )
 

--- a/internal/msg/errormsg.go
+++ b/internal/msg/errormsg.go
@@ -1,11 +1,5 @@
 package msg
 
-// appstore uploading
-const (
-	// UploadingTimeout is a message to warn the user that the upload timed out.
-	UploadingTimeout = `Failed to upload the project because it took too long. `
-)
-
 // cmd setting
 const (
 	// InvalidUsername indicates invalid username

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -64,17 +64,6 @@ func LogGlobalTimeoutShutdown() {
 └───────────────────────────────────────────────────┘`)
 }
 
-// LogUploadTimeout prints out a timeout warning.
-func LogUploadTimeout() {
-	red := color.New(color.FgRed).SprintFunc()
-	fmt.Printf("\n%s: %s\n\n", red("TIMEOUT"), UploadingTimeout)
-}
-
-// LogUploadTimeoutSuggestion prints out adding unnecessary files to .sauceignore
-func LogUploadTimeoutSuggestion() {
-	fmt.Printf("%s\n\n", SauceIgnoreSuggestion)
-}
-
 // LogRootDirWarning prints out a warning message regarding the lack of an explicit rootDir configuration.
 func LogRootDirWarning() {
 	red := color.New(color.FgRed).SprintFunc()


### PR DESCRIPTION
## Proposed changes

Remove unnecessary file check. It wasn't improving the error reporting.

With file check in place:
```sh
❯ saucectl run
16:22:48 ERR failed to execute run command error="./apps/bla.apk: file not found"
```

Without:
```sh
❯ saucectl run
16:23:22 INF Running Espresso in Sauce Labs
16:23:22 INF Checking if ./apps/bla.apk has already been uploaded previously
16:23:22 ERR failed to execute run command error="project upload: open /Users/alexplischke/devel/saucectl-espresso-example/apps/bla.apk: no such file or directory"
```