### PR TITLE
feat: Add spotlight reporter

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -292,6 +292,16 @@
                         "default": "saucectl-test-result.xml"
                       }
                     }
+                  },
+                  "spotlight": {
+                    "type": "object",
+                    "description": "The spotlight reporter prints a an overview of failed, or otherwise interesting, jobs.",
+                    "properties": {
+                      "enabled": {
+                        "description": "Toggles the reporter on/off.",
+                        "type": "boolean"
+                      }
+                    }
                   }
                 },
                 "additionalProperties": false

--- a/api/v1alpha/subschema/reporters.schema.json
+++ b/api/v1alpha/subschema/reporters.schema.json
@@ -40,6 +40,16 @@
               "default": "saucectl-test-result.xml"
             }
           }
+        },
+        "spotlight": {
+          "type": "object",
+          "description": "The spotlight reporter prints a an overview of failed, or otherwise interesting, jobs.",
+          "properties": {
+            "enabled": {
+              "description": "Toggles the reporter on/off.",
+              "type": "boolean"
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/internal/cmd/run/cucumber.go
+++ b/internal/cmd/run/cucumber.go
@@ -116,7 +116,7 @@ func runCucumber(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 		props.SetFramework("playwright-cucumberjs").SetFVersion(p.Playwright.Version).SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).
 			SetArtifacts(p.Artifacts).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults).
 			SetSlack(p.Notifications.Slack).SetSharding(cucumber.IsSharded(p.Suites)).SetLaunchOrder(p.Sauce.LaunchOrder).
-			SetSmartRetry(p.IsSmartRetried())
+			SetSmartRetry(p.IsSmartRetried()).SetReporters(p.Reporters)
 		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -134,7 +134,7 @@ func runCypress(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 		props.SetFramework("cypress").SetFVersion(p.GetVersion()).SetFlags(cmd.Flags()).SetSauceConfig(p.GetSauceCfg()).
 			SetArtifacts(p.GetArtifactsCfg()).SetNPM(p.GetNpm()).SetNumSuites(len(p.GetSuites())).SetJobs(captor.Default.TestResults).
 			SetSlack(p.GetNotifications().Slack).SetSharding(p.IsSharded()).SetLaunchOrder(p.GetSauceCfg().LaunchOrder).
-			SetSmartRetry(p.IsSmartRetried())
+			SetSmartRetry(p.IsSmartRetried()).SetReporters(p.GetReporters())
 
 		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
@@ -163,7 +163,7 @@ func runCypress(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 			BuildService:    &restoClient,
 			Region:          regio,
 			ShowConsoleLog:  p.IsShowConsoleLog(),
-			Reporters: createReporters(p.GetReporter(), p.GetNotifications(), p.GetSauceCfg().Metadata, &testcompClient, &restoClient,
+			Reporters: createReporters(p.GetReporters(), p.GetNotifications(), p.GetSauceCfg().Metadata, &testcompClient, &restoClient,
 				"cypress", "sauce", gFlags.async),
 			Async:                  gFlags.async,
 			FailFast:               gFlags.failFast,

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -133,7 +133,7 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, isCLIDriven bo
 		props.SetFramework("espresso").SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
 			SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults).SetSlack(p.Notifications.Slack).
 			SetSharding(espresso.IsSharded(p.Suites)).SetLaunchOrder(p.Sauce.LaunchOrder).
-			SetSmartRetry(p.IsSmartRetried())
+			SetSmartRetry(p.IsSmartRetried()).SetReporters(p.Reporters)
 		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -150,7 +150,7 @@ func runPlaywright(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 		props.SetFramework("playwright").SetFVersion(p.Playwright.Version).SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).
 			SetArtifacts(p.Artifacts).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults).
 			SetSlack(p.Notifications.Slack).SetSharding(playwright.IsSharded(p.Suites)).SetLaunchOrder(p.Sauce.LaunchOrder).
-			SetSmartRetry(p.IsSmartRetried())
+			SetSmartRetry(p.IsSmartRetried()).SetReporters(p.Reporters)
 		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -172,7 +172,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 		props.SetFramework("testcafe").SetFVersion(p.Testcafe.Version).SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).
 			SetArtifacts(p.Artifacts).SetNPM(p.Npm).SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults).
 			SetSlack(p.Notifications.Slack).SetSharding(testcafe.IsSharded(p.Suites)).SetLaunchOrder(p.Sauce.LaunchOrder).
-			SetSmartRetry(p.IsSmartRetried())
+			SetSmartRetry(p.IsSmartRetried()).SetReporters(p.Reporters)
 		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -133,7 +133,7 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, isCLIDriven bool) 
 		props.SetFramework("xcuitest").SetFlags(cmd.Flags()).SetSauceConfig(p.Sauce).SetArtifacts(p.Artifacts).
 			SetNumSuites(len(p.Suites)).SetJobs(captor.Default.TestResults).SetSlack(p.Notifications.Slack).
 			SetSharding(xcuitest.IsSharded(p.Suites)).SetLaunchOrder(p.Sauce.LaunchOrder).
-			SetSmartRetry(p.IsSmartRetried())
+			SetSmartRetry(p.IsSmartRetried()).SetReporters(p.Reporters)
 		tracker.Collect(cases.Title(language.English).String(cmds.FullName(cmd)), props)
 		_ = tracker.Close()
 	}()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,6 +147,10 @@ type Artifacts struct {
 
 // Reporters represents the reporter configuration.
 type Reporters struct {
+	Spotlight struct {
+		Enabled bool `yaml:"enabled"`
+	}
+
 	JUnit struct {
 		Enabled  bool   `yaml:"enabled"`
 		Filename string `yaml:"filename"`

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -36,7 +36,7 @@ type Project interface {
 	GetArtifactsCfg() config.Artifacts
 	IsShowConsoleLog() bool
 	GetBeforeExec() []string
-	GetReporter() config.Reporters
+	GetReporters() config.Reporters
 	GetNotifications() config.Notifications
 	GetNpm() config.Npm
 	SetCLIFlags(map[string]interface{})

--- a/internal/cypress/v1/config.go
+++ b/internal/cypress/v1/config.go
@@ -423,7 +423,7 @@ func (p *Project) GetBeforeExec() []string {
 }
 
 // GetReporter returns config.Reporters
-func (p *Project) GetReporter() config.Reporters {
+func (p *Project) GetReporters() config.Reporters {
 	return p.Reporters
 }
 

--- a/internal/cypress/v1alpha/config.go
+++ b/internal/cypress/v1alpha/config.go
@@ -492,7 +492,7 @@ func (p *Project) GetBeforeExec() []string {
 }
 
 // GetReporter returns config.Reporters
-func (p *Project) GetReporter() config.Reporters {
+func (p *Project) GetReporters() config.Reporters {
 	return p.Reporters
 }
 

--- a/internal/report/spotlight/spotlight.go
+++ b/internal/report/spotlight/spotlight.go
@@ -34,9 +34,6 @@ func (r *Reporter) Add(t report.TestResult) {
 		return
 	}
 
-	if t.Status == job.StateFailed || t.Status == imagerunner.StateFailed ||
-		t.Status == imagerunner.StateCancelled || t.Status == imagerunner.StateTerminated {
-	}
 	if t.TimedOut {
 		t.Status = job.StateUnknown
 	}

--- a/internal/report/spotlight/spotlight.go
+++ b/internal/report/spotlight/spotlight.go
@@ -1,0 +1,131 @@
+package spotlight
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/fatih/color"
+	"github.com/saucelabs/saucectl/internal/imagerunner"
+	"github.com/saucelabs/saucectl/internal/job"
+	"github.com/saucelabs/saucectl/internal/junit"
+	"github.com/saucelabs/saucectl/internal/report"
+)
+
+// Reporter implements report.Reporter and highlights the most important test
+// results.
+type Reporter struct {
+	TestResults []report.TestResult
+	Dst         io.Writer
+	lock        sync.Mutex
+}
+
+// Add adds the test result that can be rendered by Render.
+func (r *Reporter) Add(t report.TestResult) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.TestResults = append(r.TestResults, t)
+}
+
+// Render renders out a test summary.
+func (r *Reporter) Render() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.println()
+	rl := color.New(color.FgBlue, color.Underline, color.Bold).Sprintf("Spotlight:")
+	r.printf("  %s\n", rl)
+	r.println()
+
+	for _, ts := range r.TestResults {
+		// skip in-progress jobs
+		if !job.Done(ts.Status) && !imagerunner.Done(ts.Status) && !ts.TimedOut {
+			continue
+		}
+		// skip passed jobs
+		if ts.Status == job.StatePassed || ts.Status == imagerunner.StateSucceeded {
+			continue
+		}
+		if ts.Status == job.StateFailed || ts.Status == imagerunner.StateFailed ||
+			ts.Status == imagerunner.StateCancelled || ts.Status == imagerunner.StateTerminated {
+		}
+		if ts.TimedOut {
+			ts.Status = job.StateUnknown
+		}
+
+		// the order of values must match the order of the header
+		r.println("", jobStatusSymbol(ts.Status), ts.Name)
+		r.println("   ● URL:", ts.URL)
+
+		var junitReports []junit.TestSuites
+		for _, attempt := range ts.Attempts {
+			junitReports = append(junitReports, attempt.TestSuites)
+		}
+		if len(junitReports) > 0 {
+			junitReport := junit.MergeReports(junitReports...)
+			testCases := junitReport.TestCases()
+
+			var failedTests []string
+			for _, tc := range testCases {
+				if tc.IsError() || tc.IsFailure() {
+					failedTests = append(failedTests, fmt.Sprintf("%s %s › %s", testCaseStatusSymbol(tc), tc.ClassName, tc.Name))
+				}
+				// only show the first 5 failed tests to conserve space
+				if len(failedTests) == 5 {
+					break
+				}
+			}
+
+			if len(failedTests) > 0 {
+				r.println("   ● Failed Tests: (max 5)")
+				for _, test := range failedTests {
+					r.println("    ", test)
+				}
+			}
+			r.println()
+		}
+	}
+}
+
+func (r *Reporter) println(a ...any) {
+	_, _ = fmt.Fprintln(r.Dst, a...)
+}
+
+func (r *Reporter) printf(format string, a ...any) {
+	_, _ = fmt.Fprintf(r.Dst, format, a...)
+}
+
+// Reset resets the reporter to its initial state. This action will delete all test results.
+func (r *Reporter) Reset() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.TestResults = make([]report.TestResult, 0)
+}
+
+// ArtifactRequirements returns a list of artifact types this reporter requires
+// to create a proper report.
+func (r *Reporter) ArtifactRequirements() []report.ArtifactType {
+	return []report.ArtifactType{report.JUnitArtifact}
+}
+
+func jobStatusSymbol(status string) string {
+	switch status {
+	case job.StatePassed, imagerunner.StateSucceeded:
+		return color.GreenString("✔")
+	case job.StateInProgress, job.StateQueued, job.StateNew, imagerunner.StateRunning, imagerunner.StatePending,
+		imagerunner.StateUploading:
+		return color.BlueString("*")
+	default:
+		return color.RedString("✖")
+	}
+}
+
+func testCaseStatusSymbol(tc junit.TestCase) string {
+	if tc.IsError() || tc.IsFailure() {
+		return color.RedString("✖")
+	}
+	if tc.IsSkipped() {
+		return color.YellowString("-")
+	}
+	return color.GreenString("✔")
+}

--- a/internal/report/spotlight/spotlight_test.go
+++ b/internal/report/spotlight/spotlight_test.go
@@ -1,0 +1,203 @@
+package spotlight
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/saucelabs/saucectl/internal/job"
+	"github.com/saucelabs/saucectl/internal/report"
+)
+
+func TestReporter_Render(t *testing.T) {
+	type fields struct {
+		TestResults []report.TestResult
+	}
+	startTime := time.Now()
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "all pass",
+			fields: fields{
+				TestResults: []report.TestResult{
+					{
+						Name:          "Firefox",
+						Duration:      34479 * time.Millisecond,
+						StartTime:     startTime,
+						EndTime:       startTime.Add(34479 * time.Millisecond),
+						Status:        job.StatePassed,
+						Browser:       "Firefox",
+						Platform:      "Windows 10",
+						PassThreshold: true,
+						Attempts: []report.Attempt{
+							{Status: job.StateFailed},
+							{Status: job.StateFailed},
+							{Status: job.StatePassed},
+						},
+					},
+					{
+						Name:          "Chrome",
+						Duration:      5123 * time.Millisecond,
+						StartTime:     startTime,
+						EndTime:       startTime.Add(5123 * time.Millisecond),
+						Status:        job.StatePassed,
+						Browser:       "Chrome",
+						Platform:      "Windows 10",
+						PassThreshold: true,
+						Attempts: []report.Attempt{
+							{Status: job.StatePassed},
+						},
+					},
+				},
+			},
+			want: `
+       Name                              Duration    Status    Browser    Platform      Attempts  
+──────────────────────────────────────────────────────────────────────────────────────────────────
+  ✔    Firefox                                34s    passed    Firefox    Windows 10           3  
+  ✔    Chrome                                  5s    passed    Chrome     Windows 10           1  
+──────────────────────────────────────────────────────────────────────────────────────────────────
+  ✔    All suites have passed                 34s                                                 
+`,
+		},
+		{
+			name: "with failure",
+			fields: fields{
+				TestResults: []report.TestResult{
+					{
+						Name:      "Firefox",
+						Duration:  34479 * time.Millisecond,
+						StartTime: startTime,
+						EndTime:   startTime.Add(34479 * time.Millisecond),
+						Status:    job.StatePassed,
+						Browser:   "Firefox",
+						Platform:  "Windows 10",
+						Attempts: []report.Attempt{
+							{Status: job.StatePassed},
+						},
+					},
+					{
+						Name:      "Chrome",
+						Duration:  171452 * time.Millisecond,
+						StartTime: startTime,
+						EndTime:   startTime.Add(171452 * time.Millisecond),
+						Status:    job.StateFailed,
+						Browser:   "Chrome",
+						Platform:  "Windows 10",
+						Attempts: []report.Attempt{
+							{Status: job.StateFailed},
+							{Status: job.StateFailed},
+							{Status: job.StateFailed},
+						},
+					},
+				},
+			},
+			want: `
+       Name                               Duration    Status    Browser    Platform      Attempts  
+───────────────────────────────────────────────────────────────────────────────────────────────────
+  ✔    Firefox                                 34s    passed    Firefox    Windows 10           1  
+  ✖    Chrome                                2m51s    failed    Chrome     Windows 10           3  
+───────────────────────────────────────────────────────────────────────────────────────────────────
+  ✖    1 of 2 suites have failed (50%)       2m51s                                                 
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buffy bytes.Buffer
+
+			r := &Reporter{
+				TestResults: tt.fields.TestResults,
+				Dst:         &buffy,
+			}
+			r.Render()
+
+			out := buffy.String()
+			if !reflect.DeepEqual(out, tt.want) {
+				t.Errorf("Render() got = \n%s, want = \n%s", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestReporter_Reset(t *testing.T) {
+	type fields struct {
+		TestResults []report.TestResult
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{
+			name: "expect empty render",
+			fields: fields{
+				TestResults: []report.TestResult{
+					{
+						Name:     "Firefox",
+						Duration: 34479 * time.Millisecond,
+						Status:   job.StatePassed,
+						Browser:  "Firefox",
+						Platform: "Windows 10",
+					}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reporter{
+				TestResults: tt.fields.TestResults,
+			}
+			r.Reset()
+
+			if len(r.TestResults) != 0 {
+				t.Errorf("len(TestResults) got = %d, want = %d", len(r.TestResults), 0)
+			}
+		})
+	}
+}
+
+func TestReporter_Add(t *testing.T) {
+	type fields struct {
+		TestResults []report.TestResult
+	}
+	type args struct {
+		t report.TestResult
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name:   "just one",
+			fields: fields{},
+			args: args{
+				t: report.TestResult{
+					Name:     "Firefox",
+					Duration: 34479 * time.Millisecond,
+					Status:   job.StatePassed,
+					Browser:  "Firefox",
+					Platform: "Windows 10",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reporter{
+				TestResults: tt.fields.TestResults,
+			}
+			r.Add(tt.args.t)
+
+			if len(r.TestResults) != 1 {
+				t.Errorf("len(TestResults) got = %d, want = %d", len(r.TestResults), 1)
+			}
+			if !reflect.DeepEqual(r.TestResults[0], tt.args.t) {
+				t.Errorf(" got = %v, want = %v", r.TestResults[0], tt.args.t)
+			}
+		})
+	}
+}

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -141,8 +141,6 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 				browser = fmt.Sprintf("%s %s", browser, res.job.BrowserShortVersion)
 			}
 
-			r.FetchJUnitReports(&res)
-
 			var artifacts []report.Artifact
 			files := r.downloadArtifacts(res.name, res.job, artifactCfg.When)
 			for _, f := range files {
@@ -150,6 +148,8 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 					FilePath: f,
 				})
 			}
+
+			r.FetchJUnitReports(&res, artifacts)
 
 			var url string
 			if res.job.ID != "" {
@@ -486,21 +486,40 @@ func (r *CloudRunner) remoteArchiveFiles(project interface{}, files []string, sa
 }
 
 // FetchJUnitReports retrieves junit reports for the given result and all of its
-// attempts.
-func (r *CloudRunner) FetchJUnitReports(res *result) {
+// attempts. Can use the given artifacts to avoid unnecessary API calls.
+func (r *CloudRunner) FetchJUnitReports(res *result, artifacts []report.Artifact) {
 	if !report.IsArtifactRequired(r.Reporters, report.JUnitArtifact) {
 		return
+	}
+
+	var junitArtifact *report.Artifact
+	for _, artifact := range artifacts {
+		if strings.HasSuffix(artifact.FilePath, junit.FileName) {
+			junitArtifact = &artifact
+			break
+		}
 	}
 
 	for i := range res.attempts {
 		attempt := &res.attempts[i]
 
-		content, err := r.JobService.GetJobAssetFileContent(
-			context.Background(),
-			attempt.ID,
-			junit.FileName,
-			res.job.IsRDC,
-		)
+		var content []byte
+		var err error
+
+		// If this is the last attempt, we can use the given junit artifact to
+		// avoid unnecessary API calls.
+		if i == len(res.attempts)-1 && junitArtifact != nil {
+			content, err = os.ReadFile(junitArtifact.FilePath)
+			log.Info().Msg("Using local JUnit report") // TODO remove me
+		} else {
+			content, err = r.JobService.GetJobAssetFileContent(
+				context.Background(),
+				attempt.ID,
+				junit.FileName,
+				res.job.IsRDC,
+			)
+		}
+
 		if err != nil {
 			log.Warn().Err(err).Str("jobID", attempt.ID).Msg("Unable to retrieve JUnit report")
 			continue

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -510,7 +510,7 @@ func (r *CloudRunner) FetchJUnitReports(res *result, artifacts []report.Artifact
 		// avoid unnecessary API calls.
 		if i == len(res.attempts)-1 && junitArtifact != nil {
 			content, err = os.ReadFile(junitArtifact.FilePath)
-			log.Info().Msg("Using local JUnit report") // TODO remove me
+			log.Debug().Msg("Using cached JUnit report")
 		} else {
 			content, err = r.JobService.GetJobAssetFileContent(
 				context.Background(),

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -118,6 +118,13 @@ func (p Properties) SetSmartRetry(isSmartRetried bool) Properties {
 	return p
 }
 
+func (p Properties) SetReporters(reporters config.Reporters) Properties {
+	p["reporters_spotlight_enabled"] = reporters.Spotlight.Enabled
+	p["reporters_junit_enabled"] = reporters.JUnit.Enabled
+	p["reporters_json_enabled"] = reporters.JSON.Enabled
+	return p
+}
+
 // Tracker is an interface for providing usage tracking.
 type Tracker interface {
 	io.Closer


### PR DESCRIPTION
## Proposed changes

The new spotlight reporter enhances the test summary with additional highlights (hence the name, spotlight) for a quicker UX when it comes to troubleshooting failing (or otherwise interesting) tests.

```
  Spotlight:

 ✖ Firefox Win
   ● URL: https://app.saucelabs.com/tests/8518d9a0550e4ee3a82245ffa8e3127d
   ● Failed Tests: (showing max. 5)
     ✖ demo-todo-app.spec.js › New Todo › should clear text input field when an item is added



  Results:


       Name                                Duration    Status    Browser        Platform      Attempts
────────────────────────────────────────────────────────────────────────────────────────────────────────
  ✖    Firefox Win                             1m4s    failed    firefox 115    Windows 11           1
────────────────────────────────────────────────────────────────────────────────────────────────────────
  ✖    1 of 1 suites have failed (100%)        1m5s

  Build Link: https://app.saucelabs.com/builds/vdc/cc964446d0f83515be25db0ad8098c72
```

It is off by default (should we turn it on by default?).

Additional changes:
- Capturing reporter usage.
- Optimization: Avoid downloading the same junit report more than once
