### PR TITLE
fix: Better logging for timed out jobs

### DIFF
--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -696,7 +696,7 @@ func (r *CloudRunner) logSuite(res result) {
 	jobDetailsPage := fmt.Sprintf("%s/tests/%s", r.Region.AppBaseURL(), res.job.ID)
 
 	if res.job.TimedOut {
-		log.Warn().Str("suite", res.name).Str("url", jobDetailsPage).Msg("Suite timed out.")
+		log.Error().Str("suite", res.name).Str("url", jobDetailsPage).Msg("Suite timed out.")
 		return
 	}
 

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -185,12 +185,15 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 		}
 		r.logSuite(res)
 
-		// Skip reporting to Insights for async job
-		if r.Async {
-			continue
+		// NOTE: Jobs must be finished in order to be reported to Insights.
+		// * Async jobs have an unknown status by definition, so should always be excluded from reporting.
+		// * Timed out jobs will be requested to stop, but stopping a job
+		//   is either not possible (rdc) or async (vdc) so its actual status is not known now.
+		//	 Skip reporting to be safe.
+		maybeInProgress := r.Async || res.job.TimedOut
+		if !maybeInProgress {
+			r.reportSuiteToInsights(res)
 		}
-		// Report suite to Insights
-		r.reportSuiteToInsights(res)
 	}
 	close(done)
 

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -190,8 +190,8 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 		// * Timed out jobs will be requested to stop, but stopping a job
 		//   is either not possible (rdc) or async (vdc) so its actual status is not known now.
 		//   Skip reporting to be safe.
-		maybeInProgress := r.Async || res.job.TimedOut
-		if !maybeInProgress {
+		isFinished := !r.Async && !res.job.TimedOut
+		if isFinished {
 			r.reportSuiteToInsights(res)
 		}
 	}

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -189,7 +189,7 @@ func (r *CloudRunner) collectResults(artifactCfg config.ArtifactDownload, result
 		// * Async jobs have an unknown status by definition, so should always be excluded from reporting.
 		// * Timed out jobs will be requested to stop, but stopping a job
 		//   is either not possible (rdc) or async (vdc) so its actual status is not known now.
-		//	 Skip reporting to be safe.
+		//   Skip reporting to be safe.
 		maybeInProgress := r.Async || res.job.TimedOut
 		if !maybeInProgress {
 			r.reportSuiteToInsights(res)

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -694,6 +694,12 @@ func (r *CloudRunner) logSuite(res result) {
 	}
 
 	jobDetailsPage := fmt.Sprintf("%s/tests/%s", r.Region.AppBaseURL(), res.job.ID)
+
+	if res.job.TimedOut {
+		log.Warn().Str("suite", res.name).Str("url", jobDetailsPage).Msg("Suite timed out.")
+		return
+	}
+
 	msg := "Suite finished."
 	if res.job.Passed {
 		log.Info().Str("suite", res.name).Bool("passed", res.job.Passed).Str("url", jobDetailsPage).


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Stopping a job via the jobs api is async. So even though saucectl requests to stop a job when the client timeout is reached, the job's actual status is unknown; it may still be running by the time saucectl wants to report to insights or retrieve assets.

This doesn't cause an actual error, but leads to confusing and unnecessary log output where operations that are known to fail are visible to the user.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->