### PR TITLE
feat: Support regional credentials

### DIFF
--- a/internal/cmd/run/apitest.go
+++ b/internal/cmd/run/apitest.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/usage"
 
@@ -38,7 +37,7 @@ func runApitest(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 	}
 
 	regio := region.FromString(p.Sauce.Region)
-	creds := credentials.Get()
+	creds := regio.Credentials()
 
 	apitestingClient := http.NewAPITester(regio.APIBaseURL(), creds.Username, creds.AccessKey, apitestingTimeout)
 	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)

--- a/internal/cmd/run/cucumber.go
+++ b/internal/cmd/run/cucumber.go
@@ -7,7 +7,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/ci"
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"github.com/saucelabs/saucectl/internal/config"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/cucumber"
 	"github.com/saucelabs/saucectl/internal/flags"
 	"github.com/saucelabs/saucectl/internal/framework"
@@ -115,7 +114,7 @@ func runCucumber(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 
 	cleanupArtifacts(p.Artifacts)
 
-	creds := credentials.Get()
+	creds := regio.Credentials()
 
 	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
 	restoClient.ArtifactConfig = p.Artifacts.Download

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 
 	"github.com/rs/zerolog/log"
@@ -137,7 +136,7 @@ func runCypress(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 
 	cleanupArtifacts(p.GetArtifactsCfg())
 
-	creds := credentials.Get()
+	creds := regio.Credentials()
 
 	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
 	restoClient.ArtifactConfig = p.GetArtifactsCfg().Download

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 
 	"github.com/rs/zerolog/log"
@@ -137,7 +136,7 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, isCLIDriven bo
 func runEspressoInCloud(p espresso.Project, regio region.Region) (int, error) {
 	log.Info().Msg("Running Espresso in Sauce Labs")
 
-	creds := credentials.Get()
+	creds := regio.Credentials()
 	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
 	restoClient.ArtifactConfig = p.Artifacts.Download
 	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)

--- a/internal/cmd/run/imagerunner.go
+++ b/internal/cmd/run/imagerunner.go
@@ -5,7 +5,6 @@ import (
 
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"github.com/saucelabs/saucectl/internal/config"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/imagerunner"
 	"github.com/saucelabs/saucectl/internal/region"
@@ -66,7 +65,7 @@ func runImageRunner(cmd *cobra.Command) (int, error) {
 
 	cleanupArtifacts(p.Artifacts)
 
-	creds := credentials.Get()
+	creds := regio.Credentials()
 	imageRunnerClient := http.NewImageRunner(regio.APIBaseURL(), creds, imgExecTimeout)
 	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
 

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 
 	"github.com/rs/zerolog/log"
@@ -150,7 +149,7 @@ func runPlaywright(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 
 	cleanupArtifacts(p.Artifacts)
 
-	creds := credentials.Get()
+	creds := regio.Credentials()
 
 	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
 	restoClient.ArtifactConfig = p.Artifacts.Download

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 
 	"github.com/rs/zerolog/log"
@@ -125,7 +124,7 @@ func runReplay(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 func runPuppeteerReplayInSauce(p replay.Project, regio region.Region) (int, error) {
 	log.Info().Msg("Replaying chrome devtools recordings")
 
-	creds := credentials.Get()
+	creds := regio.Credentials()
 	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
 	restoClient.ArtifactConfig = p.Artifacts.Download
 	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 
 	"github.com/rs/zerolog/log"
@@ -172,7 +171,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 
 	cleanupArtifacts(p.Artifacts)
 
-	creds := credentials.Get()
+	creds := regio.Credentials()
 
 	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
 	restoClient.ArtifactConfig = p.Artifacts.Download

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
-	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 
 	"github.com/rs/zerolog/log"
@@ -137,7 +136,7 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, isCLIDriven bool) 
 func runXcuitestInCloud(p xcuitest.Project, regio region.Region) (int, error) {
 	log.Info().Msg("Running XCUITest in Sauce Labs")
 
-	creds := credentials.Get()
+	creds := regio.Credentials()
 
 	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
 	restoClient.ArtifactConfig = p.Artifacts.Download

--- a/internal/region/region.go
+++ b/internal/region/region.go
@@ -180,7 +180,7 @@ func (r Region) WebDriverBaseURL() string {
 
 func (r Region) Credentials() iam.Credentials {
 	meta := lookupMeta(r)
-
+        // check if there are any region specific credentials first
 	if meta.Credentials.IsSet() {
 		return meta.Credentials
 	}

--- a/internal/region/region.go
+++ b/internal/region/region.go
@@ -180,7 +180,7 @@ func (r Region) WebDriverBaseURL() string {
 
 func (r Region) Credentials() iam.Credentials {
 	meta := lookupMeta(r)
-        // check if there are any region specific credentials first
+	// check if there are any region specific credentials first
 	if meta.Credentials.IsSet() {
 		return meta.Credentials
 	}

--- a/internal/region/region_test.go
+++ b/internal/region/region_test.go
@@ -3,9 +3,10 @@ package region
 import (
 	"testing"
 
-	"github.com/saucelabs/saucectl/internal/iam"
 	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
+
+	"github.com/saucelabs/saucectl/internal/iam"
 )
 
 func TestFromString(t *testing.T) {

--- a/internal/region/region_test.go
+++ b/internal/region/region_test.go
@@ -3,6 +3,8 @@ package region
 import (
 	"testing"
 
+	"github.com/saucelabs/saucectl/internal/iam"
+	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 )
 
@@ -44,4 +46,166 @@ func TestString(t *testing.T) {
 	name := "staging"
 	r := FromString(name)
 	assert.Equal(t, name, r.String())
+}
+
+func Test_mergeRegionMetas(t *testing.T) {
+	type args struct {
+		base    regionMeta
+		overlay regionMeta
+	}
+	tests := []struct {
+		name string
+		args args
+		want regionMeta
+	}{
+		{
+			name: "base props get overwritten by overlay",
+			args: args{
+				base: regionMeta{
+					Name:             "Region",
+					APIBaseURL:       "api1",
+					AppBaseURL:       "app1",
+					WebdriverBaseURL: "wd1",
+					Credentials: iam.Credentials{
+						Username:  "user1",
+						AccessKey: "ac1",
+					},
+				},
+				overlay: regionMeta{
+					Name:             "Overlay",
+					APIBaseURL:       "api2",
+					AppBaseURL:       "app2",
+					WebdriverBaseURL: "wd2",
+					Credentials: iam.Credentials{
+						Username:  "user2",
+						AccessKey: "ac2",
+					},
+				},
+			},
+			want: regionMeta{
+				Name:             "Overlay",
+				APIBaseURL:       "api2",
+				AppBaseURL:       "app2",
+				WebdriverBaseURL: "wd2",
+				Credentials: iam.Credentials{
+					Username:  "user2",
+					AccessKey: "ac2",
+				},
+			},
+		},
+		{
+			name: "empty base creds get set by overlay",
+			args: args{
+				base: regionMeta{
+					Name:             "Region",
+					APIBaseURL:       "api1",
+					AppBaseURL:       "app1",
+					WebdriverBaseURL: "wd1",
+				},
+				overlay: regionMeta{
+					Credentials: iam.Credentials{
+						Username:  "user",
+						AccessKey: "ac",
+					},
+				},
+			},
+			want: regionMeta{
+				Name:             "Region",
+				APIBaseURL:       "api1",
+				AppBaseURL:       "app1",
+				WebdriverBaseURL: "wd1",
+				Credentials: iam.Credentials{
+					Username:  "user",
+					AccessKey: "ac",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeRegionMetas(tt.args.base, tt.args.overlay)
+			if tt.want != got {
+				t.Errorf("mergeRegionMetas() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_allRegionMetas(t *testing.T) {
+	type args struct {
+		sauce []regionMeta
+		user  []regionMeta
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[Region]regionMeta
+	}{
+		{
+			name: "user regions appended to sauce regions",
+			args: args{
+				sauce: []regionMeta{
+					{
+						Name: "Staging",
+					},
+				},
+				user: []regionMeta{
+					{
+						Name: "Local",
+					},
+				},
+			},
+			want: map[Region]regionMeta{
+				Region("Staging"): {
+					Name: "Staging",
+				},
+				Region("Local"): {
+					Name: "Local",
+				},
+			},
+		},
+		{
+			name: "user region can overwrite sauce regions",
+			args: args{
+				sauce: []regionMeta{
+					{
+						Name: "staging",
+						Credentials: iam.Credentials{
+							Username:  "default",
+							AccessKey: "default",
+						},
+					},
+				},
+				user: []regionMeta{
+					{
+						Name: "staging",
+						Credentials: iam.Credentials{
+							Username:  "custom",
+							AccessKey: "custom",
+						},
+					},
+				},
+			},
+			want: map[Region]regionMeta{
+				Staging: {
+					Name: Staging.String(),
+					Credentials: iam.Credentials{
+						Username:  "custom",
+						AccessKey: "custom",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allRegionMetas(tt.args.sauce, tt.args.user)
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("allRegionalMetas() = %v, want %v", got, tt.want)
+
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Allow defining credentials for both built-in and custom defined regions.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

* All sauce regions will still default to env vars and `~/.sauce/credentials.yml` by default but can be overridden in `regions.yml` like so:

```yaml
- name: us-west-1
  credentials:
    username: customUser
    accessKey: customKey
```

* Since even sauce regions can be overridden, there is no longer global default credentials. So clients now access credentials from the configured region instead of the `credentials` package.

[DEVX-2637]

[DEVX-2637]: https://saucedev.atlassian.net/browse/DEVX-2637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ