### PR TITLE
feat: add async support for imagerunner

### DIFF
--- a/internal/cmd/run/imagerunner.go
+++ b/internal/cmd/run/imagerunner.go
@@ -57,6 +57,7 @@ func runImageRunner(cmd *cobra.Command) (int, error) {
 		Reporters: []report.Reporter{&table.Reporter{
 			Dst: os.Stdout,
 		}},
+		Async: gFlags.async,
 	}
 	return r.RunProject()
 }


### PR DESCRIPTION
Add `--async` support for imagerunner:

```
❯ saucectl run -c .sauce/imagerunner.yml --async
Running version 0.0.0+unknown
13:48:02 WRN A new version of saucectl is available (v0.163.0)
13:48:02 INF Launching workers. concurrency=2
13:48:02 INF Starting suite. image=busybox:1.35.0 suite="busybox num 1"
13:48:04 INF Started suite. image=busybox:1.35.0 runID=01289b0ddc3446b6b4b165f7c0b58248 suite="busybox num 1"

       Name                              Duration    Status     Attempts
──────────────────────────────────────────────────────────────────────────
  *    busybox num 1                           1s    Pending           1
──────────────────────────────────────────────────────────────────────────
  *    All suites have launched                1s
```