### PR TITLE
chore: Set workload type when initing sauce config

### DIFF
--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -55,6 +55,7 @@ type initConfig struct {
 	concurrency      int
 	username         string
 	accessKey        string
+	workload         string
 }
 
 var (
@@ -99,6 +100,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVarP(&initCfg.frameworkVersion, "frameworkVersion", "v", "", "framework version to be used")
 	cmd.Flags().StringVar(&initCfg.cypressJSON, "cypress.config", "", "path to cypress.json file (cypress only)")
 	cmd.Flags().StringVar(&initCfg.dockerImage, "dockerImage", "", "docker image to use (imagerunner only)")
+	cmd.Flags().StringVar(&initCfg.workload, "workload", "", "workload to use (imagerunner only)")
 	cmd.Flags().StringVar(&initCfg.app, "app", "", "path to application to test (espresso/xcuitest only)")
 	cmd.Flags().StringVarP(&initCfg.testApp, "testApp", "t", "", "path to test application (espresso/xcuitest only)")
 	cmd.Flags().StringSliceVarP(&initCfg.otherApps, "otherApps", "o", []string{}, "path to other applications (espresso/xcuitest only)")

--- a/internal/cmd/ini/imagerunner.go
+++ b/internal/cmd/ini/imagerunner.go
@@ -25,6 +25,7 @@ func configureImageRunner(cfg *initConfig) interface{} {
 					User:  "${DOCKER_USERNAME}",
 					Token: "${DOCKER_PASSWORD}",
 				},
+				Workload: cfg.workload,
 			},
 		},
 		Artifacts: config.Artifacts{

--- a/internal/cmd/ini/initializer_test.go
+++ b/internal/cmd/ini/initializer_test.go
@@ -1399,6 +1399,14 @@ func Test_initializers(t *testing.T) {
 				if err != nil {
 					return err
 				}
+				_, err = c.ExpectString("Set workload:")
+				if err != nil {
+					return err
+				}
+				_, err = c.SendLine("webdriver")
+				if err != nil {
+					return err
+				}
 				_, err = c.ExpectString("Download artifacts:")
 				if err != nil {
 					return err
@@ -1426,6 +1434,7 @@ func Test_initializers(t *testing.T) {
 			expectedState: &initConfig{
 				frameworkName: imagerunner.Kind,
 				dockerImage:   "ubuntu:latest",
+				workload:      "webdriver",
 				artifactWhen:  config.WhenPass,
 			},
 		},


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
```
$ saucectl init 
12:15:24 INF Start Init Command
? Select region: us-west-1
? Select framework: imagerunner
? Docker Image to use: helloworld
? Set workload: webdriver
? Download artifacts: when tests are failing

The following files have been created:
  .sauce/config.yml


Before running your tests, you need to set the following environment variables:
  - DOCKER_USERNAME
  - DOCKER_PASSWORD
```
## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->