### PR TITLE
Include directories in zip files

### DIFF
--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -51,8 +51,8 @@ func (w *Writer) Add(src, dst string) (count int, length int, err error) {
 		return 0, 0, nil
 	}
 
+	log.Debug().Str("name", src).Msg("Adding to archive")
 	if !finfo.IsDir() {
-		log.Debug().Str("name", src).Msg("Adding to archive")
 		target := path.Join(dst, finfo.Name())
 		w, err := w.W.Create(target)
 		if err != nil {
@@ -80,8 +80,8 @@ func (w *Writer) Add(src, dst string) (count int, length int, err error) {
 	}
 
 	base := filepath.Base(src)
-	relBase := filepath.Join(dst, base)
-	_, err = w.W.Create(fmt.Sprintf("%s/", relBase))
+	// Add the directory to the archive. The trailing slash denotes a directory entry.
+	_, err = w.W.Create(fmt.Sprintf("%s/", filepath.Join(dst, base)))
 	if err != nil {
 		return 0, 0, err
 	}

--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -85,6 +85,8 @@ func (w *Writer) Add(src, dst string) (count int, length int, err error) {
 	if err != nil {
 		return 0, 0, err
 	}
+	count++
+
 	for _, f := range files {
 		rebase := path.Join(dst, base)
 		fpath := filepath.Join(src, f.Name())

--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -79,8 +79,13 @@ func (w *Writer) Add(src, dst string) (count int, length int, err error) {
 		return 0, 0, err
 	}
 
+	base := filepath.Base(src)
+	relBase := filepath.Join(dst, base)
+	_, err = w.W.Create(fmt.Sprintf("%s/", relBase))
+	if err != nil {
+		return 0, 0, err
+	}
 	for _, f := range files {
-		base := filepath.Base(src)
 		rebase := path.Join(dst, base)
 		fpath := filepath.Join(src, f.Name())
 		fileCount, pathLength, err := w.Add(fpath, rebase)

--- a/internal/archive/zip/zip_test.go
+++ b/internal/archive/zip/zip_test.go
@@ -60,9 +60,9 @@ func TestZipper_Add(t *testing.T) {
 			wantFiles: []string{
 				dirBase,
 				filepath.Join(dirBase, "screenshots"),
-				"/screenshot1.png",
-				"/some.foo.js",
-				"/some.other.bar.js",
+				filepath.Join(dirBase, "screenshots", "/screenshot1.png"),
+				filepath.Join(dirBase, "/some.foo.js"),
+				filepath.Join(dirBase, "/some.other.bar.js"),
 			},
 			wantCount:  5,
 			wantLength: len(dirBase) + len("/screenshots/screenshot1.png"),
@@ -81,7 +81,7 @@ func TestZipper_Add(t *testing.T) {
 			wantErr: false,
 			wantFiles: []string{
 				dirBase,
-				"/some.other.bar.js",
+				filepath.Join(dirBase, "/some.other.bar.js"),
 			},
 			wantCount:  2,
 			wantLength: len(dirBase) + len("/some.other.bar.js"),

--- a/internal/archive/zip/zip_test.go
+++ b/internal/archive/zip/zip_test.go
@@ -53,12 +53,18 @@ func TestZipper_Add(t *testing.T) {
 		wantLength int
 	}{
 		{
-			name:       "zip it up",
-			fields:     fields{W: zip.NewWriter(out), M: sauceignore.NewMatcher([]sauceignore.Pattern{}), ZipFile: out},
-			args:       args{dir.Path(), "", out.Name()},
-			wantErr:    false,
-			wantFiles:  []string{"/screenshot1.png", "/some.foo.js", "/some.other.bar.js"},
-			wantCount:  3,
+			name:    "zip it up",
+			fields:  fields{W: zip.NewWriter(out), M: sauceignore.NewMatcher([]sauceignore.Pattern{}), ZipFile: out},
+			args:    args{dir.Path(), "", out.Name()},
+			wantErr: false,
+			wantFiles: []string{
+				dirBase,
+				filepath.Join(dirBase, "screenshots"),
+				"/screenshot1.png",
+				"/some.foo.js",
+				"/some.other.bar.js",
+			},
+			wantCount:  5,
 			wantLength: len(dirBase) + len("/screenshots/screenshot1.png"),
 		},
 		{
@@ -71,10 +77,13 @@ func TestZipper_Add(t *testing.T) {
 				}),
 				ZipFile: sauceignoreOut,
 			},
-			args:       args{dir.Path(), "", sauceignoreOut.Name()},
-			wantErr:    false,
-			wantFiles:  []string{"/some.other.bar.js"},
-			wantCount:  1,
+			args:    args{dir.Path(), "", sauceignoreOut.Name()},
+			wantErr: false,
+			wantFiles: []string{
+				dirBase,
+				"/some.other.bar.js",
+			},
+			wantCount:  2,
 			wantLength: len(dirBase) + len("/some.other.bar.js"),
 		},
 	}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

When zip archiving a directory, explicitly include the root directory and all sub-directories in the archive.

For most situations, this will have zero effect since during unarchiving all implicit sub-directories will be created, but this change makes the behaviour more inline with other zip utilties, including `zip` and `Archive Utility.app` on Mac.

Where it will make a difference is when executing on Sauce: the unarchiving helper functions have a "convenience" feature where it will return the path to the root dir of the archive's contents, if and only if, the first entry of the zip file directory is the prefix for all included files.

So given this directory structure:
```
root/
├── 1.txt
└── sub/
    └── 2.txt
```

The current zip implementation will have the contents:
```
root/1.txt
root/sub/2.txt
```

So, since `root/1.txt` is not a prefix for `root/sub/2.txt`, the unarchiver in sauce won't return `root`.

With this change, the contents look like:
```
root/
root/1.txt
root/sub/
root/sub/2.txt
```

And here, the helper function in Sauce will return `root` since `root/` *is* a prefix for every entry in the archive.


## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->