### PR TITLE
feat: add testApp in metadata for mobile tests

### DIFF
--- a/internal/http/webdriver.go
+++ b/internal/http/webdriver.go
@@ -38,6 +38,7 @@ type Capabilities struct {
 // MatchingCaps are specific attributes that together form the capabilities that are used to match a session.
 type MatchingCaps struct {
 	App               string    `json:"app,omitempty"`
+	TestApp           string    `json:"testApp,omitempty"`
 	OtherApps         []string  `json:"otherApps,omitempty"`
 	BrowserName       string    `json:"browserName,omitempty"`
 	BrowserVersion    string    `json:"browserVersion,omitempty"`
@@ -117,6 +118,7 @@ func (c *Webdriver) StartJob(ctx context.Context, opts job.StartOptions) (jobID 
 
 	caps := Capabilities{AlwaysMatch: MatchingCaps{
 		App:             opts.App,
+		TestApp:         opts.TestApp,
 		OtherApps:       opts.OtherApps,
 		BrowserName:     c.normalizeBrowser(opts.Framework, opts.BrowserName),
 		BrowserVersion:  opts.BrowserVersion,

--- a/internal/job/starter.go
+++ b/internal/job/starter.go
@@ -21,6 +21,7 @@ type StartOptions struct {
 	User           string                 `json:"username"`
 	AccessKey      string                 `json:"accessKey"`
 	App            string                 `json:"app,omitempty"`
+	TestApp        string                 `json:"testApp,omitempty"`
 	Suite          string                 `json:"suite,omitempty"`
 	OtherApps      []string               `json:"otherApps,omitempty"`
 	Framework      string                 `json:"framework,omitempty"`

--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -203,6 +203,7 @@ func (r *EspressoRunner) startJob(jobOpts chan<- job.StartOptions, s espresso.Su
 		ConfigFilePath:    r.Project.ConfigFilePath,
 		CLIFlags:          r.Project.CLIFlags,
 		App:               appFileURI,
+		TestApp:           testAppFileURI,
 		Suite:             testAppFileURI,
 		OtherApps:         otherAppsURIs,
 		Framework:         "espresso",

--- a/internal/saucecloud/xcuitest.go
+++ b/internal/saucecloud/xcuitest.go
@@ -196,6 +196,7 @@ func (r *XcuitestRunner) startJob(jobOpts chan<- job.StartOptions, appFileID, te
 		DisplayName:      s.Name,
 		Timeout:          s.Timeout,
 		App:              appFileID,
+		TestApp:          testAppFileID,
 		Suite:            testAppFileID,
 		OtherApps:        otherAppsIDs,
 		Framework:        "xcuitest",


### PR DESCRIPTION
## Proposed changes

Add `testApp` to VDC capabilities. On retrieval, this field still ends up in `base_config`, but unlike `testFile`, which is further nested under `batch`, it is less likely to be truncated when retrieving the metadata via the jobs API.
It is now also closer (hierarchically) to its siblings, `app` and `otherApps`.