### PR TITLE
feat: Allow additional runner metadata to be set by the user

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -2632,6 +2632,10 @@
                   "c2m2",
                   "c3m3"
                 ]
+              },
+              "metadata": {
+                "description": "Supply additional metadata to your runner.",
+                "type": "object"
               }
             },
             "required": [

--- a/api/v1alpha/framework/imagerunner.schema.json
+++ b/api/v1alpha/framework/imagerunner.schema.json
@@ -115,6 +115,10 @@
             "c2m2",
             "c3m3"
           ]
+        },
+        "metadata": {
+          "description": "Supply additional metadata to your runner.",
+          "type": "object"
         }
       },
       "required": [

--- a/internal/imagerunner/config.go
+++ b/internal/imagerunner/config.go
@@ -50,6 +50,7 @@ type Suite struct {
 	Timeout         time.Duration     `yaml:"timeout,omitempty" json:"timeout"`
 	Workload        string            `yaml:"workload,omitempty" json:"workload,omitempty"`
 	ResourceProfile string            `yaml:"resourceProfile,omitempty" json:"resourceProfile,omitempty"`
+	Metadata        map[string]string `yaml:"metadata,omitempty" json:"metadata,omitempty"`
 }
 
 type ImagePullAuth struct {
@@ -98,27 +99,35 @@ func SetDefaults(p *Project) {
 	p.Sauce.Tunnel.SetDefaults()
 	p.Sauce.Metadata.SetDefaultBuild()
 
-	for i, suite := range p.Suites {
+	for i := range p.Suites {
+		suite := &p.Suites[i]
 		if suite.Timeout <= 0 {
-			p.Suites[i].Timeout = p.Defaults.Timeout
+			suite.Timeout = p.Defaults.Timeout
 		}
 
 		if suite.Workload == "" {
-			p.Suites[i].Workload = p.Defaults.Workload
+			suite.Workload = p.Defaults.Workload
 		}
 
 		if suite.ResourceProfile == "" {
-			p.Suites[i].ResourceProfile = "c1m1"
+			suite.ResourceProfile = "c1m1"
 		}
 
-		if p.Suites[i].Env == nil {
-			p.Suites[i].Env = map[string]string{}
+		if suite.Env == nil {
+			suite.Env = make(map[string]string)
 		}
+		if suite.Metadata == nil {
+			suite.Metadata = make(map[string]string)
+		}
+
+		suite.Metadata["name"] = suite.Name
+		suite.Metadata["resourceProfile"] = suite.ResourceProfile
+
 		for k, v := range p.Defaults.Env {
-			p.Suites[i].Env[k] = v
+			suite.Env[k] = v
 		}
 		for k, v := range p.Env {
-			p.Suites[i].Env[k] = v
+			suite.Env[k] = v
 		}
 	}
 }

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -161,9 +161,6 @@ func (r *ImgRunner) runSuites(suites chan imagerunner.Suite, results chan<- exec
 
 func (r *ImgRunner) runSuite(suite imagerunner.Suite) (imagerunner.Runner, error) {
 	var run imagerunner.Runner
-	metadata := make(map[string]string)
-	metadata["name"] = suite.Name
-	metadata["resourceProfile"] = suite.ResourceProfile
 
 	files, err := mapFiles(suite.Files)
 	if err != nil {
@@ -197,7 +194,7 @@ func (r *ImgRunner) runSuite(suite imagerunner.Suite) (imagerunner.Runner, error
 		Env:          mapEnv(suite.Env),
 		Files:        files,
 		Artifacts:    suite.Artifacts,
-		Metadata:     metadata,
+		Metadata:     suite.Metadata,
 		WorkloadType: suite.Workload,
 		Tunnel:       r.getTunnel(),
 	})


### PR DESCRIPTION
## Proposed changes

Allow additional runner metadata to be set by the user. Mainly for troubleshooting reasons to activate/deactivate certain features if or when requested by Sauce Labs.

I consolidated some parts of the code so it's a bit less spread with regards to where values are defaulted.