### PR TITLE
fix: Support --env flag and root env vars simultaneously

### DIFF
--- a/internal/apitest/config.go
+++ b/internal/apitest/config.go
@@ -27,6 +27,7 @@ type Project struct {
 	Sauce          config.SauceConfig `yaml:"sauce,omitempty"`
 	RootDir        string             `yaml:"rootDir,omitempty"`
 	Env            map[string]string  `yaml:"env,omitempty"`
+	EnvFlag        map[string]string  `yaml:"-"`
 }
 
 // Suite represents the apitest suite configuration.
@@ -84,13 +85,16 @@ func SetDefaults(p *Project) {
 	}
 
 	// Apply global env var onto every suite.
-	for k, v := range p.Env {
-		for ks := range p.Suites {
-			s := &p.Suites[ks]
-			if s.Env == nil {
-				s.Env = map[string]string{}
+	// Precedence: --env flag > root-level env vars > suite-level env vars.
+	for _, env := range []map[string]string{p.Env, p.EnvFlag} {
+		for k, v := range env {
+			for ks := range p.Suites {
+				s := &p.Suites[ks]
+				if s.Env == nil {
+					s.Env = map[string]string{}
+				}
+				s.Env[k] = v
 			}
-			s.Env[k] = v
 		}
 	}
 }

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -113,7 +113,7 @@ func Command() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&gFlags.failFast, "fail-fast", false, "Stops suites after the first failure")
 	cmd.PersistentFlags().DurationVar(&gFlags.appStoreTimeout, "uploadTimeout", 5*time.Minute, "Upload timeout that limits how long saucectl will wait for an upload to finish. Supports duration values like '10s' '30m' etc. (default: 5m)")
 	sc.StringP("region", "r", "sauce::region", "us-west-1", "The sauce labs region.")
-	sc.StringToStringP("env", "e", "env", map[string]string{}, "Set environment variables, e.g. -e foo=bar. Not supported for RDC or Espresso on virtual devices!")
+	sc.StringToStringP("env", "e", "envFlag", map[string]string{}, "Set environment variables, e.g. -e foo=bar. Not supported for RDC or Espresso on virtual devices! It will overwrite existing environment variable values in sauce config file.")
 	sc.Bool("show-console-log", "showConsoleLog", false, "Shows suites console.log locally. By default console.log is only shown on failures.")
 	sc.Int("ccy", "sauce::concurrency", 2, "Concurrency specifies how many suites are run at the same time.")
 	sc.String("tunnel-id", "sauce::tunnel::id", "", "Sets the sauce-connect tunnel ID to be used for the run.")

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -113,7 +113,7 @@ func Command() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&gFlags.failFast, "fail-fast", false, "Stops suites after the first failure")
 	cmd.PersistentFlags().DurationVar(&gFlags.appStoreTimeout, "uploadTimeout", 5*time.Minute, "Upload timeout that limits how long saucectl will wait for an upload to finish. Supports duration values like '10s' '30m' etc. (default: 5m)")
 	sc.StringP("region", "r", "sauce::region", "us-west-1", "The sauce labs region.")
-	sc.StringToStringP("env", "e", "envFlag", map[string]string{}, "Set environment variables, e.g. -e foo=bar. Not supported for RDC or Espresso on virtual devices! It will overwrite existing environment variable values in sauce config file.")
+	sc.StringToStringP("env", "e", "envFlag", map[string]string{}, "Set environment variables, e.g. -e foo=bar. Not supported for RDC or Espresso on virtual devices!")
 	sc.Bool("show-console-log", "showConsoleLog", false, "Shows suites console.log locally. By default console.log is only shown on failures.")
 	sc.Int("ccy", "sauce::concurrency", 2, "Concurrency specifies how many suites are run at the same time.")
 	sc.String("tunnel-id", "sauce::tunnel::id", "", "Sets the sauce-connect tunnel ID to be used for the run.")

--- a/internal/cucumber/config.go
+++ b/internal/cucumber/config.go
@@ -47,6 +47,7 @@ type Project struct {
 	Reporters     config.Reporters     `yaml:"reporters,omitempty" json:"-"`
 	Defaults      config.Defaults      `yaml:"defaults,omitempty" json:"defaults"`
 	Env           map[string]string    `yaml:"env,omitempty" json:"env"`
+	EnvFlag       map[string]string    `yaml:"-" json:"-"`
 	Notifications config.Notifications `yaml:"notifications,omitempty" json:"-"`
 }
 
@@ -150,13 +151,16 @@ func SetDefaults(p *Project) {
 	}
 
 	// Apply global env vars onto every suite.
-	for k, v := range p.Env {
-		for ks := range p.Suites {
-			s := &p.Suites[ks]
-			if s.Env == nil {
-				s.Env = map[string]string{}
+	// Precedence: --env flag > root-level env vars > suite-level env vars.
+	for _, env := range []map[string]string{p.Env, p.EnvFlag} {
+		for k, v := range env {
+			for ks := range p.Suites {
+				s := &p.Suites[ks]
+				if s.Env == nil {
+					s.Env = map[string]string{}
+				}
+				s.Env[k] = v
 			}
-			s.Env[k] = v
 		}
 	}
 }

--- a/internal/cypress/v1/config.go
+++ b/internal/cypress/v1/config.go
@@ -49,6 +49,7 @@ type Project struct {
 	Artifacts     config.Artifacts     `yaml:"artifacts,omitempty" json:"artifacts"`
 	Reporters     config.Reporters     `yaml:"reporters,omitempty" json:"-"`
 	Env           map[string]string    `yaml:"env,omitempty" json:"env"`
+	EnvFlag       map[string]string    `yaml:"-" json:"-"`
 	Notifications config.Notifications `yaml:"notifications,omitempty" json:"-"`
 }
 
@@ -160,8 +161,11 @@ func (p *Project) SetDefaults() {
 		}
 
 		// Apply global env vars onto suite.
-		for k, v := range p.Env {
-			s.Config.Env[k] = v
+		// Precedence: --env flag > root-level env vars > suite-level env vars.
+		for _, env := range []map[string]string{p.Env, p.EnvFlag} {
+			for k, v := range env {
+				s.Config.Env[k] = v
+			}
 		}
 
 		if s.Config.TestingType == "" {

--- a/internal/cypress/v1alpha/config.go
+++ b/internal/cypress/v1alpha/config.go
@@ -49,6 +49,7 @@ type Project struct {
 	Artifacts     config.Artifacts     `yaml:"artifacts,omitempty" json:"artifacts"`
 	Reporters     config.Reporters     `yaml:"reporters,omitempty" json:"-"`
 	Env           map[string]string    `yaml:"env,omitempty" json:"env"`
+	EnvFlag       map[string]string    `yaml:"-" json:"-"`
 	Notifications config.Notifications `yaml:"notifications,omitempty" json:"-"`
 }
 
@@ -158,8 +159,11 @@ func (p *Project) SetDefaults() {
 		}
 
 		// Apply global env vars onto suite.
-		for k, v := range p.Env {
-			s.Config.Env[k] = v
+		// Precedence: --env flag > root-level env vars > suite-level env vars.
+		for _, env := range []map[string]string{p.Env, p.EnvFlag} {
+			for k, v := range env {
+				s.Config.Env[k] = v
+			}
 		}
 
 		if s.PassThreshold < 1 {

--- a/internal/imagerunner/config.go
+++ b/internal/imagerunner/config.go
@@ -33,6 +33,7 @@ type Project struct {
 	Artifacts      config.Artifacts   `yaml:"artifacts,omitempty" json:"artifacts"`
 	DryRun         bool               `yaml:"-" json:"-"`
 	Env            map[string]string  `yaml:"env,omitempty" json:"env"`
+	EnvFlag        map[string]string  `yaml:"-" json:"-"`
 }
 
 type Defaults struct {
@@ -123,11 +124,11 @@ func SetDefaults(p *Project) {
 		suite.Metadata["name"] = suite.Name
 		suite.Metadata["resourceProfile"] = suite.ResourceProfile
 
-		for k, v := range p.Defaults.Env {
-			suite.Env[k] = v
-		}
-		for k, v := range p.Env {
-			suite.Env[k] = v
+		// Precedence: --env flag > root-level env vars > default env vars.
+		for _, env := range []map[string]string{p.Defaults.Env, p.Env, p.EnvFlag} {
+			for k, v := range env {
+				suite.Env[k] = v
+			}
 		}
 	}
 }

--- a/internal/imagerunner/config.go
+++ b/internal/imagerunner/config.go
@@ -124,7 +124,7 @@ func SetDefaults(p *Project) {
 		suite.Metadata["name"] = suite.Name
 		suite.Metadata["resourceProfile"] = suite.ResourceProfile
 
-		// Precedence: --env flag > root-level env vars > default env vars.
+		// Precedence: --env flag > root-level env vars > default env vars > suite env vars.
 		for _, env := range []map[string]string{p.Defaults.Env, p.Env, p.EnvFlag} {
 			for k, v := range env {
 				suite.Env[k] = v

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -51,6 +51,7 @@ type Project struct {
 	Reporters     config.Reporters     `yaml:"reporters,omitempty" json:"-"`
 	Defaults      config.Defaults      `yaml:"defaults,omitempty" json:"defaults"`
 	Env           map[string]string    `yaml:"env,omitempty" json:"env"`
+	EnvFlag       map[string]string    `yaml:"-" json:"-"`
 	Notifications config.Notifications `yaml:"notifications,omitempty" json:"-"`
 }
 
@@ -165,13 +166,16 @@ func SetDefaults(p *Project) {
 	}
 
 	// Apply global env vars onto every suite.
-	for k, v := range p.Env {
-		for ks := range p.Suites {
-			s := &p.Suites[ks]
-			if s.Env == nil {
-				s.Env = map[string]string{}
+	// Precedence: --env flag > root-level env vars > suite-level env vars.
+	for _, env := range []map[string]string{p.EnvFlag, p.Env} {
+		for k, v := range env {
+			for ks := range p.Suites {
+				s := &p.Suites[ks]
+				if s.Env == nil {
+					s.Env = map[string]string{}
+				}
+				s.Env[k] = v
 			}
-			s.Env[k] = v
 		}
 	}
 }

--- a/internal/testcafe/config.go
+++ b/internal/testcafe/config.go
@@ -51,6 +51,7 @@ type Project struct {
 	Reporters     config.Reporters     `yaml:"reporters,omitempty" json:"-"`
 	Defaults      config.Defaults      `yaml:"defaults,omitempty" json:"defaults"`
 	Env           map[string]string    `yaml:"env,omitempty" json:"env"`
+	EnvFlag       map[string]string    `yaml:"-" json:"-"`
 	Notifications config.Notifications `yaml:"notifications,omitempty" json:"-"`
 }
 
@@ -222,13 +223,16 @@ func SetDefaults(p *Project) {
 	}
 
 	// Apply global env vars onto every suite.
-	for k, v := range p.Env {
-		for ks := range p.Suites {
-			s := &p.Suites[ks]
-			if s.Env == nil {
-				s.Env = map[string]string{}
+	// Precedence: --env flag > root-level env vars > suite-level env vars.
+	for _, env := range []map[string]string{p.Env, p.EnvFlag} {
+		for k, v := range env {
+			for ks := range p.Suites {
+				s := &p.Suites[ks]
+				if s.Env == nil {
+					s.Env = map[string]string{}
+				}
+				s.Env[k] = v
 			}
-			s.Env[k] = v
 		}
 	}
 }

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -44,6 +44,7 @@ type Project struct {
 	Reporters     config.Reporters     `yaml:"reporters,omitempty" json:"-"`
 	Notifications config.Notifications `yaml:"notifications,omitempty" json:"-"`
 	Env           map[string]string    `yaml:"env,omitempty" json:"-"`
+	EnvFlag       map[string]string    `yaml:"-" json:"-"`
 }
 
 // Xcuitest represents xcuitest apps configuration.
@@ -187,11 +188,14 @@ func SetDefaults(p *Project) {
 			suite.PassThreshold = 1
 		}
 
-		for k, v := range p.Env {
-			if suite.Env == nil {
-				suite.Env = map[string]string{}
+		// Precedence: --env flag > root-level env vars > suite-level env vars.
+		for _, env := range []map[string]string{p.Env, p.EnvFlag} {
+			for k, v := range env {
+				if suite.Env == nil {
+					suite.Env = map[string]string{}
+				}
+				suite.Env[k] = v
 			}
-			suite.Env[k] = v
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Previously, when setting environment variables via the `--env` flag, the root-level environment variables would be dropped. This pull request ensures that the `--env` flag and root-level environment variables can coexist.

Precedence: `--env` flag > root-level environment variables > suite-level environment variables.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->