### PR TITLE
fix: Fix smart retry in XCUITest simulator test

### DIFF
--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -174,6 +174,7 @@ func runXcuitestInCloud(p xcuitest.Project, regio region.Region) (int, error) {
 			Async:     gFlags.async,
 			FailFast:  gFlags.failFast,
 			Retrier: &retry.JunitRetrier{
+				VDCReader: &restoClient,
 				RDCReader: &rdcClient,
 			},
 		},

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -40,8 +40,8 @@ func (b *JunitRetrier) retryFailedTests(reader job.Reader, jobOpts chan<- job.St
 
 // setClassesToRetry sets the correct filtering flag when retrying.
 // RDC API does not provide different endpoints (or identical values) for Espresso
-// and XCUITest. Thus, we need set the classes at the correct position depending the
-// framework that is being executed.
+// and XCUITest. Thus, we need set the classes at the correct position depending
+// on the framework that is being executed.
 func setClassesToRetry(opt *job.StartOptions, testcases []junit.TestCase) {
 	lg := log.Info().
 		Str("suite", opt.DisplayName).
@@ -53,10 +53,11 @@ func setClassesToRetry(opt *job.StartOptions, testcases []junit.TestCase) {
 
 	if opt.Framework == xcuitest.Kind {
 		tests := getFailedXCUITests(testcases)
+
+		// RDC and VDC API filter use different fields for test filtering.
 		if opt.RealDevice {
 			opt.TestsToRun = tests
 		} else {
-			// Simulator test filter should be set in TestOptions
 			opt.TestOptions["class"] = tests
 		}
 		lg.Msgf(msg.RetryWithTests, tests)

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -92,7 +92,7 @@ func getFailedXCUITests(testCases []junit.TestCase) []string {
 	classes := map[string]bool{}
 	for _, tc := range testCases {
 		if tc.Error != nil || tc.Failure != nil {
-			className := unifiedXCUITestClassName(tc.ClassName)
+			className := normalizeXCUITestClassName(tc.ClassName)
 			if tc.Name != "" {
 				classes[fmt.Sprintf("%s/%s", className, tc.Name)] = true
 			} else {
@@ -103,7 +103,12 @@ func getFailedXCUITests(testCases []junit.TestCase) []string {
 	return maps.Keys(classes)
 }
 
-func unifiedXCUITestClassName(name string) string {
+// normalizeXCUITestClassName normalizes the class name of an XCUITest. The
+// class name within the platform generated JUnit XML file can be dot-separated,
+// but our platform API expects a slash-separated class name. The platform is
+// unfortunately not consistent in this regard and is not in full control of the
+// generated JUnit XML file, hence we reconcile the two here.
+func normalizeXCUITestClassName(name string) string {
 	items := strings.Split(name, ".")
 	if len(items) == 1 {
 		return name

--- a/internal/saucecloud/retry/junitretrier_test.go
+++ b/internal/saucecloud/retry/junitretrier_test.go
@@ -373,3 +373,35 @@ func TestAppsRetrier_Retry(t *testing.T) {
 		})
 	}
 }
+
+func Test_normalizeXCUITestClassName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "needs normalization",
+			args: args{name: "DemoAppTests.ClassyTest"},
+			want: "DemoAppTests/ClassyTest",
+		},
+		{
+			name: "already normalized",
+			args: args{name: "DemoAppTests/ClassyTest"},
+			want: "DemoAppTests/ClassyTest",
+		},
+		{
+			name: "nothing to normalize",
+			args: args{name: "DemoAppTests"},
+			want: "DemoAppTests",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, normalizeXCUITestClassName(tt.args.name), "normalizeXCUITestClassName(%v)", tt.args.name)
+		})
+	}
+}

--- a/internal/saucecloud/retry/junitretrier_test.go
+++ b/internal/saucecloud/retry/junitretrier_test.go
@@ -185,6 +185,7 @@ func TestAppsRetrier_Retry(t *testing.T) {
 					SmartRetry: job.SmartRetry{
 						FailedOnly: true,
 					},
+					RealDevice: true,
 				},
 				previous: job.Job{
 					ID:    "fake-job-id",
@@ -194,10 +195,12 @@ func TestAppsRetrier_Retry(t *testing.T) {
 			expected: job.StartOptions{
 				Framework:   xcuitest.Kind,
 				DisplayName: "Dummy Test",
-				TestsToRun:  []string{"Demo.Class1/demoTest"},
+				TestOptions: map[string]interface{}{},
+				TestsToRun:  []string{"Demo/Class1/demoTest"},
 				SmartRetry: job.SmartRetry{
 					FailedOnly: true,
 				},
+				RealDevice: true,
 			},
 		},
 		{


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
In the current JUnit report, the `classname` follows the `class.testMethod` pattern. However, this format is not suitable for filtering out failed tests in smart retry tests. This PR is proposed to update the `classname` to the `class/testMethod` format.

Initial test: https://app.saucelabs.com/tests/fb0d832bc6d644c58beebe1415d229c5#1
Retried test: https://app.saucelabs.com/tests/b6d20f0fd20345bea7eb463d1e7f105c#1

Verified, real device test remains unaffected.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->