### PR TITLE
chore: deprecate flag uploadTimeout

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -102,6 +102,7 @@ func Command() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&gFlags.async, "async", false, "Launches tests without waiting for test results")
 	cmd.PersistentFlags().BoolVar(&gFlags.failFast, "fail-fast", false, "Stops suites after the first failure")
 	cmd.PersistentFlags().DurationVar(&gFlags.appStoreTimeout, "uploadTimeout", 5*time.Minute, "Upload timeout that limits how long saucectl will wait for an upload to finish. Supports duration values like '10s' '30m' etc. (default: 5m)")
+	cmd.PersistentFlags().DurationVar(&gFlags.appStoreTimeout, "upload-timeout", 5*time.Minute, "Upload timeout that limits how long saucectl will wait for an upload to finish. Supports duration values like '10s' '30m' etc. (default: 5m)")
 	sc.StringP("region", "r", "sauce::region", "", "The sauce labs region. Options: us-west-1, eu-central-1.")
 	sc.StringToStringP("env", "e", "envFlag", map[string]string{}, "Set environment variables, e.g. -e foo=bar. Not supported for RDC or Espresso on virtual devices!")
 	sc.Bool("show-console-log", "showConsoleLog", false, "Shows suites console.log locally. By default console.log is only shown on failures.")
@@ -144,6 +145,7 @@ func Command() *cobra.Command {
 
 	// Deprecated flags
 	_ = sc.Fset.MarkDeprecated("tunnel-id", "please use --tunnel-name instead")
+	_ = sc.Fset.MarkDeprecated("uploadTimeout", "please use --upload-timeout instead")
 
 	sc.BindAll()
 


### PR DESCRIPTION
## Proposed changes

Deprecate the flag `uploadTimeout` and introduce its replacement `upload-timeout`. The new flag is now consistent with the case we use for other global flags.