### PR TITLE
fix: app storage filename references for xcuitest simulators

### DIFF
--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -49,7 +49,7 @@ func NormalizeStorageReference(ref string) string {
 	return ref
 }
 
-// Validate validates that the apps is valid (storageID / File / URL).
+// Validate validates that app is valid (storageID / File / URL).
 func Validate(kind, app string, validExt []string) error {
 	if IsStorageReference(app) {
 		return nil

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -36,17 +36,17 @@ func IsStorageReference(link string) bool {
 	return reFileID.MatchString(link) || reFilePattern.MatchString(link)
 }
 
-// StandardizeReferenceLink standardize the provided storageID reference to make it work for VMD and RDC.
-func StandardizeReferenceLink(storageRef string) string {
-	if reFileID.MatchString(storageRef) {
-		if !strings.HasPrefix(storageRef, "storage:") {
-			return fmt.Sprintf("storage:%s", storageRef)
+// NormalizeStorageReference normalizes ref to work across VMD and RDC.
+func NormalizeStorageReference(ref string) string {
+	if reFileID.MatchString(ref) {
+		if !strings.HasPrefix(ref, "storage:") {
+			return fmt.Sprintf("storage:%s", ref)
 		}
-		if strings.HasPrefix(storageRef, "storage://") {
-			return strings.Replace(storageRef, "storage://", "storage:", 1)
+		if strings.HasPrefix(ref, "storage://") {
+			return strings.Replace(ref, "storage://", "storage:", 1)
 		}
 	}
-	return storageRef
+	return ref
 }
 
 // Validate validates that the apps is valid (storageID / File / URL).

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	reFileID            = regexp.MustCompile(`(storage:(//)?)?(?P<fileID>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$`)
-	reFilePattern       = regexp.MustCompile(`^(storage:filename=)(?P<filename>[\S][\S ]+(\.ipa|\.apk))$`)
+	reFilePattern       = regexp.MustCompile(`^(storage:filename=)(?P<filename>[\S][\S ]+(\.ipa|\.apk|\.zip))$`)
 	reHTTPSchemePattern = regexp.MustCompile(`(?i)^https?`)
 )
 

--- a/internal/apps/apps_test.go
+++ b/internal/apps/apps_test.go
@@ -209,7 +209,7 @@ func TestIsStorageReference(t *testing.T) {
 			args: args{
 				link: "storage:filename=dummyfilename.zip",
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "Bad Reference",

--- a/internal/apps/apps_test.go
+++ b/internal/apps/apps_test.go
@@ -257,8 +257,8 @@ func TestStandardizeReferenceLink(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := StandardizeReferenceLink(tt.storageRef); got != tt.want {
-				t.Errorf("StandardizeReferenceLink() = %v, want %v", got, tt.want)
+			if got := NormalizeStorageReference(tt.storageRef); got != tt.want {
+				t.Errorf("NormalizeStorageReference() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -604,7 +604,7 @@ func (r *CloudRunner) uploadProject(filename, description string, pType uploadTy
 	}
 
 	if apps.IsStorageReference(filename) {
-		return apps.StandardizeReferenceLink(filename), nil
+		return apps.NormalizeStorageReference(filename), nil
 	}
 
 	if apps.IsRemote(filename) {


### PR DESCRIPTION
## Proposed changes

Makes app storage references work when using filenames + xcuitest simulators.

Also:
- minor refactor that aligns the lingo between the functions `IsStorageReference` and `NormalizeStorageReference`.