### PR TITLE
chore: Don't track usage against staging

### DIFF
--- a/internal/cmd/apit/cmd.go
+++ b/internal/cmd/apit/cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/spf13/cobra"
 )
 
@@ -26,12 +27,16 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 				preRun(cmd, args)
 			}
 
-			if region.FromString(regio) == region.None {
+			reg := region.FromString(regio)
+			if reg == region.None {
 				return errors.New("invalid region")
+			}
+			if reg == region.Staging {
+				segment.DefaultTracker.Enabled = false
 			}
 
 			creds := credentials.Get()
-			url := region.FromString(regio).APIBaseURL()
+			url := reg.APIBaseURL()
 
 			apitesterClient = http.NewAPITester(url, creds.Username, creds.AccessKey, 15*time.Minute)
 

--- a/internal/cmd/artifacts/cmd.go
+++ b/internal/cmd/artifacts/cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/saucelabs/saucectl/internal/saucecloud"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/spf13/cobra"
 )
 
@@ -33,12 +34,16 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 				preRun(cmd, args)
 			}
 
-			if region.FromString(regio) == region.None {
+			reg := region.FromString(regio)
+			if reg == region.None {
 				return errors.New("invalid region")
+			}
+			if reg == region.Staging {
+				segment.DefaultTracker.Enabled = false
 			}
 
 			creds := credentials.Get()
-			url := region.FromString(regio).APIBaseURL()
+			url := reg.APIBaseURL()
 			restoClient := http.NewResto(url, creds.Username, creds.AccessKey, restoTimeout)
 			rdcClient := http.NewRDCService(url, creds.Username, creds.AccessKey, rdcTimeout, config.ArtifactDownload{})
 			testcompClient := http.NewTestComposer(url, creds, testComposerTimeout)

--- a/internal/cmd/imagerunner/cmd.go
+++ b/internal/cmd/imagerunner/cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/spf13/cobra"
 )
 
@@ -26,8 +27,12 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 				preRun(cmd, args)
 			}
 
-			if region.FromString(regio) == region.None {
+			reg := region.FromString(regio)
+			if reg == region.None {
 				return errors.New("invalid region")
+			}
+			if reg == region.Staging {
+				segment.DefaultTracker.Enabled = false
 			}
 
 			creds := credentials.Get()

--- a/internal/cmd/jobs/cmd.go
+++ b/internal/cmd/jobs/cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/saucelabs/saucectl/internal/saucecloud"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/spf13/cobra"
 )
 
@@ -31,12 +32,16 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 				preRun(cmd, args)
 			}
 
-			if region.FromString(regio) == region.None {
+			reg := region.FromString(regio)
+			if reg == region.None {
 				return errors.New("invalid region")
+			}
+			if reg == region.Staging {
+				segment.DefaultTracker.Enabled = false
 			}
 
 			creds := credentials.Get()
-			url := region.FromString(regio).APIBaseURL()
+			url := reg.APIBaseURL()
 			insightsClient := http.NewInsightsService(url, creds, insightsTimeout)
 			iamClient := http.NewUserService(url, creds, iamTimeout)
 

--- a/internal/cmd/run/apitest.go
+++ b/internal/cmd/run/apitest.go
@@ -57,6 +57,9 @@ func runApitest(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 	}
 
 	tracker := segment.DefaultTracker
+	if regio == region.Staging {
+		tracker.Enabled = false
+	}
 
 	go func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/cucumber.go
+++ b/internal/cmd/run/cucumber.go
@@ -107,6 +107,9 @@ func runCucumber(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 	}
 
 	tracker := segment.DefaultTracker
+	if regio == region.Staging {
+		tracker.Enabled = false
+	}
 
 	go func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -125,6 +125,9 @@ func runCypress(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 	iamClient.URL = regio.APIBaseURL()
 	restoClient.ArtifactConfig = p.GetArtifactsCfg().Download
 	tracker := segment.DefaultTracker
+	if regio == region.Staging {
+		tracker.Enabled = false
+	}
 
 	go func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -124,6 +124,9 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, isCLIDriven bo
 	}
 
 	tracker := segment.DefaultTracker
+	if regio == region.Staging {
+		tracker.Enabled = false
+	}
 
 	go func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/imagerunner.go
+++ b/internal/cmd/run/imagerunner.go
@@ -38,6 +38,9 @@ func runImageRunner(cmd *cobra.Command) (int, error) {
 	restoClient.URL = regio.APIBaseURL()
 
 	tracker := segment.DefaultTracker
+	if regio == region.Staging {
+		tracker.Enabled = false
+	}
 
 	go func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -140,6 +140,9 @@ func runPlaywright(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 	}
 
 	tracker := segment.DefaultTracker
+	if regio == region.Staging {
+		tracker.Enabled = false
+	}
 
 	go func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -111,6 +111,9 @@ func runReplay(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 	}
 
 	tracker := segment.DefaultTracker
+	if regio == region.Staging {
+		tracker.Enabled = false
+	}
 
 	go func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -163,6 +163,9 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 	}
 
 	tracker := segment.DefaultTracker
+	if regio == region.Staging {
+		tracker.Enabled = false
+	}
 
 	go func() {
 		props := usage.Properties{}

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -122,6 +122,9 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, isCLIDriven bool) 
 	}
 
 	tracker := segment.DefaultTracker
+	if regio == region.Staging {
+		tracker.Enabled = false
+	}
 
 	go func() {
 		props := usage.Properties{}

--- a/internal/cmd/storage/cmd.go
+++ b/internal/cmd/storage/cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/spf13/cobra"
 )
 
@@ -27,11 +28,15 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 				preRun(cmd, args)
 			}
 
-			if region.FromString(regio) == region.None {
+			reg := region.FromString(regio)
+			if reg == region.None {
 				return errors.New("invalid region")
 			}
+			if reg == region.Staging {
+				segment.DefaultTracker.Enabled = false
+			}
 
-			appsClient = *http.NewAppStore(region.FromString(regio).APIBaseURL(),
+			appsClient = *http.NewAppStore(reg.APIBaseURL(),
 				credentials.Get().Username, credentials.Get().AccessKey,
 				15*time.Minute)
 


### PR DESCRIPTION
## Proposed changes

Don't track usage against staging. Causes some grief in Mixpanel, because not all internal users in staging also exist in prod. Those missing users are not correctly identified in Mixpanel and can't be easily excluded unless you exclude data tagged with the region "staging". However, staging data shouldn't even end up prod at all. So, disable usage tracking when region is staging.