### PR TITLE
chore!: remove deprecated flag tunnel-id

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -106,7 +106,6 @@ func Command() *cobra.Command {
 	sc.StringToStringP("env", "e", "envFlag", map[string]string{}, "Set environment variables, e.g. -e foo=bar. Not supported for RDC or Espresso on virtual devices!")
 	sc.Bool("show-console-log", "showConsoleLog", false, "Shows suites console.log locally. By default console.log is only shown on failures.")
 	sc.Int("ccy", "sauce::concurrency", 2, "Concurrency specifies how many suites are run at the same time.")
-	sc.String("tunnel-id", "sauce::tunnel::id", "", "Sets the sauce-connect tunnel ID to be used for the run.")
 	sc.String("tunnel-name", "sauce::tunnel::name", "", "Sets the sauce-connect tunnel name to be used for the run.")
 	sc.String("tunnel-owner", "sauce::tunnel::owner", "", "Sets the sauce-connect tunnel owner to be used for the run.")
 	sc.String("runner-version", "runnerVersion", "", "Overrides the automatically determined runner version.")
@@ -142,8 +141,8 @@ func Command() *cobra.Command {
 	_ = cmd.PersistentFlags().MarkHidden("runner-version")
 	_ = cmd.PersistentFlags().MarkHidden("experiment")
 
-	// Deprecated flags
-	_ = sc.Fset.MarkDeprecated("tunnel-id", "please use --tunnel-name instead")
+	// Deprecated flags go here
+	// None at the moment.
 
 	sc.BindAll()
 


### PR DESCRIPTION
## Proposed changes

Remove the long since deprecated and unused flag `tunnel-id`.