### PR TITLE
chore: junit separation of concerns

### DIFF
--- a/internal/junit/junit.go
+++ b/internal/junit/junit.go
@@ -7,6 +7,12 @@ import (
 // FileName is the name of the JUnit report.
 const FileName = "junit.xml"
 
+// Property maps to a <property> element that's part of <properties>.
+type Property struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
 // TestCase maps to <testcase> element
 type TestCase struct {
 	Name string `xml:"name,attr"`
@@ -106,12 +112,6 @@ func (ts TestSuites) TestCases() []TestCase {
 	}
 
 	return tcs
-}
-
-// Property maps to a <property> element that's part of <properties>.
-type Property struct {
-	Name  string `xml:"name,attr"`
-	Value string `xml:"value,attr"`
 }
 
 // Parse a junit report from an XML encoded byte string. The root <testsuites>

--- a/internal/junit/junit.go
+++ b/internal/junit/junit.go
@@ -98,6 +98,16 @@ type TestSuites struct {
 	Errors   int `xml:"errors,attr,omitempty"`
 }
 
+// TestCases returns all test cases from all test suites.
+func (ts TestSuites) TestCases() []TestCase {
+	var tcs []TestCase
+	for _, ts := range ts.TestSuites {
+		tcs = append(tcs, ts.TestCases...)
+	}
+
+	return tcs
+}
+
 // Property maps to a <property> element that's part of <properties>.
 type Property struct {
 	Name  string `xml:"name,attr"`
@@ -124,13 +134,4 @@ func Parse(data []byte) (TestSuites, error) {
 	}
 
 	return tss, err
-}
-
-// CollectTestCases collects testcases from a report.
-func CollectTestCases(testsuites TestSuites) []TestCase {
-	var tc []TestCase
-	for _, s := range testsuites.TestSuites {
-		tc = append(tc, s.TestCases...)
-	}
-	return tc
 }

--- a/internal/junit/junit.go
+++ b/internal/junit/junit.go
@@ -2,7 +2,6 @@ package junit
 
 import (
 	"encoding/xml"
-	"fmt"
 )
 
 // FileName is the name of the JUnit report.
@@ -127,44 +126,6 @@ func Parse(data []byte) (TestSuites, error) {
 	return tss, err
 }
 
-// GetFailedXCUITests get failed XCUITest test list from testcases.
-func GetFailedXCUITests(testCases []TestCase) []string {
-	classes := map[string]bool{}
-	for _, tc := range testCases {
-		if tc.Error != nil || tc.Failure != nil {
-			// The format of the filtered test is "<className>/<testMethodName>".
-			// Fallback to <className> if the test method name is unexpectedly empty.
-			// tc.Name: <testMethodName>
-			// tc.ClassName: <className>
-			if tc.Name != "" {
-				classes[fmt.Sprintf("%s/%s", tc.ClassName, tc.Name)] = true
-			} else {
-				classes[tc.ClassName] = true
-			}
-		}
-	}
-	return getKeysFromMap(classes)
-}
-
-// GetFailedEspressoTests get failed espresso test list from testcases.
-func GetFailedEspressoTests(testCases []TestCase) []string {
-	classes := map[string]bool{}
-	for _, tc := range testCases {
-		if tc.Error != nil || tc.Failure != nil {
-			// The format of the filtered test is "<className>#<testMethodName>".
-			// Fallback to <className> if the test method name is unexpectedly empty.
-			// tc.Name: <testMethodName>
-			// tc.ClassName: <className>
-			if tc.Name != "" {
-				classes[fmt.Sprintf("%s#%s", tc.ClassName, tc.Name)] = true
-			} else {
-				classes[tc.ClassName] = true
-			}
-		}
-	}
-	return getKeysFromMap(classes)
-}
-
 // CollectTestCases collects testcases from a report.
 func CollectTestCases(testsuites TestSuites) []TestCase {
 	var tc []TestCase
@@ -172,14 +133,4 @@ func CollectTestCases(testsuites TestSuites) []TestCase {
 		tc = append(tc, s.TestCases...)
 	}
 	return tc
-}
-
-func getKeysFromMap(mp map[string]bool) []string {
-	var keys = make([]string, len(mp))
-	var i int
-	for k := range mp {
-		keys[i] = k
-		i++
-	}
-	return keys
 }

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -33,7 +33,7 @@ func (b *JunitRetrier) retryFailedTests(reader job.Reader, jobOpts chan<- job.St
 		return
 	}
 
-	setClassesToRetry(&opt, junit.CollectTestCases(suites))
+	setClassesToRetry(&opt, suites.TestCases())
 	jobOpts <- opt
 }
 

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -77,15 +77,13 @@ func (b *JunitRetrier) Retry(jobOpts chan<- job.StartOptions, opt job.StartOptio
 	jobOpts <- opt
 }
 
-// getFailedXCUITests get failed XCUITest test list from testcases.
+// getFailedXCUITests returns a list of failed XCUITest tests from the given
+// test cases. The format is "<className>/<testMethodName>", with the test
+// method name being optional.
 func getFailedXCUITests(testCases []junit.TestCase) []string {
 	classes := map[string]bool{}
 	for _, tc := range testCases {
 		if tc.Error != nil || tc.Failure != nil {
-			// The format of the filtered test is "<className>/<testMethodName>".
-			// Fallback to <className> if the test method name is unexpectedly empty.
-			// tc.Name: <testMethodName>
-			// tc.ClassName: <className>
 			if tc.Name != "" {
 				classes[fmt.Sprintf("%s/%s", tc.ClassName, tc.Name)] = true
 			} else {
@@ -96,15 +94,13 @@ func getFailedXCUITests(testCases []junit.TestCase) []string {
 	return maps.Keys(classes)
 }
 
-// getFailedEspressoTests get failed espresso test list from testcases.
+// getFailedEspressoTests returns a list of failed Espresso tests from the given
+// test cases. The format is "<className>#<testMethodName>", with the test
+// method name being optional.
 func getFailedEspressoTests(testCases []junit.TestCase) []string {
 	classes := map[string]bool{}
 	for _, tc := range testCases {
 		if tc.Error != nil || tc.Failure != nil {
-			// The format of the filtered test is "<className>#<testMethodName>".
-			// Fallback to <className> if the test method name is unexpectedly empty.
-			// tc.Name: <testMethodName>
-			// tc.ClassName: <className>
 			if tc.Name != "" {
 				classes[fmt.Sprintf("%s#%s", tc.ClassName, tc.Name)] = true
 			} else {

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -9,6 +9,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/junit"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/xcuitest"
+	"golang.org/x/exp/maps"
 )
 
 type JunitRetrier struct {
@@ -92,7 +93,7 @@ func getFailedXCUITests(testCases []junit.TestCase) []string {
 			}
 		}
 	}
-	return getKeysFromMap(classes)
+	return maps.Keys(classes)
 }
 
 // getFailedEspressoTests get failed espresso test list from testcases.
@@ -111,15 +112,5 @@ func getFailedEspressoTests(testCases []junit.TestCase) []string {
 			}
 		}
 	}
-	return getKeysFromMap(classes)
-}
-
-func getKeysFromMap(mp map[string]bool) []string {
-	var keys = make([]string, len(mp))
-	var i int
-	for k := range mp {
-		keys[i] = k
-		i++
-	}
-	return keys
+	return maps.Keys(classes)
 }


### PR DESCRIPTION
## Proposed changes

A separation of concerns refactor with no functional changes.

Main changes are:
- [08d158fef88ff4764917508354045db0d9ef1552](https://github.com/saucelabs/saucectl/commit/08d158fef88ff4764917508354045db0d9ef1552): These framework specific details are not relevant to the junit domain. The retrier specifically or `saucecloud` package on a broader level, are the ones that need to deal with this. It's where framework or cloud implementation specific details are handled. This move reduces the implicit coupling between the two. Now it's one-sided: `saucecloud` -> `junit`.
- https://github.com/saucelabs/saucectl/commit/d3cf20d3681ac0a9ab9cb968a5e4fa1d3626660e: This function felt more native as a method.  `CollectTestCases` is something that could be done on multiple levels (TestSuites, []TestSuites, []TestSuite) and if you needed that, you'd have to start adding suffixes, which just pollutes the `junit` namespace more. The method conversion keeps it tidier and closer to its operational source. This is one of those rarer cases where a method, I think, is more appropriate than a function.