### PR TITLE
fix: init region requirement for no-prompt mode

### DIFF
--- a/internal/cmd/ini/cmd.go
+++ b/internal/cmd/ini/cmd.go
@@ -169,6 +169,9 @@ func noPromptMode(cmd *cobra.Command, cfg *initConfig) error {
 	if !creds.IsSet() {
 		return errors.New(msg.EmptyCredentials)
 	}
+	if cfg.region == "" {
+		return errors.New(msg.MissingRegion)
+	}
 
 	ini := newInitializer(stdio, creds, cfg)
 


### PR DESCRIPTION
## Proposed changes

Ensure that the proper error message is returned when the region is not set.

Before:
```
❯ saucectl init playwright --no-prompt
4 errors occured:
- no playwright version specified
- no platform name specified
- no browser name specified
- Get "/v2/testcomposer/frameworks?frameworkName=playwright": unsupported protocol scheme ""
```

After:
```
❯ saucectl init playwright --no-prompt
12:40:58 ERR failed to execute init command error="no sauce region set"
```