### PR TITLE
fix: Set platformName for simulators

### DIFF
--- a/.sauce/xcuitest.yml
+++ b/.sauce/xcuitest.yml
@@ -39,7 +39,6 @@ suites:
         - MyDemoAppUITests/ProductListingPageTest
     simulators:
       - name: "iPhone 11 Simulator"
-        platformName: iOS
         platformVersions:
           - "16.2"
 

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -122,6 +122,9 @@ func SetDefaults(p *Project) {
 			// device type only supports uppercase values
 			suite.Devices[id].Options.DeviceType = strings.ToUpper(suite.Devices[id].Options.DeviceType)
 		}
+		for id := range suite.Simulators {
+			suite.Simulators[id].PlatformName = "iOS"
+		}
 
 		if suite.Timeout <= 0 {
 			p.Suites[ks].Timeout = p.Defaults.Timeout


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

`platformName` for xcuitest has only one possible value, `iOS`. Remove it from configs and set a default value to match espresso emulator behaviour.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
`platformName` is **not** currently defined in the json schema for the `simulators` array so no changes needed there.