### PR TITLE
fix: Missing default otherApps

### DIFF
--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -101,26 +101,28 @@ func SetDefaults(p *Project) {
 	p.Sauce.Tunnel.SetDefaults()
 	p.Sauce.Metadata.SetDefaultBuild()
 
-	for i, suite := range p.Suites {
+	for i := range p.Suites {
+		suite := &p.Suites[i]
+
 		for j := range suite.Devices {
 			// Android is the only choice.
-			p.Suites[i].Devices[j].PlatformName = Android
-			p.Suites[i].Devices[j].Options.DeviceType = strings.ToUpper(p.Suites[i].Devices[j].Options.DeviceType)
+			suite.Devices[j].PlatformName = Android
+			suite.Devices[j].Options.DeviceType = strings.ToUpper(p.Suites[i].Devices[j].Options.DeviceType)
 		}
 		for j := range suite.Emulators {
-			p.Suites[i].Emulators[j].PlatformName = Android
+			suite.Emulators[j].PlatformName = Android
 		}
 
 		if suite.Timeout <= 0 {
-			p.Suites[i].Timeout = p.Defaults.Timeout
+			suite.Timeout = p.Defaults.Timeout
 		}
 
 		if suite.TestApp == "" {
-			p.Suites[i].TestApp = p.Espresso.TestApp
-			p.Suites[i].TestAppDescription = p.Espresso.TestAppDescription
+			suite.TestApp = p.Espresso.TestApp
+			suite.TestAppDescription = p.Espresso.TestAppDescription
 		}
 		if suite.PassThreshold < 1 {
-			p.Suites[i].PassThreshold = 1
+			suite.PassThreshold = 1
 		}
 	}
 }

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -153,7 +153,9 @@ func SetDefaults(p *Project) {
 	p.Sauce.Tunnel.SetDefaults()
 	p.Sauce.Metadata.SetDefaultBuild()
 
-	for ks, suite := range p.Suites {
+	for i := range p.Suites {
+		suite := &p.Suites[i]
+
 		for id := range suite.Devices {
 			suite.Devices[id].PlatformName = "iOS"
 
@@ -165,22 +167,22 @@ func SetDefaults(p *Project) {
 		}
 
 		if suite.Timeout <= 0 {
-			p.Suites[ks].Timeout = p.Defaults.Timeout
+			suite.Timeout = p.Defaults.Timeout
 		}
 
 		if suite.TestApp == "" {
-			p.Suites[ks].TestApp = p.Xcuitest.TestApp
-			p.Suites[ks].TestAppDescription = p.Xcuitest.TestAppDescription
+			suite.TestApp = p.Xcuitest.TestApp
+			suite.TestAppDescription = p.Xcuitest.TestAppDescription
 		}
 		if suite.App == "" {
-			p.Suites[ks].App = p.Xcuitest.App
-			p.Suites[ks].AppDescription = p.Xcuitest.AppDescription
+			suite.App = p.Xcuitest.App
+			suite.AppDescription = p.Xcuitest.AppDescription
 		}
 		if len(suite.OtherApps) == 0 {
 			suite.OtherApps = append(suite.OtherApps, p.Xcuitest.OtherApps...)
 		}
 		if suite.PassThreshold < 1 {
-			p.Suites[ks].PassThreshold = 1
+			suite.PassThreshold = 1
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

Classic mistake that can easily happen in go. Values vs. pointers. `otherApps` wasn't set properly due the use of a copy-value reference, rather than the pointer. I changed the loops in both espresso and xcuitest and removed the copied value entirely, so that it's less likely to happen again.