### PR TITLE
chore: Refactor attempt tracking

### DIFF
--- a/internal/apitest/runner.go
+++ b/internal/apitest/runner.go
@@ -574,15 +574,25 @@ func (r *Runner) collectResults(expected int, results chan TestResult) bool {
 			passed = false
 		}
 
+		duration := time.Duration(testResult.ExecutionTimeSeconds) * time.Second
+		startTime := time.Now().Add(-duration)
+		endTime := time.Now()
+
 		for _, rep := range r.Reporters {
 			rep.Add(report.TestResult{
 				Name:      testName,
 				URL:       reportURL,
 				Status:    status,
-				Duration:  time.Second * time.Duration(testResult.ExecutionTimeSeconds),
-				StartTime: (time.Now()).Add(-time.Second * time.Duration(testResult.ExecutionTimeSeconds)),
-				Attempts:  1,
-				TimedOut:  testResult.TimedOut,
+				Duration:  duration,
+				StartTime: startTime,
+				EndTime:   endTime,
+				Attempts: []report.Attempt{{
+					Duration:  duration,
+					StartTime: startTime,
+					EndTime:   endTime,
+					Status:    status,
+				}},
+				TimedOut: testResult.TimedOut,
 			})
 		}
 	}

--- a/internal/job/starter.go
+++ b/internal/job/starter.go
@@ -3,6 +3,8 @@ package job
 import (
 	"context"
 	"time"
+
+	"github.com/saucelabs/saucectl/internal/report"
 )
 
 // StartOptions represents the options for starting a job in the Sauce Labs cloud.
@@ -10,8 +12,8 @@ type StartOptions struct {
 	// DisplayName is used for local logging purposes only (e.g. console).
 	DisplayName string `json:"-"`
 
-	// PreviousJobIDs contains the previous jobs IDs in the context of retries.
-	PreviousJobIDs []string `json:"-"`
+	// PrevAttempts contains any previous attempts of the job.
+	PrevAttempts []report.Attempt `json:"-"`
 
 	// Timeout is used for local/per-suite timeout.
 	Timeout time.Duration `json:"-"`

--- a/internal/report/junit/junit_test.go
+++ b/internal/report/junit/junit_test.go
@@ -474,7 +474,7 @@ func TestReduceJunitFiles(t *testing.T) {
 		},
 	}
 
-	got := reduceJunitFiles(input)
+	got := reduceTestSuites(input)
 	if !cmp.Equal(want, got) {
 		t.Error(cmp.Diff(want, got))
 	}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,6 +1,19 @@
 package report
 
-import "time"
+import (
+	"time"
+
+	"github.com/saucelabs/saucectl/internal/junit"
+)
+
+type Attempt struct {
+	ID         string           `json:"id"`
+	Duration   time.Duration    `json:"duration"`
+	StartTime  time.Time        `json:"startTime"`
+	EndTime    time.Time        `json:"endTime"`
+	Status     string           `json:"status"`
+	TestSuites junit.TestSuites `json:"-"`
+}
 
 // TestResult represents the test result.
 type TestResult struct {
@@ -15,11 +28,10 @@ type TestResult struct {
 	URL           string        `json:"url"`
 	Artifacts     []Artifact    `json:"artifacts,omitempty"`
 	Origin        string        `json:"origin"`
-	Attempts      int           `json:"attempts"`
 	RDC           bool          `json:"-"`
 	TimedOut      bool          `json:"-"`
 	PassThreshold bool          `json:"-"`
-	ParentJUnits  []Artifact    `json:"-"`
+	Attempts      []Attempt     `json:"-"`
 }
 
 // ArtifactType represents the type of assets (e.g. a junit report). Semantically similar to Content-Type.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -6,12 +6,19 @@ import (
 	"github.com/saucelabs/saucectl/internal/junit"
 )
 
+// Attempt represents a single attempt of a job.
 type Attempt struct {
-	ID         string           `json:"id"`
-	Duration   time.Duration    `json:"duration"`
-	StartTime  time.Time        `json:"startTime"`
-	EndTime    time.Time        `json:"endTime"`
-	Status     string           `json:"status"`
+	// ID is the unique identifier of the attempt. This is usually the job ID.
+	// Can also be the runner ID (imagerunner) or whatever is used to identify
+	// the attempt in the context of the job.
+	ID        string        `json:"id"`
+	Duration  time.Duration `json:"duration"`
+	StartTime time.Time     `json:"startTime"`
+	EndTime   time.Time     `json:"endTime"`
+	Status    string        `json:"status"`
+
+	// TestSuites contains the junit test suites that were generated as part of
+	// the attempt.
 	TestSuites junit.TestSuites `json:"-"`
 }
 

--- a/internal/report/table/table.go
+++ b/internal/report/table/table.go
@@ -116,7 +116,7 @@ func (r *Reporter) Render() {
 
 		// the order of values must match the order of the header
 		t.AppendRow(table.Row{statusSymbol(ts.Status), ts.Name, ts.Duration.Truncate(1 * time.Second),
-			statusText(ts.Status), ts.Browser, ts.Platform, ts.DeviceName, ts.Attempts})
+			statusText(ts.Status), ts.Browser, ts.Platform, ts.DeviceName, len(ts.Attempts)})
 	}
 
 	t.AppendFooter(footer(errors, inProgress, len(r.TestResults), calDuration(r.TestResults)))

--- a/internal/report/table/table_test.go
+++ b/internal/report/table/table_test.go
@@ -32,8 +32,12 @@ func TestReporter_Render(t *testing.T) {
 						Status:        job.StatePassed,
 						Browser:       "Firefox",
 						Platform:      "Windows 10",
-						Attempts:      3,
 						PassThreshold: true,
+						Attempts: []report.Attempt{
+							{Status: job.StateFailed},
+							{Status: job.StateFailed},
+							{Status: job.StatePassed},
+						},
 					},
 					{
 						Name:          "Chrome",
@@ -43,8 +47,10 @@ func TestReporter_Render(t *testing.T) {
 						Status:        job.StatePassed,
 						Browser:       "Chrome",
 						Platform:      "Windows 10",
-						Attempts:      1,
 						PassThreshold: true,
+						Attempts: []report.Attempt{
+							{Status: job.StatePassed},
+						},
 					},
 				},
 			},
@@ -69,7 +75,9 @@ func TestReporter_Render(t *testing.T) {
 						Status:    job.StatePassed,
 						Browser:   "Firefox",
 						Platform:  "Windows 10",
-						Attempts:  1,
+						Attempts: []report.Attempt{
+							{Status: job.StatePassed},
+						},
 					},
 					{
 						Name:      "Chrome",
@@ -79,7 +87,11 @@ func TestReporter_Render(t *testing.T) {
 						Status:    job.StateFailed,
 						Browser:   "Chrome",
 						Platform:  "Windows 10",
-						Attempts:  3,
+						Attempts: []report.Attempt{
+							{Status: job.StateFailed},
+							{Status: job.StateFailed},
+							{Status: job.StateFailed},
+						},
 					},
 				},
 			},

--- a/internal/saucecloud/cloud_test.go
+++ b/internal/saucecloud/cloud_test.go
@@ -235,7 +235,7 @@ func TestRunJobRetries(t *testing.T) {
 		res := <-results
 		close(opts)
 		close(results)
-		assert.Equal(t, res.attempts, tt.wantAttempts)
+		assert.Equal(t, len(res.attempts), tt.wantAttempts)
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

Rather than tracking attempts numerically (i.e. some counter), give the attempt a proper entity with which it can track its metadata, rather than sprinkling the metadata loosely across multiple fields (see previous "attempts" and "ParentJunits" field).