### PR TITLE
fix: Skip rendering JUnit&JSON reporters when running in async mode

### DIFF
--- a/internal/cmd/run/cucumber.go
+++ b/internal/cmd/run/cucumber.go
@@ -145,7 +145,7 @@ func runCucumber(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &testcompClient, &restoClient,
-				"cucumber", "sauce"),
+				"cucumber", "sauce", gFlags.async),
 			Async:                  gFlags.async,
 			FailFast:               gFlags.failFast,
 			MetadataSearchStrategy: framework.NewSearchStrategy(p.Playwright.Version, p.RootDir),

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -164,7 +164,7 @@ func runCypress(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 			Region:          regio,
 			ShowConsoleLog:  p.IsShowConsoleLog(),
 			Reporters: createReporters(p.GetReporter(), p.GetNotifications(), p.GetSauceCfg().Metadata, &testcompClient, &restoClient,
-				"cypress", "sauce"),
+				"cypress", "sauce", gFlags.async),
 			Async:                  gFlags.async,
 			FailFast:               gFlags.failFast,
 			MetadataSearchStrategy: framework.NewSearchStrategy(p.GetVersion(), p.GetRootDir()),

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -168,7 +168,7 @@ func runEspressoInCloud(p espresso.Project, regio region.Region) (int, error) {
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &testcompClient, &restoClient,
-				"espresso", "sauce"),
+				"espresso", "sauce", gFlags.async),
 			Framework: framework.Framework{Name: espresso.Kind},
 			Async:     gFlags.async,
 			FailFast:  gFlags.failFast,

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -179,7 +179,7 @@ func runPlaywright(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &testcompClient, &restoClient,
-				"playwright", "sauce"),
+				"playwright", "sauce", gFlags.async),
 			Async:                  gFlags.async,
 			FailFast:               gFlags.failFast,
 			MetadataSearchStrategy: framework.NewSearchStrategy(p.Playwright.Version, p.RootDir),

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -153,7 +153,7 @@ func runPuppeteerReplayInSauce(p replay.Project, regio region.Region) (int, erro
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &testcompClient, &restoClient,
-				"puppeteer-replay", "sauce"),
+				"puppeteer-replay", "sauce", gFlags.async),
 			Async:                  gFlags.async,
 			FailFast:               gFlags.failFast,
 			MetadataSearchStrategy: framework.ExactStrategy{},

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -282,7 +282,7 @@ func checkForUpdates() {
 }
 
 func createReporters(c config.Reporters, ntfs config.Notifications, metadata config.Metadata,
-	svc slack.Service, buildReader build.Reader, framework, env string) []report.Reporter {
+	svc slack.Service, buildReader build.Reader, framework, env string, async bool) []report.Reporter {
 	buildReporter := buildtable.New(buildReader)
 	githubReporter := github.NewJobSummaryReporter()
 
@@ -292,13 +292,13 @@ func createReporters(c config.Reporters, ntfs config.Notifications, metadata con
 		&githubReporter,
 	}
 
-	if c.JUnit.Enabled {
+	if !async && c.JUnit.Enabled {
 		reps = append(reps, &junit.Reporter{
 			Filename: c.JUnit.Filename,
 		})
 	}
 
-	if c.JSON.Enabled {
+	if !async && c.JSON.Enabled {
 		reps = append(reps, &json.Reporter{
 			WebhookURL: c.JSON.WebhookURL,
 			Filename:   c.JSON.Filename,

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -201,7 +201,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &testcompClient, &restoClient,
-				"testcafe", "sauce"),
+				"testcafe", "sauce", gFlags.async),
 			Async:                  gFlags.async,
 			FailFast:               gFlags.failFast,
 			MetadataSearchStrategy: framework.NewSearchStrategy(p.Testcafe.Version, p.RootDir),

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -166,7 +166,7 @@ func runXcuitestInCloud(p xcuitest.Project, regio region.Region) (int, error) {
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(p.Reporters, p.Notifications, p.Sauce.Metadata, &testcompClient, &restoClient,
-				"xcuitest", "sauce"),
+				"xcuitest", "sauce", gFlags.async),
 			Framework: framework.Framework{Name: xcuitest.Kind},
 			Async:     gFlags.async,
 			FailFast:  gFlags.failFast,

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -103,13 +103,6 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 	inProgress := expected
 	passed := true
 
-	var junitRequired bool
-	var jsonResultRequired bool
-	if !r.Async {
-		junitRequired = report.IsArtifactRequired(r.Reporters, report.JUnitArtifact)
-		jsonResultRequired = report.IsArtifactRequired(r.Reporters, report.JSONArtifact)
-	}
-
 	done := make(chan interface{})
 	go func(r *CloudRunner) {
 		t := time.NewTicker(10 * time.Second)
@@ -152,7 +145,7 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 			var artifacts []report.Artifact
 			var parentJUnits []report.Artifact
 
-			if junitRequired {
+			if report.IsArtifactRequired(r.Reporters, report.JUnitArtifact) {
 				jb, err := r.JobService.GetJobAssetFileContent(
 					context.Background(),
 					res.job.ID,
@@ -174,6 +167,13 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 						AssetType: report.JUnitArtifact,
 						Body:      jb,
 						Error:     err,
+					})
+				}
+			}
+			if report.IsArtifactRequired(r.Reporters, report.JSONArtifact) {
+				for _, f := range r.downloadArtifacts(res.name, res.job, artifactCfg.When) {
+					artifacts = append(artifacts, report.Artifact{
+						FilePath: f,
 					})
 				}
 			}
@@ -200,19 +200,11 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 				ParentJUnits: parentJUnits,
 			}
 
-			files := r.downloadArtifacts(res.name, res.job, artifactCfg.When)
-			if jsonResultRequired {
-				for _, f := range files {
-					artifacts = append(artifacts, report.Artifact{
-						FilePath: f,
-					})
-				}
-			}
-
 			for _, rep := range r.Reporters {
 				rep.Add(tr)
 			}
 		}
+
 		r.logSuite(res)
 
 		// Skip reporting to Insights for async job

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -103,8 +103,12 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 	inProgress := expected
 	passed := true
 
-	junitRequired := report.IsArtifactRequired(r.Reporters, report.JUnitArtifact)
-	jsonResultRequired := report.IsArtifactRequired(r.Reporters, report.JSONArtifact)
+	var junitRequired bool
+	var jsonResultRequired bool
+	if !r.Async {
+		junitRequired = report.IsArtifactRequired(r.Reporters, report.JUnitArtifact)
+		jsonResultRequired = report.IsArtifactRequired(r.Reporters, report.JSONArtifact)
+	}
 
 	done := make(chan interface{})
 	go func(r *CloudRunner) {

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -170,8 +170,9 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 					})
 				}
 			}
+			files := r.downloadArtifacts(res.name, res.job, artifactCfg.When)
 			if report.IsArtifactRequired(r.Reporters, report.JSONArtifact) {
-				for _, f := range r.downloadArtifacts(res.name, res.job, artifactCfg.When) {
+				for _, f := range files {
 					artifacts = append(artifacts, report.Artifact{
 						FilePath: f,
 					})


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Skip rendering reporters when running in async mode.

<img width="1317" alt="Screenshot 2023-07-19 at 3 26 23 PM" src="https://github.com/saucelabs/saucectl/assets/71669683/9f66f0ab-780f-49f7-b1ab-f6d84a5b93a8">

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--


Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->