### PR TITLE
fix: Switch to using fmt.Println

### DIFF
--- a/internal/cmd/artifacts/list.go
+++ b/internal/cmd/artifacts/list.go
@@ -144,7 +144,7 @@ func renderTable(lst artifacts.List) {
 	}
 	t.SuppressEmptyColumns()
 
-	println(t.Render())
+	fmt.Println(t.Render())
 }
 
 func renderJSON(val any) error {

--- a/internal/cmd/artifacts/upload.go
+++ b/internal/cmd/artifacts/upload.go
@@ -76,7 +76,7 @@ func UploadCommand() *cobra.Command {
 
 			switch out {
 			case "text":
-				println("Success!")
+				fmt.Println("Success!")
 			case "json":
 				if err := renderJSON(filePath); err != nil {
 					return fmt.Errorf("failed to render output: %w", err)

--- a/internal/cmd/configure/cmd.go
+++ b/internal/cmd/configure/cmd.go
@@ -55,7 +55,7 @@ func Command() *cobra.Command {
 }
 
 func printCreds(creds iam.Credentials) {
-	println()
+	fmt.Println()
 
 	labelStyle := color.New(color.Bold)
 	valueStyle := color.New(color.FgBlue)
@@ -64,11 +64,11 @@ func printCreds(creds iam.Credentials) {
 	fmt.Println(labelStyle.Sprint("\t  Username:"), valueStyle.Sprint(creds.Username))
 	fmt.Println(labelStyle.Sprint("\tAccess key:"), valueStyle.Sprint(mask(creds.AccessKey)))
 
-	println()
+	fmt.Println()
 	fmt.Printf("Collected from: %s", creds.Source)
 
-	println()
-	println()
+	fmt.Println()
+	fmt.Println()
 }
 
 // interactiveConfiguration expect user to manually type-in its credentials
@@ -134,11 +134,11 @@ func interactiveConfiguration() (iam.Credentials, error) {
 			},
 		}
 
-		println() // visual paragraph break
+		fmt.Println() // visual paragraph break
 		if err = survey.Ask(qs, &creds); err != nil {
 			return creds, err
 		}
-		println() // visual paragraph break
+		fmt.Println() // visual paragraph break
 	}
 
 	return creds, nil
@@ -168,7 +168,7 @@ func Run() error {
 	if err := credentials.ToFile(creds); err != nil {
 		return fmt.Errorf("unable to save credentials: %s", err)
 	}
-	println("You're all set!")
+	fmt.Println("You're all set!")
 	return nil
 }
 

--- a/internal/cmd/imagerunner/artifacts.go
+++ b/internal/cmd/imagerunner/artifacts.go
@@ -194,9 +194,8 @@ func renderTable(lst imagerunner.ArtifactList) {
 		// the order of values must match the order of the header
 		t.AppendRow(table.Row{item})
 	}
-	t.SuppressEmptyColumns()
 
-	println(t.Render())
+	fmt.Println(t.Render())
 }
 
 func renderJSON(val any) error {

--- a/internal/cmd/ini/common.go
+++ b/internal/cmd/ini/common.go
@@ -94,12 +94,12 @@ func saveSauceIgnore(content string) error {
 }
 
 func displaySummary(files []string) {
-	println()
+	fmt.Println()
 	color.HiGreen("The following files have been created:")
 	for _, f := range files {
 		color.Green("  %s", f)
 	}
-	println()
+	fmt.Println()
 }
 
 func displayExtraInfo(framework string) {

--- a/internal/cmd/ini/imagerunner.go
+++ b/internal/cmd/ini/imagerunner.go
@@ -82,9 +82,9 @@ func configureImageRunner(cfg *initConfig) interface{} {
 }
 
 func displayExtraInfoImageRunner() {
-	println()
+	fmt.Println()
 	color.HiGreen("Before running your tests, you need to set the following environment variables:")
 	color.Green("  - DOCKER_USERNAME")
 	color.Green("  - DOCKER_PASSWORD")
-	println()
+	fmt.Println()
 }

--- a/internal/cmd/jobs/get.go
+++ b/internal/cmd/jobs/get.go
@@ -92,5 +92,5 @@ func renderJobTable(job job.Job) {
 	})
 	t.SuppressEmptyColumns()
 
-	println(t.Render())
+	fmt.Println(t.Render())
 }

--- a/internal/cmd/jobs/list.go
+++ b/internal/cmd/jobs/list.go
@@ -189,7 +189,7 @@ func renderTable(lst cjob.List) {
 		fmt.Sprintf("Size: %d", lst.Size),
 	})
 
-	println(t.Render())
+	fmt.Println(t.Render())
 }
 
 func renderJSON(val any) error {

--- a/internal/cmd/storage/delete.go
+++ b/internal/cmd/storage/delete.go
@@ -40,7 +40,7 @@ func DeleteCommand() *cobra.Command {
 				return fmt.Errorf("failed to delete file: %v", err)
 			}
 
-			println("File deleted successfully!")
+			fmt.Println("File deleted successfully!")
 
 			return nil
 		},

--- a/internal/cmd/storage/list.go
+++ b/internal/cmd/storage/list.go
@@ -166,7 +166,7 @@ func renderTable(list storage.List) {
 		t.AppendRow(table.Row{item.Size, item.Uploaded, item.ID, item.Name})
 	}
 
-	println(t.Render())
+	fmt.Println(t.Render())
 
 	if list.Truncated {
 		println("\nYour query returned more files than we can display. Please refine your query.")


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

In several places, our code currently utilizes `println()` for outputting information.
However, `println()` is primarily meant for bootstrapping and debugging purposes, and it directs output to stderr. For standard output, we should switch to using `fmt.Println()`.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->