### PR TITLE
feat: Add cli to list imagerunner containers

### DIFF
--- a/internal/cmd/imagerunner/cmd.go
+++ b/internal/cmd/imagerunner/cmd.go
@@ -56,6 +56,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 		LogsCommand(),
 		ArtifactsCommand(),
 		StopCommand(),
+		ListCommand(),
 	)
 	return cmd
 }

--- a/internal/cmd/imagerunner/list.go
+++ b/internal/cmd/imagerunner/list.go
@@ -90,5 +90,5 @@ func renderContainersTable(containers http.ContainersResp) {
 			time.Unix(c.TerminationTime, 0).Format(time.RFC3339),
 		})
 	}
-	println(t.Render())
+	fmt.Println(t.Render())
 }

--- a/internal/cmd/imagerunner/list.go
+++ b/internal/cmd/imagerunner/list.go
@@ -1,0 +1,94 @@
+package imagerunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/saucelabs/saucectl/internal/segment"
+	"github.com/saucelabs/saucectl/internal/usage"
+	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+func ListCommand() *cobra.Command {
+	var out string
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "Returns the list of containers",
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			err := http.CheckProxy()
+			if err != nil {
+				return fmt.Errorf("invalid HTTP_PROXY value")
+			}
+
+			tracker := segment.DefaultTracker
+
+			go func() {
+				tracker.Collect(
+					cases.Title(language.English).String(cmds.FullName(cmd)),
+					usage.Properties{}.SetFlags(cmd.Flags()),
+				)
+				_ = tracker.Close()
+			}()
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return list(out)
+		},
+	}
+	flags := cmd.PersistentFlags()
+	flags.StringVarP(&out, "out", "o", "text", "Output format to the console. Options: text, json.")
+
+	return cmd
+}
+
+func list(outputFormat string) error {
+	containers, err := imagerunnerClient.ListContainers(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to get container list: %v", err)
+	}
+
+	switch outputFormat {
+	case "json":
+		if err := renderJSON(containers); err != nil {
+			return fmt.Errorf("failed to render output: %v", err)
+		}
+	case "text":
+		renderContainersTable(containers)
+	default:
+		return errors.New("unknown output format")
+	}
+	return nil
+}
+
+func renderContainersTable(containers http.ContainersResp) {
+	if len(containers.Items) == 0 {
+		println("Cannot find any containers")
+		return
+	}
+	t := table.NewWriter()
+	t.SetStyle(defaultTableStyle)
+	t.SuppressEmptyColumns()
+	t.AppendHeader(table.Row{
+		"ID", "Image", "Status", "CreationTime", "TerminationTime",
+	})
+
+	for _, c := range containers.Items {
+		// the order of values must match the order of the header
+		t.AppendRow(table.Row{
+			c.ID,
+			c.Image,
+			c.Status,
+			time.Unix(c.CreationTime, 0).Format(time.RFC3339),
+			time.Unix(c.TerminationTime, 0).Format(time.RFC3339),
+		})
+	}
+	println(t.Render())
+}

--- a/internal/http/imagerunner.go
+++ b/internal/http/imagerunner.go
@@ -36,6 +36,10 @@ type AuthToken struct {
 	Password  string    `json:"password"`
 }
 
+type ContainersResp struct {
+	Items []imagerunner.Runner `json:"content"`
+}
+
 func NewImageRunner(url string, creds iam.Credentials, timeout time.Duration,
 	asyncEventManager imagerunner.AsyncEventManagerI) ImageRunner {
 	eventLogger := zerolog.New(zerolog.ConsoleWriter{
@@ -485,4 +489,32 @@ func (c *ImageRunner) RegistryLogin(ctx context.Context, repo string) (AuthToken
 
 	err = json.Unmarshal(data, &authToken)
 	return authToken, err
+}
+
+func (c *ImageRunner) ListContainers(ctx context.Context) (ContainersResp, error) {
+	url := fmt.Sprintf("%s/v1alpha1/hosted/image/runners", c.URL)
+
+	var containers ContainersResp
+	req, err := NewRetryableRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return containers, err
+	}
+	req.SetBasicAuth(c.Creds.Username, c.Creds.AccessKey)
+
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return containers, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return containers, fmt.Errorf("unexpected server response (%d): %s", resp.StatusCode, b)
+	}
+
+	if err = json.NewDecoder(resp.Body).Decode(&containers); err != nil {
+		return containers, fmt.Errorf("failed to decode server response: %v", err)
+	}
+
+	return containers, nil
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Add cli to list containers:

```
$ saucectl imagerunner list -o text
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ ID                                Image                                            Status     CreationTime               TerminationTime           │
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ 44d3a9a52d0c4df2ba56f5900d42805d  saucelabs/imagerunner-playwright-example:latest  Cancelled  2024-01-25T17:03:07-08:00  2024-01-25T17:03:18-08:00 │
│ b8b79cd4e2fe4c6b9bab2924fb56821e  saucelabs/imagerunner-playwright-example:latest  Succeeded  2024-01-25T16:23:47-08:00  2024-01-25T16:24:38-08:00 │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

JSON output
```
{
  "content": [
    {
      "id": "44d3a9a52d0c4df2ba56f5900d42805d",
      "status": "Cancelled",
      "image": "saucelabs/imagerunner-playwright-example:latest",
      "creation_time": 1706230987,
      "termination_time": 1706230998
    },
    {
      "id": "14c42f8a5fa3402996139d5952e18f8f",
      "status": "Cancelled",
      "image": "saucelabs/imagerunner-playwright-example:latest",
      "creation_time": 1706230986,
      "termination_time": 1706230998
    }
  ]
}
```

It supports `text` and `json` output formats. But there's a difference due to the SO backend API's behavior: it provides `CreationTime` and `TerminationTime` as Unix timestamps.

- `text`: `CreationTime` and `TerminationTime` are converted to RFC3339 format. More human-readable.
- `json`: These timestamps are kept as Unix timestamps, as returned by the SO backend API.

The discrepancy between the formats is due to the SO backend API exclusively providing Unix timestamps. I'm open to suggestions for improving these output formats.

--- 

This description explains the reasoning behind the different timestamp formats in `text` and `json` outputs and invites feedback on this implementation.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->