### PR TITLE
Optimize Project ID retrieval for APIT

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.0.0 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/go-cmp v0.5.9
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/internal/apitest/config.go
+++ b/internal/apitest/config.go
@@ -39,9 +39,15 @@ type Suite struct {
 	TestMatch      []string          `yaml:"testMatch,omitempty"`
 	Env            map[string]string `yaml:"env,omitempty"`
 
-	// HookID is a technical ID unique to a project that's required by the APIs that execute API tests.
-	// The HookID is retrieved dynamically before calling those endpoints.
+	// HookID is a technical ID unique to a project that's required by the APIs
+	// that execute API tests. The HookID is retrieved dynamically based on
+	// ProjectName before calling those endpoints.
 	HookID string `yaml:"-"`
+
+	// ProjectID is a technical ID unique to a project that's required by the
+	// APIs that execute API tests. The ProjectID is retrieved dynamically based
+	// on ProjectName before calling those endpoints.
+	ProjectID string `yaml:"-"`
 }
 
 // FromFile creates a new apitest Project based on the filepath cfgPath.

--- a/internal/apitest/runner.go
+++ b/internal/apitest/runner.go
@@ -391,11 +391,9 @@ func (r *Runner) runSuites() bool {
 
 func (r *Runner) buildLocalTestDetails(project ProjectMeta, eventIDs []string, testNames []string, results chan []TestResult) {
 	for _, eventID := range eventIDs {
-		reportURL := fmt.Sprintf("%s/api-testing/project/%s/event/%s", r.Region.AppBaseURL(), project.ID, eventID)
 		log.Info().
 			Str("project", project.Name).
 			Str("report", fmt.Sprintf("%s/api-testing/project/%s/event/%s", r.Region.AppBaseURL(), project.ID, eventID)).
-			Str("report", reportURL).
 			Msg("Async test started.")
 	}
 
@@ -412,11 +410,9 @@ func (r *Runner) buildLocalTestDetails(project ProjectMeta, eventIDs []string, t
 
 func (r *Runner) fetchTestDetails(project ProjectMeta, hookID string, eventIDs []string, testIDs []string, results chan []TestResult) {
 	for _, eventID := range eventIDs {
-		reportURL := fmt.Sprintf("%s/api-testing/project/%s/event/%s", r.Region.AppBaseURL(), project.ID, eventID)
 		log.Info().
 			Str("project", project.Name).
 			Str("report", fmt.Sprintf("%s/api-testing/project/%s/event/%s", r.Region.AppBaseURL(), project.ID, eventID)).
-			Str("report", reportURL).
 			Msg("Async test started.")
 	}
 

--- a/internal/apitest/runner_test.go
+++ b/internal/apitest/runner_test.go
@@ -540,6 +540,7 @@ func TestRunner_ResolveHookIDs(t *testing.T) {
 						{
 							Name:        "Suite #1",
 							ProjectName: "Project SingleHook",
+							ProjectID:   "single",
 						},
 					},
 				},
@@ -549,6 +550,7 @@ func TestRunner_ResolveHookIDs(t *testing.T) {
 					{
 						Name:        "Suite #1",
 						ProjectName: "Project SingleHook",
+						ProjectID:   "single",
 						HookID:      "uuid1",
 					},
 				},
@@ -563,6 +565,7 @@ func TestRunner_ResolveHookIDs(t *testing.T) {
 						{
 							Name:        "Suite #1",
 							ProjectName: "Project MultipleHooks",
+							ProjectID:   "multiple",
 						},
 					},
 				},
@@ -572,6 +575,7 @@ func TestRunner_ResolveHookIDs(t *testing.T) {
 					{
 						Name:        "Suite #1",
 						ProjectName: "Project MultipleHooks",
+						ProjectID:   "multiple",
 						HookID:      "uuid1",
 					},
 				},


### PR DESCRIPTION
## Proposed changes

Reduce number of calls made to retrieve project IDs. These were mostly redundant calls, since we already have the information at hand that just needed to be propagated.