### PR TITLE
fix!: correctly scope flag

### DIFF
--- a/internal/cmd/imagerunner/cmd.go
+++ b/internal/cmd/imagerunner/cmd.go
@@ -14,7 +14,6 @@ import (
 
 var (
 	imagerunnerClient http.ImageRunner
-	liveLogs          bool
 )
 
 func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
@@ -52,10 +51,9 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 
 	flags := cmd.PersistentFlags()
 	flags.StringVarP(&regio, "region", "r", "us-west-1", "The Sauce Labs region. Options: us-west-1, eu-central-1.")
-	flags.BoolVarP(&liveLogs, "live-logs", "", false, "Retrieve logs from temporary livelogs storage.")
 
 	cmd.AddCommand(
-		LogsCommand(&liveLogs),
+		LogsCommand(),
 		ArtifactsCommand(),
 	)
 	return cmd


### PR DESCRIPTION
## Proposed changes

The `--live-logs` flag that was intended for `saucectl imagerunner logs --live-logs` was incorrectly scoped as a global flag and thus available on all `saucectl imagerunner` subcommands.

Additionally, the flag was renamed (breaking change) to remove stutter `logs --live-logs` vs `logs --live`.

PS: This does not affect `saucectl run --live-logs` and as such, a relatively small breaking change.