### PR TITLE
Add commands to work with api testing project vaults

### DIFF
--- a/cmd/saucectl/saucectl.go
+++ b/cmd/saucectl/saucectl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/cmd/apit"
 	"github.com/saucelabs/saucectl/internal/cmd/artifacts"
 	"github.com/saucelabs/saucectl/internal/cmd/completion"
 	"github.com/saucelabs/saucectl/internal/cmd/configure"
@@ -71,6 +72,7 @@ func main() {
 		artifacts.Command(cmd.PersistentPreRun),
 		jobs.Command(cmd.PersistentPreRun),
 		imagerunner.Command(cmd.PersistentPreRun),
+		apit.Command(cmd.PersistentPreRun),
 	)
 
 	if err := cmd.Execute(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/kr/pty v1.1.5 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mitchellh/mapstructure v1.5.0
@@ -73,7 +73,7 @@ require (
 	github.com/subosito/gotenv v1.4.1 // indirect
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
 	golang.org/x/net v0.7.0 // indirect
-	golang.org/x/sys v0.5.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
+github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -552,6 +554,8 @@ golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0 h1:n2a8QNdAb0sZNpU9R1ALUXBbY+w51fCQDN+7EdxNBsY=

--- a/internal/apitest/runner.go
+++ b/internal/apitest/runner.go
@@ -96,6 +96,19 @@ type Runner struct {
 	TunnelService tunnel.Service
 }
 
+// Vault represents a project's stored variables and snippets
+type Vault struct {
+	Variables []VaultVariable   `json:"variables,omitempty"`
+	Snippets  map[string]string `json:"snippets,omitempty"`
+}
+
+// VaultVariable represents a variable stored in a project vault
+type VaultVariable struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
 // FilterSuites filters out suites in the project that don't match the given suite name.
 func FilterSuites(p *Project, suiteName string) error {
 	for _, s := range p.Suites {

--- a/internal/apitest/runner.go
+++ b/internal/apitest/runner.go
@@ -98,8 +98,8 @@ type Runner struct {
 
 // Vault represents a project's stored variables and snippets
 type Vault struct {
-	Variables []VaultVariable   `json:"variables,omitempty"`
-	Snippets  map[string]string `json:"snippets,omitempty"`
+	Variables []VaultVariable   `json:"variables"`
+	Snippets  map[string]string `json:"snippets"`
 }
 
 // VaultVariable represents a variable stored in a project vault

--- a/internal/cmd/apit/cmd.go
+++ b/internal/cmd/apit/cmd.go
@@ -43,7 +43,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 	flags.StringVarP(&regio, "region", "r", "us-west-1", "The Sauce Labs region. Options: us-west-1, eu-central-1.")
 
 	cmd.AddCommand(
-		GetVaultCommand(),
+		VaultCommand(),
 	)
 	return cmd
 }

--- a/internal/cmd/apit/cmd.go
+++ b/internal/cmd/apit/cmd.go
@@ -1,0 +1,49 @@
+package apit
+
+import (
+	"errors"
+	"time"
+
+	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/spf13/cobra"
+)
+
+var (
+	apitesterClient http.APITester
+)
+
+func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
+	var regio string
+
+	cmd := &cobra.Command{
+		Use:          "apit",
+		Short:        "Commands for interacting with API Testing",
+		SilenceUsage: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if preRun != nil {
+				preRun(cmd, args)
+			}
+
+			if region.FromString(regio) == region.None {
+				return errors.New("invalid region")
+			}
+
+			creds := credentials.Get()
+			url := region.FromString(regio).APIBaseURL()
+
+			apitesterClient = http.NewAPITester(url, creds.Username, creds.AccessKey, 15*time.Minute)
+
+			return nil
+		},
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.StringVarP(&regio, "region", "r", "us-west-1", "The Sauce Labs region. Options: us-west-1, eu-central-1.")
+
+	cmd.AddCommand(
+		GetVaultCommand(),
+	)
+	return cmd
+}

--- a/internal/cmd/apit/cmd.go
+++ b/internal/cmd/apit/cmd.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/saucelabs/saucectl/internal/apitest"
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
@@ -13,6 +14,11 @@ import (
 var (
 	apitesterClient http.APITester
 )
+
+type ResolvedProject struct {
+	apitest.ProjectMeta
+	Hooks   []apitest.Hook
+}
 
 func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 	var regio string

--- a/internal/cmd/apit/cmd.go
+++ b/internal/cmd/apit/cmd.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/saucelabs/saucectl/internal/apitest"
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
@@ -14,11 +13,6 @@ import (
 var (
 	apitesterClient http.APITester
 )
-
-type ResolvedProject struct {
-	apitest.ProjectMeta
-	Hooks   []apitest.Hook
-}
 
 func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 	var regio string
@@ -49,7 +43,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 	flags.StringVarP(&regio, "region", "r", "us-west-1", "The Sauce Labs region. Options: us-west-1, eu-central-1.")
 
 	cmd.AddCommand(
-		VaultCommand(),
+		VaultCommand(cmd.PersistentPreRunE),
 	)
 	return cmd
 }

--- a/internal/cmd/apit/get.go
+++ b/internal/cmd/apit/get.go
@@ -1,0 +1,56 @@
+package apit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/spf13/cobra"
+)
+
+func GetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get [--project PROJECT_NAME]",
+		Short: "Get the entire vault contents",
+		Long: `Use [--project] to specify the project by its name or run with [--project] to 
+choose form a list of projects
+`,
+		SilenceUsage: true,
+		// Args: func(cmd *cobra.Command, args []string) error {
+		// 	if len(args) == 0 || args[0] == "" {
+		// 		return errors.New("no snippet name specified")
+		// 	}
+		// 	return nil
+		// },
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			err := http.CheckProxy()
+			if err != nil {
+				return fmt.Errorf("invalid HTTP_PROXY value")
+			}
+
+			// tracker := segment.DefaultTracker
+
+			// go func() {
+			// 	tracker.Collect(
+			// 		cases.Title(language.English).String(cmds.FullName(cmd)),
+			// 		usage.Properties{}.SetFlags(cmd.Flags()),
+			// 	)
+			// 	_ = tracker.Close()
+			// }()
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vault, err := apitesterClient.GetVault(context.Background(), selectedProject.Hooks[0].Identifier)
+			if err != nil {
+				return err
+			}
+
+			json.NewEncoder(os.Stdout).Encode(vault)
+
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cmd/apit/get.go
+++ b/internal/cmd/apit/get.go
@@ -18,12 +18,6 @@ func GetCommand() *cobra.Command {
 choose form a list of projects
 `,
 		SilenceUsage: true,
-		// Args: func(cmd *cobra.Command, args []string) error {
-		// 	if len(args) == 0 || args[0] == "" {
-		// 		return errors.New("no snippet name specified")
-		// 	}
-		// 	return nil
-		// },
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			err := http.CheckProxy()
 			if err != nil {

--- a/internal/cmd/apit/getsnippet.go
+++ b/internal/cmd/apit/getsnippet.go
@@ -13,8 +13,7 @@ func GetSnippetCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-snippet NAME [--project PROJECT_NAME]",
 		Short: "Get a vault snippet",
-		Long: `
-Get a snippet from a project's vault. Use [--project] to specify the
+		Long: `Get a snippet from a project's vault. Use [--project] to specify the
 project by its name or run with [--project] to choose form a list of projects
 `,
 		SilenceUsage: true,

--- a/internal/cmd/apit/getsnippet.go
+++ b/internal/cmd/apit/getsnippet.go
@@ -9,9 +9,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func GetVariableCommand() *cobra.Command {
+func GetSnippetCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "get-variable <projectName> <name>",
+		Use:          "get-snippet <projectName> <name>",
 		Short:        "Get a vault variable",
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -39,15 +39,15 @@ func GetVariableCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return getVariable(args[0], args[1])
+			return getSnippet(args[0], args[1])
 		},
 	}
 
 	return cmd
 }
 
-func getVariable(projectName string, name string) error {
-	hook, err := resolve(projectName)	
+func getSnippet(projectName string, name string) error {
+	hook, err := resolve(projectName)
 	if err != nil {
 		return err
 	}
@@ -57,12 +57,11 @@ func getVariable(projectName string, name string) error {
 		return err
 	}
 
-	for _, v := range vault.Variables {
-		if v.Name == name {
-			fmt.Printf("%s=%s", v.Name, v.Value)
+	for k, v := range vault.Snippets {
+		if k == name {
+			fmt.Printf("%s", v)
 			return nil
 		}
 	}
-
-	return fmt.Errorf("Project (%s) has no vault variable with name (%s)", projectName, name)
+	return fmt.Errorf("Project (%s) has no vault snippet with name (%s)", projectName, name)
 }

--- a/internal/cmd/apit/getsnippet.go
+++ b/internal/cmd/apit/getsnippet.go
@@ -47,12 +47,12 @@ func GetSnippetCommand() *cobra.Command {
 }
 
 func getSnippet(projectName string, name string) error {
-	hook, err := resolve(projectName)
+	project, err := resolve(projectName)
 	if err != nil {
 		return err
 	}
 
-	vault, err := apitesterClient.GetVault(context.Background(), hook.Identifier)
+	vault, err := apitesterClient.GetVault(context.Background(), project.Hooks[0].Identifier)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/apit/getvariable.go
+++ b/internal/cmd/apit/getvariable.go
@@ -11,10 +11,11 @@ import (
 
 func GetVariableCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "get-variable NAME [--project PROJECT_NAME]",
-		Short:        "Get a vault variable",
-		Long:         `Get a variable value from a project's vault. Use [--project] to 
-specify the project or run without [--project] to choose from a list
+		Use:   "get-variable NAME [--project PROJECT_NAME]",
+		Short: "Get a vault variable",
+		Long: `
+Get a variable value from a project's vault. Use [--project] to 
+specify the project by name or run without [--project] to choose from a list
 of projects.`,
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/apit/getvariable.go
+++ b/internal/cmd/apit/getvariable.go
@@ -15,8 +15,8 @@ func GetVariableCommand() *cobra.Command {
 		Short: "Get a vault variable",
 		Long: `
 Get a variable value from a project's vault. Use [--project] to 
-specify the project by name or run without [--project] to choose from a list
-of projects.`,
+specify the project by its name or run without [--project] to choose from a list
+of projects`,
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "" {

--- a/internal/cmd/apit/getvariable.go
+++ b/internal/cmd/apit/getvariable.go
@@ -1,0 +1,68 @@
+package apit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/spf13/cobra"
+)
+
+func GetVariableCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "get-variable <projectName> <name>",
+		Short:        "Get a vault variable",
+		SilenceUsage: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || (args[0] == "" || args[1] == "") {
+				// TODO: Give useful error message
+				return errors.New("no project name specified")
+			}
+			return nil
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			err := http.CheckProxy()
+			if err != nil {
+				return fmt.Errorf("invalid HTTP_PROXY value")
+			}
+
+			// tracker := segment.DefaultTracker
+
+			// go func() {
+			// 	tracker.Collect(
+			// 		cases.Title(language.English).String(cmds.FullName(cmd)),
+			// 		usage.Properties{}.SetFlags(cmd.Flags()),
+			// 	)
+			// 	_ = tracker.Close()
+			// }()
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getVariable(args[0], args[1])
+		},
+	}
+
+	return cmd
+}
+
+func getVariable(projectName string, name string) error {
+	hook, err := resolve(projectName)	
+	if err != nil {
+		return err
+	}
+
+	vault, err := apitesterClient.GetVault(context.Background(), hook.Identifier)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range vault.Variables {
+		if v.Name == name {
+			fmt.Printf("%s=%s", v.Name, v.Value)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Project (%s) has no vault variabled with name (%s)", projectName, name)
+}

--- a/internal/cmd/apit/getvariable.go
+++ b/internal/cmd/apit/getvariable.go
@@ -13,8 +13,7 @@ func GetVariableCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-variable NAME [--project PROJECT_NAME]",
 		Short: "Get a vault variable",
-		Long: `
-Get a variable value from a project's vault. Use [--project] to 
+		Long: `Get a variable value from a project's vault. Use [--project] to 
 specify the project by its name or run without [--project] to choose from a list
 of projects`,
 		SilenceUsage: true,

--- a/internal/cmd/apit/setsnippet.go
+++ b/internal/cmd/apit/setsnippet.go
@@ -1,0 +1,70 @@
+package apit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/saucelabs/saucectl/internal/apitest"
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/spf13/cobra"
+)
+
+func SetSnippetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "set-snippet <projectName> <name> <value>",
+		Short:        "Set a vault snippet",
+		SilenceUsage: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || (args[0] == "" || args[1] == "" || args[2] == "") {
+				// TODO: Give useful error message
+				return errors.New("no project name specified")
+			}
+			return nil
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			err := http.CheckProxy()
+			if err != nil {
+				return fmt.Errorf("invalid HTTP_PROXY value")
+			}
+
+			// tracker := segment.DefaultTracker
+
+			// go func() {
+			// 	tracker.Collect(
+			// 		cases.Title(language.English).String(cmds.FullName(cmd)),
+			// 		usage.Properties{}.SetFlags(cmd.Flags()),
+			// 	)
+			// 	_ = tracker.Close()
+			// }()
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setSnippet(args[0], args[1], args[2])
+		},
+	}
+
+	return cmd
+}
+
+func setSnippet(projectName string, name string, value string) error {
+	hook, err := resolve(projectName)
+	if err != nil {
+		return err
+	}
+
+
+	updateVault := apitest.Vault{
+		Variables: []apitest.VaultVariable{},
+		Snippets: map[string]string{
+			name: value,
+		},
+	}
+
+	fmt.Printf("%v", updateVault)
+	err = apitesterClient.PutVault(context.Background(), hook.Identifier, updateVault)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/cmd/apit/setsnippet.go
+++ b/internal/cmd/apit/setsnippet.go
@@ -13,14 +13,20 @@ import (
 )
 
 func SetSnippetCommand() *cobra.Command {
-	var file string
-	var project string
 	cmd := &cobra.Command{
-		Use:          "set-snippet <snippetName>",
-		Short:        "Set a vault snippet",
+		Use:   "set-snippet NAME FILE_NAME|- [--project PROJECT_NAME]",
+		Short: "Set a vault snippet",
+		Long: `
+Set/update a snippet in a project's vault. If a snippet NAME is already in the vault,
+the value will be updated otherwise a new snippet will be added. You can set a snippet's
+value by providing a path to a file defining the snippet or use "-" to read from stdin.
+
+Use [--project] to specify a project by its name or run without [--project] to choose from
+a list of projects
+`,
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 || (args[0] == "") {
+			if len(args) == 0 || (args[0] == "" || args[1] == "") {
 				// TODO: Give useful error message
 				return errors.New("no project name specified")
 			}
@@ -44,47 +50,43 @@ func SetSnippetCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return setSnippet(project, args[0], file)
+			name := args[0]
+			fileName := args[1]
+
+			b, err := readSnippet(fileName)
+			if err != nil {
+				return err
+			}
+
+			updateVault := apitest.Vault{
+				Variables: []apitest.VaultVariable{},
+				Snippets: map[string]string{
+					name: string(b),
+				},
+			}
+
+			err = apitesterClient.PutVault(context.Background(), selectedProject.Hooks[0].Identifier, updateVault)
+			if err != nil {
+				return err
+			}
+			return nil
 		},
 	}
-	cmd.Flags().StringVar(&project, "project", "", "The name of the project.")
-	cmd.Flags().StringVar(&file, "file", "", "A file that defines a vault snippet. Use '-' to read from stdin.")
-	cmd.MarkFlagRequired("file")
-	cmd.MarkFlagRequired("project")
 
 	return cmd
 }
 
-func setSnippet(projectName string, name string, fileName string) error {
+func readSnippet(fileName string) ([]byte, error) {
 	var r io.Reader
 	var err error
 	if fileName == "-" {
 		r = os.Stdin
 	} else {
 		r, err = os.Open(fileName)
+		if err != nil {
+			return []byte{}, err
+		}
 	}
 
-	if err != nil {
-		return err
-	}
-
-	b, err := io.ReadAll(r)
-
-	project, err := resolve(projectName)
-	if err != nil {
-		return err
-	}
-
-	updateVault := apitest.Vault{
-		Variables: []apitest.VaultVariable{},
-		Snippets: map[string]string{
-			name: string(b),
-		},
-	}
-
-    err = apitesterClient.PutVault(context.Background(), project.Hooks[0].Identifier, updateVault)
-    if err != nil {
-    	return err
-    }
-	return nil
+	return io.ReadAll(r)
 }

--- a/internal/cmd/apit/setsnippet.go
+++ b/internal/cmd/apit/setsnippet.go
@@ -70,7 +70,7 @@ func setSnippet(projectName string, name string, fileName string) error {
 
 	b, err := io.ReadAll(r)
 
-	hook, err := resolve(projectName)
+	project, err := resolve(projectName)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func setSnippet(projectName string, name string, fileName string) error {
 		},
 	}
 
-    err = apitesterClient.PutVault(context.Background(), hook.Identifier, updateVault)
+    err = apitesterClient.PutVault(context.Background(), project.Hooks[0].Identifier, updateVault)
     if err != nil {
     	return err
     }

--- a/internal/cmd/apit/setvariable.go
+++ b/internal/cmd/apit/setvariable.go
@@ -48,7 +48,7 @@ func SetVariableCommand() *cobra.Command {
 }
 
 func setVariable(projectName string, name string, val string) error {
-	hook, err := resolve(projectName)
+	project, err := resolve(projectName)
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func setVariable(projectName string, name string, val string) error {
 		Snippets: map[string]string{},
 	}
 
-	err = apitesterClient.PutVault(context.Background(), hook.Identifier, updateVault)
+	err = apitesterClient.PutVault(context.Background(), project.Hooks[0].Identifier, updateVault)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/apit/setvariable.go
+++ b/internal/cmd/apit/setvariable.go
@@ -14,8 +14,7 @@ func SetVariableCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set-variable NAME VALUE [--project PROJECT_NAME]",
 		Short: "Set a vault variable",
-		Long: `
-Set/update a variable in a project's vault. If a variable NAME is already in the vault,
+		Long: `Set/update a variable in a project's vault. If a variable NAME is already in the vault,
 the value will be update otherwise a new variable will be added. Use [--project] to specify
 a project by its name or run without [--project] to choose from a list of projects
 `,

--- a/internal/cmd/apit/setvariable.go
+++ b/internal/cmd/apit/setvariable.go
@@ -1,0 +1,72 @@
+package apit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/saucelabs/saucectl/internal/apitest"
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/spf13/cobra"
+)
+
+func SetVariableCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "set-variable <projectName> <name> <value>",
+		Short:        "Set a vault variable",
+		SilenceUsage: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || (args[0] == "" || args[1] == "" || args[2] == "") {
+				// TODO: Give useful error message
+				return errors.New("no project name specified")
+			}
+			return nil
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			err := http.CheckProxy()
+			if err != nil {
+				return fmt.Errorf("invalid HTTP_PROXY value")
+			}
+
+			// tracker := segment.DefaultTracker
+
+			// go func() {
+			// 	tracker.Collect(
+			// 		cases.Title(language.English).String(cmds.FullName(cmd)),
+			// 		usage.Properties{}.SetFlags(cmd.Flags()),
+			// 	)
+			// 	_ = tracker.Close()
+			// }()
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setVariable(args[0], args[1], args[2])
+		},
+	}
+
+	return cmd
+}
+
+func setVariable(projectName string, name string, val string) error {
+	hook, err := resolve(projectName)
+	if err != nil {
+		return err
+	}
+
+	updateVault := apitest.Vault{
+		Variables: []apitest.VaultVariable{
+			{
+				Name:  name,
+				Value: val,
+				Type:  "variable",
+			},
+		},
+		Snippets: map[string]string{},
+	}
+
+	err = apitesterClient.PutVault(context.Background(), hook.Identifier, updateVault)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/cmd/apit/vault.go
+++ b/internal/cmd/apit/vault.go
@@ -45,6 +45,7 @@ func VaultCommand(preRunE func(cmd *cobra.Command, args []string) error) *cobra.
 	cmd.PersistentFlags().StringVar(&projectName, "project", "", "The name of the project the vault belongs to.")
 
 	cmd.AddCommand(
+		GetCommand(),
 		SetVariableCommand(),
 		GetVariableCommand(),
 		GetSnippetCommand(),

--- a/internal/cmd/apit/vault.go
+++ b/internal/cmd/apit/vault.go
@@ -1,0 +1,79 @@
+package apit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/spf13/cobra"
+)
+
+func GetVaultCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "get-vault <projectName>",
+		Short:        "Get a project's vault",
+		SilenceUsage: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || args[0] == "" {
+				return errors.New("no project name specified")
+			}
+			return nil
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			err := http.CheckProxy()
+			if err != nil {
+				return fmt.Errorf("invalid HTTP_PROXY value")
+			}
+
+			// tracker := segment.DefaultTracker
+
+			// go func() {
+			// 	tracker.Collect(
+			// 		cases.Title(language.English).String(cmds.FullName(cmd)),
+			// 		usage.Properties{}.SetFlags(cmd.Flags()),
+			// 	)
+			// 	_ = tracker.Close()
+			// }()
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return exec(args[0])
+		},
+	}
+
+	return cmd
+}
+
+func exec(projectName string) error {
+	projects, err := apitesterClient.GetProjects(context.Background());
+	if err != nil {
+		return err
+	}
+
+	var projectID string
+	for _, p := range projects {
+		if p.Name == projectName {
+			projectID = p.ID
+		}
+	}
+
+	if projectID == "" {
+		return fmt.Errorf("Can't find project with name %s", projectName)
+	}
+
+	hooks, err := apitesterClient.GetHooks(context.Background(), projectID);
+	if err != nil {
+		return err
+	}
+	if len(hooks) == 0 {
+		return fmt.Errorf("Project has no hooks")
+	}
+
+	vault, err := apitesterClient.GetVault(context.Background(), hooks[0].Identifier)
+	if err != nil {
+		return err
+	}
+	fmt.Println(vault)
+	return nil
+}

--- a/internal/cmd/apit/vault.go
+++ b/internal/cmd/apit/vault.go
@@ -18,6 +18,7 @@ func VaultCommand() *cobra.Command {
 	cmd.AddCommand(
 		SetVariableCommand(),
 		GetVariableCommand(),
+		GetSnippetCommand(),
 	)
 	return cmd
 }

--- a/internal/cmd/apit/vault.go
+++ b/internal/cmd/apit/vault.go
@@ -2,8 +2,10 @@ package apit
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/spf13/cobra"
@@ -74,6 +76,6 @@ func exec(projectName string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(vault)
+	json.NewEncoder(os.Stdout).Encode(vault)
 	return nil
 }

--- a/internal/cmd/apit/vault.go
+++ b/internal/cmd/apit/vault.go
@@ -67,10 +67,14 @@ func projectSurvey(names []string) string {
 	return selection
 }
 
+func isTerm(fd uintptr) bool {
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
+
 func resolve(projectName string) (ResolvedProject, error) {
 	projects, err := apitesterClient.GetProjects(context.Background())
 	if projectName == "" {
-		if !isatty.IsTerminal(os.Stdin.Fd()) && !isatty.IsCygwinTerminal(os.Stdin.Fd()) {
+		if !isTerm(os.Stdin.Fd()) || !isTerm(os.Stdout.Fd()) {
 			return ResolvedProject{}, fmt.Errorf("No project specified. Use --project to choose a project by name")
 		}
 		names := []string{}

--- a/internal/cmd/apit/vault.go
+++ b/internal/cmd/apit/vault.go
@@ -54,7 +54,7 @@ func VaultCommand(preRunE func(cmd *cobra.Command, args []string) error) *cobra.
 	return cmd
 }
 
-func projectSurvey(names []string) string {
+func projectSurvey(names []string) (string, error) {
 	var selection string
 	prompt := &survey.Select{
 		Help: "Select the project the vault belongs to. Use --project to define a project in your command and skip this selection",
@@ -62,9 +62,9 @@ func projectSurvey(names []string) string {
 		Options: names,
 	}
 
-	survey.AskOne(prompt, &selection)
+	err := survey.AskOne(prompt, &selection)
 
-	return selection
+	return selection, err
 }
 
 func isTerm(fd uintptr) bool {
@@ -81,7 +81,7 @@ func resolve(projectName string) (ResolvedProject, error) {
 		for _, p := range projects {
 			names = append(names, p.Name)
 		}
-		projectName = projectSurvey(names)
+		projectName, err = projectSurvey(names)
 	}
 	if err != nil {
 		return ResolvedProject{}, err

--- a/internal/cmd/apit/vault.go
+++ b/internal/cmd/apit/vault.go
@@ -3,8 +3,10 @@ package apit
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/mattn/go-isatty"
 	"github.com/saucelabs/saucectl/internal/apitest"
 	"github.com/spf13/cobra"
 )
@@ -67,6 +69,9 @@ func projectSurvey(names []string) string {
 func resolve(projectName string) (ResolvedProject, error) {
 	projects, err := apitesterClient.GetProjects(context.Background())
 	if projectName == "" {
+		if !isatty.IsTerminal(os.Stdin.Fd()) && !isatty.IsCygwinTerminal(os.Stdin.Fd()) {
+			return ResolvedProject{}, fmt.Errorf("No project specified. Use --project to choose a project by name")
+		}
 		names := []string{}
 		for _, p := range projects {
 			names = append(names, p.Name)

--- a/internal/cmd/apit/vault.go
+++ b/internal/cmd/apit/vault.go
@@ -19,6 +19,7 @@ func VaultCommand() *cobra.Command {
 		SetVariableCommand(),
 		GetVariableCommand(),
 		GetSnippetCommand(),
+		SetSnippetCommand(),
 	)
 	return cmd
 }

--- a/internal/http/apitester.go
+++ b/internal/http/apitester.go
@@ -399,7 +399,7 @@ func (c *APITester) GetVault(ctx context.Context, hookID string) (apitest.Vault,
 }
 
 func (c *APITester) PutVault(ctx context.Context, hookID string, vault apitest.Vault) error {
-	url := fmt.Sprintf("%s/api-testing/rest/v4/%s/vaults", c.URL, hookID)
+	url := fmt.Sprintf("%s/api-testing/rest/v4/%s/vault", c.URL, hookID)
 
 	var b bytes.Buffer
 	err := json.NewEncoder(&b).Encode(vault)
@@ -425,14 +425,14 @@ func (c *APITester) PutVault(ctx context.Context, hookID string, vault apitest.V
 		return errors.New(msg.InternalServerError)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode == http.StatusBadRequest {
 		body, _ := io.ReadAll(resp.Body)
 		var errResp VaultErrResponse
 		err = json.Unmarshal(body, &errResp)
-		if err != nil {
+		if err == nil {
+			// TODO: Cleaner error msg
 			return fmt.Errorf("request failed; unexpected response code:'%d', msg:'%s'", resp.StatusCode, body)
 		}
-		// TODO: Parse the error response for accurate feedback
 	}
 
 	return nil

--- a/internal/http/apitester.go
+++ b/internal/http/apitester.go
@@ -425,14 +425,15 @@ func (c *APITester) PutVault(ctx context.Context, hookID string, vault apitest.V
 		return errors.New(msg.InternalServerError)
 	}
 
-	if resp.StatusCode == http.StatusBadRequest {
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		var errResp VaultErrResponse
 		err = json.Unmarshal(body, &errResp)
 		if err == nil {
 			// TODO: Cleaner error msg
-			return fmt.Errorf("request failed; unexpected response code:'%d', msg:'%s'", resp.StatusCode, body)
+			return fmt.Errorf("request failed; unexpected response code:'%d', msg:'%s'", resp.StatusCode, errResp.Message)
 		}
+		return fmt.Errorf("request failed; unexpected response code:'%d', msg:'%s'", resp.StatusCode, body)
 	}
 
 	return nil


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds the following commands to work with an api testing project vault:

```
saucectl apit vault get [--project PROJECT_NAME]
saucectl apit vault get-variable NAME [--project PROJECT_NAME]
saucectl apit vault set-variable NAME VALUE [--project PROJECT_NAME]
saucectl apit vault get-snippet NAME [--project PROJECT_NAME]
saucectl apit vault set-snippet NAME FILE_PATH|- [--project PROJECT_NAME]
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

* Opted to make `project` a flag and not a positional arg. I opted for that because a command like `get-variable` feels like it wants the variable-in-question as the positional arg. Having the project be positional felt a bit awkward and unintuitive. But we already have some commands that have a "resource" as a positional arg, e.g `artifacts download JOB_ID FILE_PATTERN`. So if we prefer consistency, I'm happy to go that route.
* If `--project` is not specified and the terminal is a tty, user will be prompted to choose from a list of projects:
![demo1](https://github.com/saucelabs/saucectl/assets/56001373/05417ce4-299c-4e82-85e9-d47cc5bd1841)
* A snippet is structured data (at the moment an xml document, but will eventually be yaml) so I've implemented `set-variable` to take either a path to a file or `-` to denote stdin. Accepting from stdin is slightly pedantic, but experienced cli users may expect it.