### PR TITLE
fix: properly report imagerunner startup errors

### DIFF
--- a/internal/imagerunner/imagerunner.go
+++ b/internal/imagerunner/imagerunner.go
@@ -1,6 +1,9 @@
 package imagerunner
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // The different states that a runner can be in.
 const (
@@ -88,4 +91,22 @@ type Runner struct {
 type ArtifactList struct {
 	ID    string   `json:"id"`
 	Items []string `json:"items"`
+}
+
+type ServerError struct {
+	// HTTPStatus is the HTTP status code as returned by the server.
+	HTTPStatus int `json:"-"`
+
+	// Short is a short error prefix saying what failed, e.g. "failed to do x".
+	Short string `json:"-"`
+
+	// Code is the error code, such as 'ERR_IMAGE_NOT_ACCESSIBLE'.
+	Code string `json:"code"`
+
+	// Msg describes the error in more detail.
+	Msg string `json:"message"`
+}
+
+func (s *ServerError) Error() string {
+	return fmt.Sprintf("%s (%d): %s: %s", s.Short, s.HTTPStatus, s.Code, s.Msg)
 }


### PR DESCRIPTION
## Proposed changes

Ensure that imagerunner startup errors are properly reported back to the user.


Here is an example of launching with invalid image pull credentials **before** this PR:
```
❯ saucectl run
Running version 0.0.0+unknown
07:55:40 WRN A new version of saucectl is available (v0.164.0)
07:55:40 INF Launching workers. concurrency=2
07:55:40 INF Starting suite. image=europe-west3-docker.pkg.dev/sauce-hto-p-jy6b/abn-amro-sauce/saucelabs-wiremock-dynamic-instance:latest suite="Testing Image Credentials"

       Name                              Duration    Status    Attempts
─────────────────────────────────────────────────────────────────────────
  ✖    Testing Image Credentials               1s                     1
─────────────────────────────────────────────────────────────────────────
  *    All suites have launched                1s
  *
```

Same example as above, but **after** the changes:
```
❯ saucectl run -c .sauce/bad_config.yml
Running version 0.0.0+unknown
10:31:49 WRN A new version of saucectl is available (v0.164.0)
10:31:49 INF Launching workers. concurrency=2
10:31:49 INF Starting suite. image=europe-west3-docker.pkg.dev/sauce-hto-p-jy6b/abn-amro-sauce/saucelabs-wiremock-dynamic-instance:latest suite="Testing Image Credentials"
10:31:50 ERR Suite failed. error="runner start (422): ERR_IMAGE_NOT_ACCESSIBLE: the provided image does not meet the requirements" passed=false runID= suite="Testing Image Credentials"

       Name                                Duration    Status    Attempts
───────────────────────────────────────────────────────────────────────────
  ✖    Testing Image Credentials                 1s    Failed           1
───────────────────────────────────────────────────────────────────────────
  ✖    1 of 1 suites have failed (100%)          1s
```