### PR TITLE
fix: Handle empty credentials when listing credentials

### DIFF
--- a/internal/cmd/configure/list.go
+++ b/internal/cmd/configure/list.go
@@ -1,6 +1,8 @@
 package configure
 
 import (
+	"fmt"
+
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +16,10 @@ func ListCommand() *cobra.Command {
 		Short: "Shows the current credentials and their origin.",
 		Run: func(cmd *cobra.Command, args []string) {
 			creds := credentials.Get()
+			if creds.Username == "" || creds.AccessKey == "" {
+				fmt.Println(`Credentials have not been set. Please use "saucectl configure" to set your credentials.`)
+				return
+			}
 			printCreds(creds)
 		},
 	}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Handle empty credentials

```
saucectl-local configure list
Credentials have not been set. Please use "saucectl configure" to set your credentials.
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->