### PR TITLE
fix: Fix Windows zip file

### DIFF
--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -40,6 +40,10 @@ func New(f io.Writer, matcher sauceignore.Matcher) (Writer, error) {
 
 // Add adds the file at src to the destination dst in the archive and returns a count of
 // the files added to the archive, as well the length of the longest path.
+// The added file names should not contain any backslashes according to the specification outlined in
+// https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT.
+// It's essential to adhere to this specification to ensure compatibility and
+// proper functioning of the files across different systems and platforms.
 func (w *Writer) Add(src, dst string) (count int, length int, err error) {
 	finfo, err := os.Stat(src)
 	if err != nil {
@@ -57,7 +61,7 @@ func (w *Writer) Add(src, dst string) (count int, length int, err error) {
 		// The trailing slash denotes a directory entry.
 		target = fmt.Sprintf("%s/", target)
 	}
-	fileWriter, err := w.W.Create(target)
+	fileWriter, err := w.W.Create(filepath.ToSlash(target))
 	if err != nil {
 		return 0, 0, err
 	}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

When triggering tests on a Mac platform from a Windows machine, there is an issue with unzipping packages that have an `@` prefix in the node_modules zip.

Passed job: https://app.saucelabs.com/tests/979a262f57724f80b45de70392039333

After:
<img width="349" alt="Screenshot 2023-08-04 at 3 51 08 PM" src="https://github.com/saucelabs/saucectl/assets/71669683/82d09998-a7b2-4da9-aa07-b881fa218f53">  

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--


Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->