### PR TITLE
feat: Add additional testOptions for xcuitest

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -2176,6 +2176,30 @@
                     "notClass": {
                       "description": "Run all classes except those specified here.",
                       "type": "array"
+                    },
+                    "testLanguage": {
+                      "description": "Specifies ISO 639-1 language during testing.",
+                      "type": "string"
+                    },
+                    "testRegion": {
+                      "description": "Specifies ISO 3166-1 region during testing.",
+                      "type": "string"
+                    },
+                    "testTimeoutsEnabled": {
+                      "description": "By default there is no timeout, if enabled, then the timeout is 600 seconds. This can be changed by adding the defaultTestExecutionTimeAllowance value.",
+                      "type": "string",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    },
+                    "maximumTestExecutionTimeAllowance": {
+                      "description": "The maximum execution time an individual test is given to execute, regardless of the test's preferred allowance.",
+                      "type": "number"
+                    },
+                    "defaultTestExecutionTimeAllowance": {
+                      "description": "The default execution time an individual test is given to execute if test timeouts are enabled.",
+                      "type": "number"
                     }
                   },
                   "additionalProperties": false

--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -2194,11 +2194,11 @@
                       ]
                     },
                     "maximumTestExecutionTimeAllowance": {
-                      "description": "The maximum execution time an individual test is given to execute, regardless of the test's preferred allowance. Supported on Simulators only.",
+                      "description": "The maximum execution time, in seconds, an individual test is given to execute, regardless of the test's preferred allowance. Supported on Simulators only.",
                       "type": "number"
                     },
                     "defaultTestExecutionTimeAllowance": {
-                      "description": "The default execution time an individual test is given to execute if test timeouts are enabled. Supported on Simulators only.",
+                      "description": "The default execution time, in seconds, an individual test is given to execute if test timeouts are enabled. Supported on Simulators only.",
                       "type": "number"
                     }
                   },

--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -2178,7 +2178,7 @@
                       "type": "array"
                     },
                     "testLanguage": {
-                      "description": "Specifies ISO 639-1 language during testing.",
+                      "description": "Specifies ISO 639-1 language during testing. Supported on Simulators only.",
                       "type": "string"
                     },
                     "testRegion": {
@@ -2186,7 +2186,7 @@
                       "type": "string"
                     },
                     "testTimeoutsEnabled": {
-                      "description": "By default there is no timeout, if enabled, then the timeout is 600 seconds. This can be changed by adding the defaultTestExecutionTimeAllowance value.",
+                      "description": "By default there is no timeout, if enabled, then the timeout is 600 seconds. This can be changed by adding the defaultTestExecutionTimeAllowance value. Supported on Simulators only.",
                       "type": "string",
                       "enum": [
                         "Yes",
@@ -2194,11 +2194,11 @@
                       ]
                     },
                     "maximumTestExecutionTimeAllowance": {
-                      "description": "The maximum execution time an individual test is given to execute, regardless of the test's preferred allowance.",
+                      "description": "The maximum execution time an individual test is given to execute, regardless of the test's preferred allowance. Supported on Simulators only.",
                       "type": "number"
                     },
                     "defaultTestExecutionTimeAllowance": {
-                      "description": "The default execution time an individual test is given to execute if test timeouts are enabled.",
+                      "description": "The default execution time an individual test is given to execute if test timeouts are enabled. Supported on Simulators only.",
                       "type": "number"
                     }
                   },

--- a/api/v1alpha/framework/xcuitest.schema.json
+++ b/api/v1alpha/framework/xcuitest.schema.json
@@ -118,11 +118,11 @@
                 "enum": ["Yes", "No"]
               },
               "maximumTestExecutionTimeAllowance": {
-                "description": "The maximum execution time an individual test is given to execute, regardless of the test's preferred allowance. Supported on Simulators only.",
+                "description": "The maximum execution time, in seconds, an individual test is given to execute, regardless of the test's preferred allowance. Supported on Simulators only.",
                 "type": "number"
               },
               "defaultTestExecutionTimeAllowance": {
-                "description": "The default execution time an individual test is given to execute if test timeouts are enabled. Supported on Simulators only.",
+                "description": "The default execution time, in seconds, an individual test is given to execute if test timeouts are enabled. Supported on Simulators only.",
                 "type": "number"
               }
             },

--- a/api/v1alpha/framework/xcuitest.schema.json
+++ b/api/v1alpha/framework/xcuitest.schema.json
@@ -103,6 +103,27 @@
               "notClass": {
                 "description": "Run all classes except those specified here.",
                 "type": "array"
+              },
+              "testLanguage": {
+                "description": "Specifies ISO 639-1 language during testing.",
+                "type": "string"
+              },
+              "testRegion": {
+                "description": "Specifies ISO 3166-1 region during testing.",
+                "type": "string"
+              },
+              "testTimeoutsEnabled": {
+                "description": "By default there is no timeout, if enabled, then the timeout is 600 seconds. This can be changed by adding the defaultTestExecutionTimeAllowance value.",
+                "type": "string",
+                "enum": ["Yes", "No"]
+              },
+              "maximumTestExecutionTimeAllowance": {
+                "description": "The maximum execution time an individual test is given to execute, regardless of the test's preferred allowance.",
+                "type": "number"
+              },
+              "defaultTestExecutionTimeAllowance": {
+                "description": "The default execution time an individual test is given to execute if test timeouts are enabled.",
+                "type": "number"
               }
             },
             "additionalProperties": false

--- a/api/v1alpha/framework/xcuitest.schema.json
+++ b/api/v1alpha/framework/xcuitest.schema.json
@@ -105,7 +105,7 @@
                 "type": "array"
               },
               "testLanguage": {
-                "description": "Specifies ISO 639-1 language during testing.",
+                "description": "Specifies ISO 639-1 language during testing. Supported on Simulators only.",
                 "type": "string"
               },
               "testRegion": {
@@ -113,16 +113,16 @@
                 "type": "string"
               },
               "testTimeoutsEnabled": {
-                "description": "By default there is no timeout, if enabled, then the timeout is 600 seconds. This can be changed by adding the defaultTestExecutionTimeAllowance value.",
+                "description": "By default there is no timeout, if enabled, then the timeout is 600 seconds. This can be changed by adding the defaultTestExecutionTimeAllowance value. Supported on Simulators only.",
                 "type": "string",
                 "enum": ["Yes", "No"]
               },
               "maximumTestExecutionTimeAllowance": {
-                "description": "The maximum execution time an individual test is given to execute, regardless of the test's preferred allowance.",
+                "description": "The maximum execution time an individual test is given to execute, regardless of the test's preferred allowance. Supported on Simulators only.",
                 "type": "number"
               },
               "defaultTestExecutionTimeAllowance": {
-                "description": "The default execution time an individual test is given to execute if test timeouts are enabled.",
+                "description": "The default execution time an individual test is given to execute if test timeouts are enabled. Supported on Simulators only.",
                 "type": "number"
               }
             },

--- a/internal/saucecloud/xcuitest.go
+++ b/internal/saucecloud/xcuitest.go
@@ -220,10 +220,7 @@ func (r *XcuitestRunner) startJob(jobOpts chan<- job.StartOptions, appFileID, te
 		SmartRetry: job.SmartRetry{
 			FailedOnly: s.SmartRetry.IsRetryFailedOnly(),
 		},
-		TestOptions: map[string]interface{}{
-			"class":    s.TestOptions.Class,
-			"notClass": s.TestOptions.NotClass,
-		},
+		TestOptions: s.TestOptions.ToMap(),
 
 		// RDC Specific flags
 		RealDevice:        d.isRealDevice,

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -65,7 +65,7 @@ type TestOptions struct {
 	DefaultTestExecutionTimeAllowance int      `yaml:"defaultTestExecutionTimeAllowance,omitempty" json:"defaultTestExecutionTimeAllowance"`
 }
 
-// ToMap converts the TestOptions to a map where the keys are dervied from json struct tags.
+// ToMap converts the TestOptions to a map where the keys are derived from json struct tags.
 func (t TestOptions) ToMap() map[string]interface{} {
 	m := make(map[string]interface{})
 	v := reflect.ValueOf(t)

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -55,8 +56,32 @@ type Xcuitest struct {
 
 // TestOptions represents the xcuitest test filter options configuration.
 type TestOptions struct {
-	NotClass []string `yaml:"notClass,omitempty" json:"notClass"`
-	Class    []string `yaml:"class,omitempty" json:"class"`
+	NotClass                          []string `yaml:"notClass,omitempty" json:"notClass"`
+	Class                             []string `yaml:"class,omitempty" json:"class"`
+	TestLanguage                      string   `yaml:"testLanguage,omitempty" json:"testLanguage"`
+	TestRegion                        string   `yaml:"testRegion,omitempty" json:"testRegion"`
+	TestTimeoutsEnabled               string   `yaml:"testTimeoutsEnabled,omitempty" json:"testTimeoutsEnabled"`
+	MaximumTestExecutionTimeAllowance int      `yaml:"maximumTestExecutionTimeAllowance,omitempty" json:"maximumTestExecutionTimeAllowance"`
+	DefaultTestExecutionTimeAllowance int      `yaml:"defaultTestExecutionTimeAllowance,omitempty" json:"defaultTestExecutionTimeAllowance"`
+}
+
+// ToMap converts the TestOptions to a map where the keys are dervied from json struct tag.
+func (t TestOptions) ToMap() map[string]interface{} {
+	m := make(map[string]interface{})
+	v := reflect.ValueOf(t)
+	tt := v.Type()
+
+	count := v.NumField()
+	for i := 0; i < count; i++ {
+		if v.Field(i).CanInterface() {
+			tag := tt.Field(i).Tag
+			tname, ok := tag.Lookup("json")
+			if ok && tname != "-" {
+				m[tname] = v.Field(i).Interface()
+			}
+		}
+	}
+	return m
 }
 
 // Suite represents the xcuitest test suite configuration.

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -65,7 +65,7 @@ type TestOptions struct {
 	DefaultTestExecutionTimeAllowance int      `yaml:"defaultTestExecutionTimeAllowance,omitempty" json:"defaultTestExecutionTimeAllowance"`
 }
 
-// ToMap converts the TestOptions to a map where the keys are dervied from json struct tag.
+// ToMap converts the TestOptions to a map where the keys are dervied from json struct tags.
 func (t TestOptions) ToMap() map[string]interface{} {
 	m := make(map[string]interface{})
 	v := reflect.ValueOf(t)

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -80,8 +80,9 @@ func (t TestOptions) ToMap() map[string]interface{} {
 				fv := v.Field(i).Interface()
 				ft := v.Field(i).Type()
 				switch ft.Kind() {
+				// Convert int to string to match chef expectation that all test option values are strings
 				case reflect.Int:
-					// Conventionally, when TestOptions are converted to match chef expectations, properties with value "" will be ignored.
+					// Conventionally, when test options with value "" will be ignored.
 					if fv.(int) == 0 {
 						m[tname] = ""
 					} else {

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -77,7 +77,19 @@ func (t TestOptions) ToMap() map[string]interface{} {
 			tag := tt.Field(i).Tag
 			tname, ok := tag.Lookup("json")
 			if ok && tname != "-" {
-				m[tname] = v.Field(i).Interface()
+				fv := v.Field(i).Interface()
+				ft := v.Field(i).Type()
+				switch ft.Kind() {
+				case reflect.Int:
+					// Conventionally, when TestOptions are converted to match chef expectations, properties with value "" will be ignored.
+					if fv.(int) == 0 {
+						m[tname] = ""
+					} else {
+						m[tname] = fmt.Sprintf("%v", fv)
+					}
+				default:
+					m[tname] = fv
+				}
 			}
 		}
 	}

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -82,7 +82,7 @@ func (t TestOptions) ToMap() map[string]interface{} {
 				switch ft.Kind() {
 				// Convert int to string to match chef expectation that all test option values are strings
 				case reflect.Int:
-					// Conventionally, when test options with value "" will be ignored.
+					// Conventionally, test options with value "" will be ignored.
 					if fv.(int) == 0 {
 						m[tname] = ""
 					} else {

--- a/internal/xcuitest/config_test.go
+++ b/internal/xcuitest/config_test.go
@@ -17,11 +17,11 @@ import (
 
 func TestToMap(t *testing.T) {
 	opts := TestOptions{
-		Class: []string{},
-		NotClass: []string{},
-		TestLanguage: "",
-		TestRegion: "",
-		TestTimeoutsEnabled: "",
+		Class:                             []string{},
+		NotClass:                          []string{},
+		TestLanguage:                      "",
+		TestRegion:                        "",
+		TestTimeoutsEnabled:               "",
 		MaximumTestExecutionTimeAllowance: 0,
 		DefaultTestExecutionTimeAllowance: 0,
 	}

--- a/internal/xcuitest/config_test.go
+++ b/internal/xcuitest/config_test.go
@@ -39,8 +39,8 @@ func TestToMap(t *testing.T) {
 		t.Errorf("ints should be converted to strings when mapping, got (%v) want (%v)", vtype, reflect.String)
 	}
 
-	if m["defaultTestExecutionTimeAllowance"] != "" {
-		t.Errorf("0 values should be cast to empty strings, got (%v)", m["defaultTestExecutionTimeAllowance"])
+	if v := m["defaultTestExecutionTimeAllowance"]; v != "" {
+		t.Errorf("0 values should be cast to empty strings, got (%v)", v)
 	}
 }
 

--- a/internal/xcuitest/config_test.go
+++ b/internal/xcuitest/config_test.go
@@ -15,7 +15,7 @@ import (
 	"gotest.tools/v3/fs"
 )
 
-func TestToMap(t *testing.T) {
+func TestTestOptions_ToMap(t *testing.T) {
 	opts := TestOptions{
 		Class:                             []string{},
 		NotClass:                          []string{},

--- a/internal/xcuitest/config_test.go
+++ b/internal/xcuitest/config_test.go
@@ -22,7 +22,7 @@ func TestToMap(t *testing.T) {
 		TestLanguage:                      "",
 		TestRegion:                        "",
 		TestTimeoutsEnabled:               "",
-		MaximumTestExecutionTimeAllowance: 0,
+		MaximumTestExecutionTimeAllowance: 20,
 		DefaultTestExecutionTimeAllowance: 0,
 	}
 	wantLength := 7
@@ -31,6 +31,16 @@ func TestToMap(t *testing.T) {
 
 	if len(m) != wantLength {
 		t.Errorf("Length of converted TestOptions should match original, got (%v) want (%v)", len(m), wantLength)
+	}
+
+	v := reflect.ValueOf(m["maximumTestExecutionTimeAllowance"])
+	vtype := v.Type()
+	if vtype.Kind() != reflect.String {
+		t.Errorf("ints should be converted to strings when mapping, got (%v) want (%v)", vtype, reflect.String)
+	}
+
+	if m["defaultTestExecutionTimeAllowance"] != "" {
+		t.Errorf("0 values should be cast to empty strings, got (%v)", m["defaultTestExecutionTimeAllowance"])
 	}
 }
 

--- a/internal/xcuitest/config_test.go
+++ b/internal/xcuitest/config_test.go
@@ -15,6 +15,25 @@ import (
 	"gotest.tools/v3/fs"
 )
 
+func TestToMap(t *testing.T) {
+	opts := TestOptions{
+		Class: []string{},
+		NotClass: []string{},
+		TestLanguage: "",
+		TestRegion: "",
+		TestTimeoutsEnabled: "",
+		MaximumTestExecutionTimeAllowance: 0,
+		DefaultTestExecutionTimeAllowance: 0,
+	}
+	wantLength := 7
+
+	m := opts.ToMap()
+
+	if len(m) != wantLength {
+		t.Errorf("Length of converted TestOptions should match original, got (%v) want (%v)", len(m), wantLength)
+	}
+}
+
 func TestValidate(t *testing.T) {
 	dir := fs.NewDir(t, "xcuitest-config",
 		fs.WithFile("test.ipa", "", fs.WithMode(0655)),


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Add additional `testOptions` for xcuitest on simulators.



SauceCTL Test option input | xcodebuild command | Notes
-- | -- | --
testTimeoutsEnabled: "Yes\|No" | -test-timeouts-enabled [YES \| NO] | By default there is no timeout, if enabled, then the timeout is 600 seconds. This can be changed by adding the defaultTestExecutionTimeAllowance value. See also https://developer.apple.com/documentation/xctest/xctestcase/3526064-executiontimeallowance
defaultTestExecutionTimeAllowance: 200 //in seconds | -default-test-execution-time-allowance seconds | The default execution time an individual test is given to execute if test timeouts are enabled. See also https://developer.apple.com/documentation/xctest/xctestcase/3526064-executiontimeallowance
maximumTestExecutionTimeAllowance 300 // in seconds | -maximum-test-execution-time-allowance seconds | The maximum execution time an individual test is given to execute, regardless of the test's preferred allowance. See also https://developer.apple.com/documentation/xctest/xctestcase/3526064-executiontimeallowance
testLanguage language | -testLanguage language | Specifies ISO 639-1 language during testing. See https://www.loc.gov/standards/iso639-2/php/code_list.php
testRegion region | -testRegion region | Specifies ISO 3166-1 region during testing, see also https://www.iso.org/obp/ui/#search



## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
Because reasons, TestOptions needs to be converted to a `map[string]interface{}` type. I opted to use reflection to do it for easier maintainability, but I could be easily convinced to not use reflection...