### PR TITLE
feat: Add storage delete command

### DIFF
--- a/internal/cmd/storage/cmd.go
+++ b/internal/cmd/storage/cmd.go
@@ -51,6 +51,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 		ListCommand(),
 		UploadCommand(),
 		DownloadCommand(),
+		DeleteCommand(),
 	)
 
 	return cmd

--- a/internal/cmd/storage/delete.go
+++ b/internal/cmd/storage/delete.go
@@ -1,0 +1,50 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
+	"github.com/saucelabs/saucectl/internal/segment"
+	"github.com/saucelabs/saucectl/internal/usage"
+	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+func DeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "delete <fileID>",
+		Short:        "Delete a file from Sauce Storage.",
+		SilenceUsage: true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || args[0] == "" {
+				return errors.New("no ID specified")
+			}
+
+			return nil
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			tracker := segment.DefaultTracker
+
+			go func() {
+				tracker.Collect(
+					cases.Title(language.English).String(cmds.FullName(cmd)),
+					usage.Properties{}.SetFlags(cmd.Flags()),
+				)
+				_ = tracker.Close()
+			}()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := appsClient.Delete(args[0]); err != nil {
+				return fmt.Errorf("failed to delete file: %v", err)
+			}
+
+			println("File deleted successfully!")
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/saucecloud/retry/saucereportretrier_test.go
+++ b/internal/saucecloud/retry/saucereportretrier_test.go
@@ -36,6 +36,10 @@ func (f *StubProjectUploader) List(opts storage.ListOptions) (storage.List, erro
 	return storage.List{}, nil
 }
 
+func (f *StubProjectUploader) Delete(id string) error {
+	return nil
+}
+
 type StubVDCJobReader struct {
 	SauceReport saucereport.SauceReport
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -60,6 +60,7 @@ type AppService interface {
 	// UploadStream uploads the contents of reader and stores them under the given filename.
 	UploadStream(filename, description string, reader io.Reader) (Item, error)
 	Download(id string) (io.ReadCloser, int64, error)
+	Delete(id string) error
 	DownloadURL(url string) (io.ReadCloser, int64, error)
 	List(opts ListOptions) (List, error)
 }


### PR DESCRIPTION
## Proposed changes

Add storage delete command.

```
❯ saucectl storage delete -h
Delete a file from Sauce Storage.

Usage:
  saucectl storage delete <fileID> [flags]

Flags:
  -h, --help   help for delete

Global Flags:
      --disable-usage-metrics   Disable usage metrics collection.
      --no-color                disable colorized output
  -r, --region string           The Sauce Labs region. Options: us-west-1, eu-central-1. (default "us-west-1")
      --verbose                 turn on verbose logging
```