### PR TITLE
refactor: improve imagerunner cloudevent handling

### DIFF
--- a/internal/cmd/docker/cmd.go
+++ b/internal/cmd/docker/cmd.go
@@ -36,7 +36,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 			creds := reg.Credentials()
 			url := reg.APIBaseURL()
 
-			asyncEventManager, err := imagerunner.NewAsyncEventManager()
+			asyncEventManager, err := imagerunner.NewAsyncEventMgr()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/imagerunner/cmd.go
+++ b/internal/cmd/imagerunner/cmd.go
@@ -38,7 +38,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 			creds := credentials.Get()
 			url := region.FromString(regio).APIBaseURL()
 
-			asyncEventManager, err := imagerunner.NewAsyncEventManager()
+			asyncEventManager, err := imagerunner.NewAsyncEventMgr()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/imagerunner/logs.go
+++ b/internal/cmd/imagerunner/logs.go
@@ -58,7 +58,7 @@ func LogsCommand() *cobra.Command {
 
 func exec(runID string, liveLogs bool) error {
 	if liveLogs {
-		err := imagerunnerClient.FetchLiveLogs(context.Background(), runID)
+		err := imagerunnerClient.GetLiveLogs(context.Background(), runID)
 		if err != nil {
 			if errors.Is(err, imgrunner.ErrResourceNotFound) {
 				return fmt.Errorf("could not find log URL for run with ID (%s): %w", runID, err)

--- a/internal/cmd/imagerunner/logs.go
+++ b/internal/cmd/imagerunner/logs.go
@@ -63,17 +63,18 @@ func exec(runID string, liveLogs bool) error {
 			if errors.Is(err, imgrunner.ErrResourceNotFound) {
 				return fmt.Errorf("could not find log URL for run with ID (%s): %w", runID, err)
 			}
-			return err
 		}
-	} else {
-		log, err := imagerunnerClient.GetLogs(context.Background(), runID)
-		if err != nil {
-			if errors.Is(err, imgrunner.ErrResourceNotFound) {
-				return fmt.Errorf("could not find log URL for run with ID (%s): %w", runID, err)
-			}
-			return err
-		}
-		fmt.Println(log)
+		return err
 	}
+
+	log, err := imagerunnerClient.GetLogs(context.Background(), runID)
+	if err != nil {
+		if errors.Is(err, imgrunner.ErrResourceNotFound) {
+			return fmt.Errorf("could not find log URL for run with ID (%s): %w", runID, err)
+		}
+		return err
+	}
+	fmt.Println(log)
+
 	return nil
 }

--- a/internal/cmd/imagerunner/logs.go
+++ b/internal/cmd/imagerunner/logs.go
@@ -55,20 +55,21 @@ func exec(runID string, liveLogs bool) error {
 	if liveLogs {
 		err := imagerunnerClient.FetchLiveLogs(context.Background(), runID)
 		if err != nil {
-			if err == imgrunner.ErrResourceNotFound {
+			if errors.Is(err, imgrunner.ErrResourceNotFound) {
 				return fmt.Errorf("could not find log URL for run with ID (%s): %w", runID, err)
 			}
-			return err
 		}
-	} else {
-		log, err := imagerunnerClient.GetLogs(context.Background(), runID)
-		if err != nil {
-			if err == imgrunner.ErrResourceNotFound {
-				return fmt.Errorf("could not find log URL for run with ID (%s): %w", runID, err)
-			}
-			return err
-		}
-		fmt.Println(log)
+		return err
 	}
+
+	log, err := imagerunnerClient.GetLogs(context.Background(), runID)
+	if err != nil {
+		if errors.Is(err, imgrunner.ErrResourceNotFound) {
+			return fmt.Errorf("could not find log URL for run with ID (%s): %w", runID, err)
+		}
+		return err
+	}
+	fmt.Println(log)
+
 	return nil
 }

--- a/internal/cmd/run/imagerunner.go
+++ b/internal/cmd/run/imagerunner.go
@@ -67,7 +67,7 @@ func runImageRunner(cmd *cobra.Command) (int, error) {
 
 	creds := regio.Credentials()
 
-	asyncEventManager, err := imagerunner.NewAsyncEventManager()
+	asyncEventManager, err := imagerunner.NewAsyncEventMgr()
 	if err != nil {
 		return 1, err
 	}

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -316,7 +316,7 @@ func (c *ImageRunner) StreamLiveLogs(ctx context.Context, id string, wait bool) 
 			if errors.Is(err, context.Canceled) || errors.As(err, &fatalErr) {
 				return err
 			}
-			log.Warn().Err(err).Msgf("Log streaming issue. Retrying in 3 seconds...")
+			log.Warn().Err(err).Msg("Log streaming issue. Retrying in 3 seconds...")
 			time.Sleep(3 * time.Second)
 			continue
 		}

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -242,7 +242,7 @@ func (c *ImageRunner) getWebSocketURL() (string, error) {
 	return wsURL.String(), nil
 }
 
-func (c *ImageRunner) OpenAsyncEventsWebSocket(id string, lastseq string, nowait bool) (*websocket.Conn, error) {
+func (c *ImageRunner) OpenAsyncEventsWebSocket(id string, lastSeq string, nowait bool) (*websocket.Conn, error) {
 	// dummy request so that we build basic auth header consistently
 	dummyURL := fmt.Sprintf("%s/v1alpha1/hosted/async/image/runners/%s/events", c.URL, id)
 	req, err := http.NewRequest("GET", dummyURL, nil)
@@ -258,8 +258,8 @@ func (c *ImageRunner) OpenAsyncEventsWebSocket(id string, lastseq string, nowait
 
 	// build query string
 	var queryParts []string
-	if lastseq != "" {
-		queryParts = append(queryParts, fmt.Sprintf("lastseq=%s", lastseq))
+	if lastSeq != "" {
+		queryParts = append(queryParts, fmt.Sprintf("lastseq=%s", lastSeq))
 	}
 	if nowait {
 		queryParts = append(queryParts, "nowait=true")
@@ -291,8 +291,8 @@ func (c *ImageRunner) OpenAsyncEventsWebSocket(id string, lastseq string, nowait
 	return ws, nil
 }
 
-func (c *ImageRunner) OpenAsyncEventsTransport(id string, lastseq string, nowait bool) (imagerunner.AsyncEventTransporter, error) {
-	ws, err := c.OpenAsyncEventsWebSocket(id, lastseq, nowait)
+func (c *ImageRunner) OpenAsyncEventsTransport(id string, lastSeq string, nowait bool) (imagerunner.AsyncEventTransporter, error) {
+	ws, err := c.OpenAsyncEventsWebSocket(id, lastSeq, nowait)
 	if err != nil {
 		var fatalErr imagerunner.AsyncEventFatalError
 		if errors.As(err, &fatalErr) {

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -371,18 +371,18 @@ func (c *ImageRunner) handleAsyncEventsOneshot(ctx context.Context, id string, l
 		case <-ctx.Done():
 			return false, lastseq, ctx.Err()
 		default:
-			readMessage, err := transport.ReadMessage()
+			msg, err := transport.ReadMessage()
 			if err != nil {
 				if nowait && strings.Contains(err.Error(), "close") {
 					return false, lastseq, nil
 				}
 				return true, lastseq, err
 			}
-			if readMessage == "" {
+			if msg == "" {
 				return true, lastseq, errors.New("empty message")
 			}
 
-			event, err := c.AsyncEventManager.ParseEvent(readMessage)
+			event, err := c.AsyncEventManager.ParseEvent(msg)
 			if err != nil {
 				return true, lastseq, err
 			}

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -395,7 +395,6 @@ func (c *ImageRunner) handleAsyncEventsOneshot(ctx context.Context, id string, l
 				c.eventLogger.Info().Msgf("%s %s",
 					color.New(color.FgCyan).Sprint(event.Data["containerName"]),
 					event.Data["line"])
-				c.AsyncEventManager.TrackLog()
 			default:
 				err := errors.New("unknown event type")
 				log.Err(err).Msgf("unknown even type: %s", event.Type)

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -305,7 +305,7 @@ func (c *ImageRunner) OpenAsyncEventsTransport(id string, lastSeq string, wait b
 	return imagerunner.NewWebSocketAsyncEventTransport(ws), nil
 }
 
-func (c *ImageRunner) HandleAsyncEvents(ctx context.Context, id string, wait bool) error {
+func (c *ImageRunner) StreamLogs(ctx context.Context, id string, wait bool) error {
 	var lastSeq string
 	var hasMoreLines bool
 	var err error
@@ -389,7 +389,7 @@ func (c *ImageRunner) processAsyncEventMessages(ctx context.Context, transport i
 }
 
 func (c *ImageRunner) FetchLiveLogs(ctx context.Context, id string) error {
-	return c.HandleAsyncEvents(ctx, id, false)
+	return c.StreamLogs(ctx, id, false)
 }
 
 func (c *ImageRunner) doGetStr(ctx context.Context, url string) (string, error) {

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -403,8 +403,7 @@ func (c *ImageRunner) handleAsyncEvents(ctx context.Context, id string, lastseq 
 }
 
 func (c *ImageRunner) FetchLiveLogs(ctx context.Context, id string) error {
-	err := c.HandleAsyncEvents(ctx, id, true)
-	return err
+	return c.HandleAsyncEvents(ctx, id, true)
 }
 
 func (c *ImageRunner) doGetStr(ctx context.Context, url string) (string, error) {

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -316,7 +316,7 @@ func (c *ImageRunner) HandleAsyncEvents(ctx context.Context, id string, nowait b
 			log.Info().Msgf("Could not setup Log streaming after %d attempts, disabling it.", maxSetupErrors)
 			return imagerunner.AsyncEventSetupError{}
 		}
-		hasMoreLines, lastseq, err = c.handleAsyncEventsOneshot(ctx, id, lastseq, nowait)
+		hasMoreLines, lastseq, err = c.handleAsyncEvents(ctx, id, lastseq, nowait)
 		if errors.Is(err, context.Canceled) {
 			return err
 		}
@@ -337,7 +337,7 @@ func (c *ImageRunner) HandleAsyncEvents(ctx context.Context, id string, nowait b
 	}
 }
 
-func (c *ImageRunner) handleAsyncEventsOneshot(ctx context.Context, id string, lastseq string, nowait bool) (bool, string, error) {
+func (c *ImageRunner) handleAsyncEvents(ctx context.Context, id string, lastseq string, nowait bool) (bool, string, error) {
 	transport, err := c.OpenAsyncEventsTransport(id, lastseq, nowait)
 	if err != nil {
 		return true, lastseq, err

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -26,7 +26,7 @@ type ImageRunner struct {
 	Client            *retryablehttp.Client
 	URL               string
 	Creds             iam.Credentials
-	AsyncEventManager imagerunner.AsyncEventManagerI
+	AsyncEventManager imagerunner.AsyncEventManager
 	eventLogger       zerolog.Logger
 }
 
@@ -37,7 +37,7 @@ type AuthToken struct {
 }
 
 func NewImageRunner(url string, creds iam.Credentials, timeout time.Duration,
-	asyncEventManager imagerunner.AsyncEventManagerI) ImageRunner {
+	asyncEventManager imagerunner.AsyncEventManager) ImageRunner {
 	eventLogger := zerolog.New(zerolog.ConsoleWriter{
 		Out: os.Stdout,
 		PartsOrder: []string{

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -305,7 +305,7 @@ func (c *ImageRunner) OpenAsyncEventsTransport(id string, lastSeq string, wait b
 	return imagerunner.NewWebSocketAsyncEventTransport(ws), nil
 }
 
-func (c *ImageRunner) StreamLogs(ctx context.Context, id string, wait bool) error {
+func (c *ImageRunner) StreamLiveLogs(ctx context.Context, id string, wait bool) error {
 	var lastSeq string
 	var hasMoreLines bool
 	var err error
@@ -383,8 +383,8 @@ func (c *ImageRunner) handleAsyncEvents(ctx context.Context, id string, lastSeq 
 	}
 }
 
-func (c *ImageRunner) FetchLiveLogs(ctx context.Context, id string) error {
-	return c.StreamLogs(ctx, id, false)
+func (c *ImageRunner) GetLiveLogs(ctx context.Context, id string) error {
+	return c.StreamLiveLogs(ctx, id, false)
 }
 
 func (c *ImageRunner) doGetStr(ctx context.Context, url string) (string, error) {

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -313,7 +313,7 @@ func (c *ImageRunner) HandleAsyncEvents(ctx context.Context, id string, nowait b
 	maxSetupErrors := 3
 	for {
 		if setupErrorCount >= maxSetupErrors {
-			log.Info().Msgf("Could not setup Log streaming after %d attempts, disabling it.", maxSetupErrors)
+			log.Warn().Msgf("Could not setup Log streaming after %d attempts, disabling it.", maxSetupErrors)
 			return imagerunner.AsyncEventSetupError{}
 		}
 		hasMoreLines, lastseq, err = c.handleAsyncEvents(ctx, id, lastseq, nowait)
@@ -332,7 +332,7 @@ func (c *ImageRunner) HandleAsyncEvents(ctx context.Context, id string, nowait b
 		} else {
 			setupErrorCount = 0
 		}
-		log.Info().Err(err).Msgf("Log streaming issue. Retrying in %s...", delay)
+		log.Warn().Err(err).Msgf("Log streaming issue. Retrying in %s...", delay)
 		time.Sleep(delay)
 	}
 }

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -242,7 +242,7 @@ func (c *ImageRunner) getWebSocketURL() (string, error) {
 	return wsURL.String(), nil
 }
 
-func (c *ImageRunner) OpenAsyncEventsWebsocket(id string, lastseq string, nowait bool) (*websocket.Conn, error) {
+func (c *ImageRunner) OpenAsyncEventsWebSocket(id string, lastseq string, nowait bool) (*websocket.Conn, error) {
 	// dummy request so that we build basic auth header consistently
 	dummyURL := fmt.Sprintf("%s/v1alpha1/hosted/async/image/runners/%s/events", c.URL, id)
 	req, err := http.NewRequest("GET", dummyURL, nil)
@@ -292,7 +292,7 @@ func (c *ImageRunner) OpenAsyncEventsWebsocket(id string, lastseq string, nowait
 }
 
 func (c *ImageRunner) OpenAsyncEventsTransport(id string, lastseq string, nowait bool) (imagerunner.AsyncEventTransportI, error) {
-	ws, err := c.OpenAsyncEventsWebsocket(id, lastseq, nowait)
+	ws, err := c.OpenAsyncEventsWebSocket(id, lastseq, nowait)
 	if err != nil {
 		if _, ok := err.(imagerunner.AsyncEventFatalError); ok {
 			return nil, err
@@ -301,7 +301,7 @@ func (c *ImageRunner) OpenAsyncEventsTransport(id string, lastseq string, nowait
 			Err: err,
 		}
 	}
-	return imagerunner.NewWebsocketAsyncEventTransport(ws), nil
+	return imagerunner.NewWebSocketAsyncEventTransport(ws), nil
 }
 
 func (c *ImageRunner) HandleAsyncEvents(ctx context.Context, id string, nowait bool) error {

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -291,7 +291,7 @@ func (c *ImageRunner) OpenAsyncEventsWebSocket(id string, lastseq string, nowait
 	return ws, nil
 }
 
-func (c *ImageRunner) OpenAsyncEventsTransport(id string, lastseq string, nowait bool) (imagerunner.AsyncEventTransportI, error) {
+func (c *ImageRunner) OpenAsyncEventsTransport(id string, lastseq string, nowait bool) (imagerunner.AsyncEventTransporter, error) {
 	ws, err := c.OpenAsyncEventsWebSocket(id, lastseq, nowait)
 	if err != nil {
 		if _, ok := err.(imagerunner.AsyncEventFatalError); ok {

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -225,8 +225,7 @@ func (c *ImageRunner) GetLogs(ctx context.Context, id string) (string, error) {
 	return c.doGetStr(ctx, urlResponse.URL)
 }
 
-func (c *ImageRunner) getWebsocketURL() (string, error) {
-
+func (c *ImageRunner) getWebSocketURL() (string, error) {
 	wsURL, err := url.Parse(c.URL)
 	if err != nil {
 		return "", err
@@ -252,7 +251,7 @@ func (c *ImageRunner) OpenAsyncEventsWebsocket(ctx context.Context, id string, l
 	}
 	req.SetBasicAuth(c.Creds.Username, c.Creds.AccessKey)
 
-	websocketURL, err := c.getWebsocketURL()
+	websocketURL, err := c.getWebSocketURL()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -396,8 +396,7 @@ func (c *ImageRunner) handleAsyncEventsOneshot(ctx context.Context, id string, l
 					color.New(color.FgCyan).Sprint(event.Data["containerName"]),
 					event.Data["line"])
 			default:
-				err := errors.New("unknown event type")
-				log.Err(err).Msgf("unknown even type: %s", event.Type)
+				log.Error().Msgf("unknown event type: %s", event.Type)
 			}
 		}
 	}

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -324,7 +324,7 @@ func (c *ImageRunner) StreamLiveLogs(ctx context.Context, id string, wait bool) 
 			return nil
 		}
 	}
-	log.Warn().Msgf("Could not setup Log streaming after 3 attempts, disabling it.")
+	log.Warn().Msg("Could not setup Log streaming after 3 attempts, disabling it.")
 	return imagerunner.AsyncEventSetupError{}
 }
 

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -258,7 +258,7 @@ func (c *ImageRunner) OpenAsyncEventsWebsocket(ctx context.Context, id string, l
 	}
 
 	// build query string
-	queryParts := []string{}
+	var queryParts []string
 	if lastseq != "" {
 		queryParts = append(queryParts, fmt.Sprintf("lastseq=%s", lastseq))
 	}

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -294,7 +294,8 @@ func (c *ImageRunner) OpenAsyncEventsWebSocket(id string, lastseq string, nowait
 func (c *ImageRunner) OpenAsyncEventsTransport(id string, lastseq string, nowait bool) (imagerunner.AsyncEventTransporter, error) {
 	ws, err := c.OpenAsyncEventsWebSocket(id, lastseq, nowait)
 	if err != nil {
-		if _, ok := err.(imagerunner.AsyncEventFatalError); ok {
+		var fatalErr imagerunner.AsyncEventFatalError
+		if errors.As(err, &fatalErr) {
 			return nil, err
 		}
 		return nil, imagerunner.AsyncEventSetupError{

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -328,6 +328,9 @@ func (c *ImageRunner) StreamLogs(ctx context.Context, id string, wait bool) erro
 	return imagerunner.AsyncEventSetupError{}
 }
 
+// handleAsyncEvents manages the process of handling asynchronous events.
+// It returns a boolean indicating whether there are more lines to process,
+// the last sequence string, and an error if one occurred.
 func (c *ImageRunner) handleAsyncEvents(ctx context.Context, id string, lastSeq string, wait bool) (bool, string, error) {
 	transport, err := c.OpenAsyncEventsTransport(id, lastSeq, wait)
 	if err != nil {
@@ -335,14 +338,6 @@ func (c *ImageRunner) handleAsyncEvents(ctx context.Context, id string, lastSeq 
 	}
 	defer transport.Close()
 
-	return c.processAsyncEventMessages(ctx, transport, lastSeq, wait)
-}
-
-// processAsyncEventMessages reads all messages from the transport and logs them
-// out. If the context is canceled, the method returns immediately. If nowait is
-// true, the method returns when the transport is closed. Otherwise, the method
-// returns when the transport is closed and all messages have been read.
-func (c *ImageRunner) processAsyncEventMessages(ctx context.Context, transport imagerunner.AsyncEventTransporter, lastSeq string, wait bool) (bool, string, error) {
 	var initialPingProcessed bool
 	for {
 		select {

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -338,10 +338,9 @@ func (c *ImageRunner) handleAsyncEvents(ctx context.Context, id string, lastSeq 
 }
 
 // processAsyncEventMessages reads all messages from the transport and logs them
-// to stdout. If the context is canceled, the method returns immediately.
-// If nowait is true, the method returns when the transport is closed.
-// Otherwise, the method returns when the transport is closed and all messages
-// have been read.
+// out. If the context is canceled, the method returns immediately. If nowait is
+// true, the method returns when the transport is closed. Otherwise, the method
+// returns when the transport is closed and all messages have been read.
 func (c *ImageRunner) processAsyncEventMessages(ctx context.Context, transport imagerunner.AsyncEventTransporter, lastSeq string, nowait bool) (bool, string, error) {
 	var initialPingProcessed bool
 	for {

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -242,7 +242,7 @@ func (c *ImageRunner) getWebSocketURL() (string, error) {
 	return wsURL.String(), nil
 }
 
-func (c *ImageRunner) OpenAsyncEventsWebsocket(ctx context.Context, id string, lastseq string, nowait bool) (*websocket.Conn, error) {
+func (c *ImageRunner) OpenAsyncEventsWebsocket(id string, lastseq string, nowait bool) (*websocket.Conn, error) {
 	// dummy request so that we build basic auth header consistently
 	dummyURL := fmt.Sprintf("%s/v1alpha1/hosted/async/image/runners/%s/events", c.URL, id)
 	req, err := http.NewRequest("GET", dummyURL, nil)
@@ -291,8 +291,8 @@ func (c *ImageRunner) OpenAsyncEventsWebsocket(ctx context.Context, id string, l
 	return ws, nil
 }
 
-func (c *ImageRunner) OpenAsyncEventsTransport(ctx context.Context, id string, lastseq string, nowait bool) (imagerunner.AsyncEventTransportI, error) {
-	ws, err := c.OpenAsyncEventsWebsocket(ctx, id, lastseq, nowait)
+func (c *ImageRunner) OpenAsyncEventsTransport(id string, lastseq string, nowait bool) (imagerunner.AsyncEventTransportI, error) {
+	ws, err := c.OpenAsyncEventsWebsocket(id, lastseq, nowait)
 	if err != nil {
 		if _, ok := err.(imagerunner.AsyncEventFatalError); ok {
 			return nil, err
@@ -338,7 +338,7 @@ func (c *ImageRunner) HandleAsyncEvents(ctx context.Context, id string, nowait b
 }
 
 func (c *ImageRunner) handleAsyncEventsOneshot(ctx context.Context, id string, lastseq string, nowait bool) (bool, string, error) {
-	transport, err := c.OpenAsyncEventsTransport(ctx, id, lastseq, nowait)
+	transport, err := c.OpenAsyncEventsTransport(id, lastseq, nowait)
 	if err != nil {
 		return true, lastseq, err
 	}

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -334,7 +334,7 @@ func (c *ImageRunner) handleAsyncEvents(ctx context.Context, id string, lastSeq 
 	}
 	defer transport.Close()
 
-	// the first message is expected to be a ping
+	// Fhe first message is expected to be a ping, though more pings may follow.
 	if err := c.processFirstMessage(transport); err != nil {
 		return true, lastSeq, err
 	}
@@ -364,6 +364,11 @@ func (c *ImageRunner) processFirstMessage(transport imagerunner.AsyncEventTransp
 	return nil
 }
 
+// processRemainingMessages reads all messages from the transport and logs them
+// to stdout. If the context is canceled, the method returns immediately.
+// If nowait is true, the method returns when the transport is closed.
+// Otherwise, the method returns when the transport is closed and all messages
+// have been read.
 func (c *ImageRunner) processRemainingMessages(ctx context.Context, transport imagerunner.AsyncEventTransporter, lastSeq string, nowait bool) (bool, string, error) {
 	for {
 		select {

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -245,7 +245,7 @@ func (c *ImageRunner) getWebSocketURL() (string, error) {
 func (c *ImageRunner) OpenAsyncEventsWebSocket(id string, lastSeq string, wait bool) (*websocket.Conn, error) {
 	// dummy request so that we build basic auth header consistently
 	dummyURL := fmt.Sprintf("%s/v1alpha1/hosted/async/image/runners/%s/events", c.URL, id)
-	req, err := http.NewRequest("GET", dummyURL, nil)
+	req, err := http.NewRequest(http.MethodGet, dummyURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/imagerunner/async.go
+++ b/internal/imagerunner/async.go
@@ -69,12 +69,12 @@ type AsyncEventManager interface {
 }
 
 type AsyncEventMgr struct {
-	logTimestamps time.Time
+	lastLogTime time.Time
 }
 
 func NewAsyncEventMgr() (*AsyncEventMgr, error) {
 	asyncEventManager := AsyncEventMgr{
-		logTimestamps: time.Now(),
+		lastLogTime: time.Now(),
 	}
 
 	return &asyncEventManager, nil
@@ -119,9 +119,9 @@ func (a *AsyncEventMgr) ParseEvent(event string) (*AsyncEvent, error) {
 }
 
 func (a *AsyncEventMgr) TrackLog() {
-	a.logTimestamps = time.Now()
+	a.lastLogTime = time.Now()
 }
 
 func (a *AsyncEventMgr) IsLogIdle() bool {
-	return time.Since(a.logTimestamps) > 30*time.Second
+	return time.Since(a.lastLogTime) > 30*time.Second
 }

--- a/internal/imagerunner/async.go
+++ b/internal/imagerunner/async.go
@@ -17,7 +17,7 @@ type AsyncEvent struct {
 	Data         map[string]string
 }
 
-type AsyncEventTransportI interface {
+type AsyncEventTransporter interface {
 	ReadMessage() (string, error)
 	Close() error
 }

--- a/internal/imagerunner/async.go
+++ b/internal/imagerunner/async.go
@@ -62,18 +62,18 @@ func (aet *SseAsyncEventTransport) Close() error {
 	return aet.httpResponse.Body.Close()
 }
 
-type AsyncEventManagerI interface {
+type AsyncEventManager interface {
 	ParseEvent(event string) (*AsyncEvent, error)
 	TrackLog()
 	IsLogIdle() bool
 }
 
-type AsyncEventManager struct {
+type AsyncEventMgr struct {
 	logTimestamps time.Time
 }
 
-func NewAsyncEventManager() (*AsyncEventManager, error) {
-	asyncEventManager := AsyncEventManager{
+func NewAsyncEventMgr() (*AsyncEventMgr, error) {
+	asyncEventManager := AsyncEventMgr{
 		logTimestamps: time.Now(),
 	}
 
@@ -90,7 +90,7 @@ func parseLineSequence(cloudEvent *cloudevents.Event) (string, error) {
 	return lineseq, nil
 }
 
-func (a *AsyncEventManager) ParseEvent(event string) (*AsyncEvent, error) {
+func (a *AsyncEventMgr) ParseEvent(event string) (*AsyncEvent, error) {
 	readEvent := cloudevents.NewEvent()
 	err := json.Unmarshal([]byte(event), &readEvent)
 	if err != nil {
@@ -118,10 +118,10 @@ func (a *AsyncEventManager) ParseEvent(event string) (*AsyncEvent, error) {
 	return &asyncEvent, nil
 }
 
-func (a *AsyncEventManager) TrackLog() {
+func (a *AsyncEventMgr) TrackLog() {
 	a.logTimestamps = time.Now()
 }
 
-func (a *AsyncEventManager) IsLogIdle() bool {
+func (a *AsyncEventMgr) IsLogIdle() bool {
 	return time.Since(a.logTimestamps) > 30*time.Second
 }

--- a/internal/imagerunner/async.go
+++ b/internal/imagerunner/async.go
@@ -1,10 +1,8 @@
 package imagerunner
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -39,27 +37,6 @@ func (aet *WebSocketAsyncEventTransport) ReadMessage() (string, error) {
 
 func (aet *WebSocketAsyncEventTransport) Close() error {
 	return aet.ws.Close()
-}
-
-type SseAsyncEventTransport struct {
-	httpResponse *http.Response
-	scanner      *bufio.Scanner
-}
-
-func (aet *SseAsyncEventTransport) ReadMessage() (string, error) {
-	if aet.scanner.Scan() {
-		msg := aet.scanner.Bytes()
-		return string(msg), nil
-	}
-	err := aet.scanner.Err()
-	if err == nil {
-		err = fmt.Errorf("no more messages")
-	}
-	return "", err
-}
-
-func (aet *SseAsyncEventTransport) Close() error {
-	return aet.httpResponse.Body.Close()
 }
 
 type AsyncEventManager interface {

--- a/internal/imagerunner/async.go
+++ b/internal/imagerunner/async.go
@@ -46,15 +46,6 @@ type SseAsyncEventTransport struct {
 	scanner      *bufio.Scanner
 }
 
-func NewSseAsyncEventTransport(httpResponse *http.Response) *SseAsyncEventTransport {
-	scanner := bufio.NewScanner(httpResponse.Body)
-	scanner.Split(bufio.ScanLines)
-	return &SseAsyncEventTransport{
-		httpResponse: httpResponse,
-		scanner:      scanner,
-	}
-}
-
 func (aet *SseAsyncEventTransport) ReadMessage() (string, error) {
 	if aet.scanner.Scan() {
 		msg := aet.scanner.Bytes()

--- a/internal/imagerunner/async.go
+++ b/internal/imagerunner/async.go
@@ -64,7 +64,6 @@ func (aet *SseAsyncEventTransport) Close() error {
 
 type AsyncEventManager interface {
 	ParseEvent(event string) (*AsyncEvent, error)
-	TrackLog()
 	IsLogIdle() bool
 }
 
@@ -113,13 +112,10 @@ func (a *AsyncEventMgr) ParseEvent(event string) (*AsyncEvent, error) {
 		if err != nil {
 			return nil, err
 		}
+		a.lastLogTime = time.Now()
 	}
 
 	return &asyncEvent, nil
-}
-
-func (a *AsyncEventMgr) TrackLog() {
-	a.lastLogTime = time.Now()
 }
 
 func (a *AsyncEventMgr) IsLogIdle() bool {

--- a/internal/imagerunner/async.go
+++ b/internal/imagerunner/async.go
@@ -22,22 +22,22 @@ type AsyncEventTransportI interface {
 	Close() error
 }
 
-type WebsocketAsyncEventTransport struct {
+type WebSocketAsyncEventTransport struct {
 	ws *websocket.Conn
 }
 
-func NewWebsocketAsyncEventTransport(ws *websocket.Conn) *WebsocketAsyncEventTransport {
-	return &WebsocketAsyncEventTransport{
+func NewWebSocketAsyncEventTransport(ws *websocket.Conn) *WebSocketAsyncEventTransport {
+	return &WebSocketAsyncEventTransport{
 		ws: ws,
 	}
 }
 
-func (aet *WebsocketAsyncEventTransport) ReadMessage() (string, error) {
+func (aet *WebSocketAsyncEventTransport) ReadMessage() (string, error) {
 	_, msg, err := aet.ws.ReadMessage()
 	return string(msg), err
 }
 
-func (aet *WebsocketAsyncEventTransport) Close() error {
+func (aet *WebSocketAsyncEventTransport) Close() error {
 	return aet.ws.Close()
 }
 

--- a/internal/imagerunner/errors.go
+++ b/internal/imagerunner/errors.go
@@ -2,6 +2,10 @@ package imagerunner
 
 import "fmt"
 
+// AsyncEventSetupError represents an error that occurs during the setup of the
+// asynchronous event handling process.
+// This error indicates that the setup process failed and may need to be retried
+// or debugged.
 type AsyncEventSetupError struct {
 	Err error
 }
@@ -10,6 +14,9 @@ func (e AsyncEventSetupError) Error() string {
 	return fmt.Sprintf("streaming setup failed with: %v", e.Err)
 }
 
+// AsyncEventFatalError represents an error that occurs during the asynchronous
+// event handling process.
+// This error is considered fatal, meaning it cannot be recovered from.
 type AsyncEventFatalError struct {
 	Err error
 }

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -324,7 +324,7 @@ func (r *ImgRunner) pollLiveLogs(ctx context.Context, runner imagerunner.Runner)
 		if err == nil {
 			return true
 		}
-		if !errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.Canceled) {
 			return true
 		}
 		if strings.Contains(err.Error(), "websocket: close") {

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -31,7 +31,8 @@ type ImageRunner interface {
 	StopRun(ctx context.Context, id string) error
 	DownloadArtifacts(ctx context.Context, id string) (io.ReadCloser, error)
 	GetLogs(ctx context.Context, id string) (string, error)
-	StreamLogs(ctx context.Context, id string, wait bool) error
+	StreamLiveLogs(ctx context.Context, id string, wait bool) error
+	GetLiveLogs(ctx context.Context, id string) error
 }
 
 type SuiteTimeoutError struct {
@@ -333,7 +334,7 @@ func (r *ImgRunner) pollLiveLogs(ctx context.Context, runner imagerunner.Runner)
 		return false
 	}
 
-	err := r.RunnerService.StreamLogs(ctx, runner.ID, true)
+	err := r.RunnerService.StreamLiveLogs(ctx, runner.ID, true)
 	if !ignoreError(err) {
 		log.Err(err).Msg("Async event handler failed.")
 	}

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -52,14 +52,14 @@ type ImgRunner struct {
 	Reporters []report.Reporter
 
 	Async             bool
-	AsyncEventManager imagerunner.AsyncEventManagerI
+	AsyncEventManager imagerunner.AsyncEventManager
 
 	ctx    context.Context
 	cancel context.CancelFunc
 }
 
 func NewImgRunner(project imagerunner.Project, runnerService ImageRunner, tunnelService tunnel.Service,
-	asyncEventManager imagerunner.AsyncEventManagerI, reporters []report.Reporter, async bool) *ImgRunner {
+	asyncEventManager imagerunner.AsyncEventManager, reporters []report.Reporter, async bool) *ImgRunner {
 	return &ImgRunner{
 		Project:           project,
 		RunnerService:     runnerService,

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -31,7 +31,7 @@ type ImageRunner interface {
 	StopRun(ctx context.Context, id string) error
 	DownloadArtifacts(ctx context.Context, id string) (io.ReadCloser, error)
 	GetLogs(ctx context.Context, id string) (string, error)
-	HandleAsyncEvents(ctx context.Context, id string, wait bool) error
+	StreamLogs(ctx context.Context, id string, wait bool) error
 }
 
 type SuiteTimeoutError struct {
@@ -333,7 +333,7 @@ func (r *ImgRunner) pollLiveLogs(ctx context.Context, runner imagerunner.Runner)
 		return false
 	}
 
-	err := r.RunnerService.HandleAsyncEvents(ctx, runner.ID, true)
+	err := r.RunnerService.StreamLogs(ctx, runner.ID, true)
 	if !ignoreError(err) {
 		log.Err(err).Msg("Async event handler failed.")
 	}

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -448,7 +448,7 @@ func (r *ImgRunner) PollRun(ctx context.Context, id string, lastStatus string) (
 	}
 }
 
-// DownloadArtifacts DownloadArtifact downloads a zipped archive of artifacts
+// DownloadArtifacts downloads a zipped archive of artifacts
 // and extracts the required files.
 func (r *ImgRunner) DownloadArtifacts(runnerID, suiteName, status string, passed bool) []string {
 	if r.Async ||

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -31,7 +31,7 @@ type ImageRunner interface {
 	StopRun(ctx context.Context, id string) error
 	DownloadArtifacts(ctx context.Context, id string) (io.ReadCloser, error)
 	GetLogs(ctx context.Context, id string) (string, error)
-	HandleAsyncEvents(ctx context.Context, id string, nowait bool) error
+	HandleAsyncEvents(ctx context.Context, id string, wait bool) error
 }
 
 type SuiteTimeoutError struct {
@@ -333,7 +333,7 @@ func (r *ImgRunner) pollLiveLogs(ctx context.Context, runner imagerunner.Runner)
 		return false
 	}
 
-	err := r.RunnerService.HandleAsyncEvents(ctx, runner.ID, false)
+	err := r.RunnerService.HandleAsyncEvents(ctx, runner.ID, true)
 	if !ignoreError(err) {
 		log.Err(err).Msg("Async event handler failed.")
 	}

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -215,19 +215,6 @@ func (r *ImgRunner) buildService(serviceIn imagerunner.SuiteService, suiteName s
 	return serviceOut, nil
 }
 
-func ignoreError(err error) bool {
-	if err == nil {
-		return true
-	}
-	if !errors.Is(err, context.Canceled) {
-		return true
-	}
-	if strings.Contains(err.Error(), "websocket: close") {
-		return true
-	}
-	return false
-}
-
 func (r *ImgRunner) runSuite(suite imagerunner.Suite) (imagerunner.Runner, error) {
 	files, err := mapFiles(suite.Files)
 	if err != nil {
@@ -305,6 +292,20 @@ func (r *ImgRunner) runSuite(suite imagerunner.Suite) (imagerunner.Runner, error
 		if !r.Project.LiveLogs {
 			return
 		}
+
+		ignoreError := func(err error) bool {
+			if err == nil {
+				return true
+			}
+			if !errors.Is(err, context.Canceled) {
+				return true
+			}
+			if strings.Contains(err.Error(), "websocket: close") {
+				return true
+			}
+			return false
+		}
+
 		err := r.RunnerService.HandleAsyncEvents(ctx, runner.ID, false)
 		if !ignoreError(err) {
 			log.Err(err).Msg("Async event handler failed.")

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -444,7 +444,8 @@ func (r *ImgRunner) PollRun(ctx context.Context, id string, lastStatus string) (
 	}
 }
 
-// DownloadArtifact downloads a zipped archive of artifacts and extracts the required files.
+// DownloadArtifacts DownloadArtifact downloads a zipped archive of artifacts
+// and extracts the required files.
 func (r *ImgRunner) DownloadArtifacts(runnerID, suiteName, status string, passed bool) []string {
 	if r.Async ||
 		runnerID == "" ||


### PR DESCRIPTION
## Proposed changes

Try to improve code quality and clarity of the cloudevent handling logic (e.g. live-logs).

No business logic changes per se, but some methods were more drastically altered than others (some inversion of booleans, consolidation or breaking apart methods) which results in internal logical changes of the program.

Out of Scope:
`imagerunner/async.go` contains code to handle cloudevents and websockets. As this is code that's more related to HTTP than ImageRunner itself, I'd love to move this to the `http` package, but not in this PR.

PS: I recommend going through the individual commits, so as to better understand the changes (I know, it's plenty!).