### PR TITLE
Add support for scoped registries

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -110,6 +110,32 @@
                   "strictSSL": {
                     "description": "Whether or not to do SSL key validation when making requests to the registry via https.",
                     "type": "boolean"
+                  },
+                  "scopedRegistries": {
+                    "description": "Specify all the scoped registries you want to configure",
+                    "type": "array",
+                    "minimum": 0,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "scope": {
+                          "description": "Scope for the registry entry",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "URL for the registry entry",
+                          "type": "string"
+                        },
+                        "authToken": {
+                          "description": "authToken for the registry entry",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "scope",
+                        "url"
+                      ]
+                    }
                   }
                 },
                 "additionalProperties": false
@@ -565,6 +591,32 @@
                   "strictSSL": {
                     "description": "Whether or not to do SSL key validation when making requests to the registry via https.",
                     "type": "boolean"
+                  },
+                  "scopedRegistries": {
+                    "description": "Specify all the scoped registries you want to configure",
+                    "type": "array",
+                    "minimum": 0,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "scope": {
+                          "description": "Scope for the registry entry",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "URL for the registry entry",
+                          "type": "string"
+                        },
+                        "authToken": {
+                          "description": "authToken for the registry entry",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "scope",
+                        "url"
+                      ]
+                    }
                   }
                 },
                 "additionalProperties": false

--- a/api/v1/subschema/npm.schema.json
+++ b/api/v1/subschema/npm.schema.json
@@ -23,6 +23,32 @@
         "strictSSL": {
           "description": "Whether or not to do SSL key validation when making requests to the registry via https.",
           "type": "boolean"
+        },
+        "scopedRegistries": {
+          "description": "Specify all the scoped registries you want to configure",
+          "type": "array",
+          "minimum": 0,
+          "items": {
+            "type": "object",
+            "properties": {
+              "scope": {
+                "description": "Scope for the registry entry",
+                "type": "string"
+              },
+              "url": {
+                "description": "URL for the registry entry",
+                "type": "string"
+              },
+              "authToken": {
+                "description": "authToken for the registry entry",
+                "type": "string"
+              }
+            },
+            "required": [
+              "scope",
+              "url"
+            ]
+          }
         }
       },
       "additionalProperties": false

--- a/api/v1alpha/subschema/npm.schema.json
+++ b/api/v1alpha/subschema/npm.schema.json
@@ -23,6 +23,32 @@
         "strictSSL": {
           "description": "Whether or not to do SSL key validation when making requests to the registry via https.",
           "type": "boolean"
+        },
+        "scopedRegistries": {
+          "description": "Specify all the scoped registries you want to configure",
+          "type": "array",
+          "minimum": 0,
+          "items": {
+            "type": "object",
+            "properties": {
+              "scope": {
+                "description": "Scope for the registry entry",
+                "type": "string"
+              },
+              "url": {
+                "description": "URL for the registry entry",
+                "type": "string"
+              },
+              "authToken": {
+                "description": "authToken for the registry entry",
+                "type": "string"
+              }
+            },
+            "required": [
+              "scope",
+              "url"
+            ]
+          }
         }
       },
       "additionalProperties": false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,12 +173,20 @@ type TypeDef struct {
 	Kind       string `yaml:"kind,omitempty"`
 }
 
+// ScopedRegistry represents the scoped registries for NPM
+type ScopedRegistry struct {
+	Scope     string `yaml:"scope,omitempty" json:"scope,omitempty"`
+	Registry  string `yaml:"registry,omitempty" json:"registry,omitempty"`
+	AuthToken string `yaml:"authToken,omitempty" json:"authToken,omitempty"`
+}
+
 // Npm represents the npm settings
 type Npm struct {
-	Registry     string            `yaml:"registry,omitempty" json:"registry,omitempty"`
-	Packages     map[string]string `yaml:"packages,omitempty" json:"packages"`
-	Dependencies []string          `yaml:"dependencies,omitempty" json:"dependencies"`
-	StrictSSL    bool              `yaml:"strictSSL,omitempty" json:"strictSSL"`
+	Registry         string            `yaml:"registry,omitempty" json:"registry,omitempty"`
+	ScopedRegistries []ScopedRegistry  `yaml:"scopedRegistries" json:"scopedRegistries,omitempty"`
+	Packages         map[string]string `yaml:"packages,omitempty" json:"packages"`
+	Dependencies     []string          `yaml:"dependencies,omitempty" json:"dependencies"`
+	StrictSSL        bool              `yaml:"strictSSL,omitempty" json:"strictSSL"`
 }
 
 // Defaults represents default suite settings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,7 +176,7 @@ type TypeDef struct {
 // ScopedRegistry represents the scoped registries for NPM
 type ScopedRegistry struct {
 	Scope     string `yaml:"scope,omitempty" json:"scope,omitempty"`
-	Registry  string `yaml:"registry,omitempty" json:"registry,omitempty"`
+	URL       string `yaml:"url,omitempty" json:"url,omitempty"`
 	AuthToken string `yaml:"authToken,omitempty" json:"authToken,omitempty"`
 }
 


### PR DESCRIPTION
## Proposed changes

Introduces Scoped Registries support to saucectl.

Introduce this new setting:

```

npm:
  scopedRegistries:
  - scope: "@saucelabs"
    url: https://my.registry.com
    authToken: "myAuthToken" (optional)
```

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->