### PR TITLE
fix: Imagerunner workload type not propagated due to wrong case

### DIFF
--- a/internal/imagerunner/imagerunner.go
+++ b/internal/imagerunner/imagerunner.go
@@ -38,7 +38,7 @@ type RunnerSpec struct {
 	Files        []FileData        `json:"files,omitempty"`
 	Metadata     map[string]string `json:"metadata,omitempty"`
 	Artifacts    []string          `json:"artifacts,omitempty"`
-	WorkloadType string            `json:"workloadType,omitempty"`
+	WorkloadType string            `json:"workload_type,omitempty"`
 	Tunnel       *Tunnel           `json:"tunnel,omitempty"`
 }
 


### PR DESCRIPTION
## Proposed changes

Backend expects [workload type](https://github.com/saucelabs/hostedrunner-api/blob/main/specs/openapi_v1alpha1.yaml#L235C9-L235C9) (and anything else in image runner) to be snake case.