### PR TITLE
Fix video skew

### DIFF
--- a/internal/http/webdriver.go
+++ b/internal/http/webdriver.go
@@ -133,7 +133,7 @@ func (c *Webdriver) StartJob(ctx context.Context, opts job.StartOptions) (jobID 
 				RunnerVersion:    opts.RunnerVersion,
 				TestFile:         opts.Suite,
 				Args:             c.formatEspressoArgs(opts.TestOptions),
-				VideoFPS:         25,
+				VideoFPS:         13, // 13 is the sweet spot to minimize frame drops
 			},
 			IdleTimeout: 9999,
 			MaxDuration: 10800,


### PR DESCRIPTION
## Proposed changes

Not a true fix but a workaround to address the video skew that we experience at high frame rates due to frame drops.

13 fps seemed to be the sweet spot that worked well for what I tested.

60 fps:
windows: https://app.saucelabs.com/tests/ee89035ffe8545edb0d6d3b4cdb9cb06
mac: https://app.saucelabs.com/tests/a05892f63bd74aee85e8949f41cb980e

13 fps:
windows: https://app.saucelabs.com/tests/19609a0e81f840fbbcb2ecdc1dfb7521
mac: https://app.saucelabs.com/tests/6eaee4dc8ae9429f92627055d2080d23