### PR TITLE
feat: attempt to stop rdc jobs on timeout

### DIFF
--- a/internal/cmd/run/cucumber.go
+++ b/internal/cmd/run/cucumber.go
@@ -137,6 +137,7 @@ func runCucumber(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 				RDCReader:     &rdcClient,
 				VDCWriter:     &testcompClient,
 				VDCStopper:    &restoClient,
+				RDCStopper:    &rdcClient,
 				VDCDownloader: &restoClient,
 			},
 			TunnelService:   &restoClient,

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -159,6 +159,7 @@ func runCypress(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 				RDCReader:     &rdcClient,
 				VDCWriter:     &testcompClient,
 				VDCStopper:    &restoClient,
+				RDCStopper:    &rdcClient,
 				VDCDownloader: &restoClient,
 			},
 			MetadataService: &testcompClient,

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -157,6 +157,7 @@ func runEspressoInCloud(p espresso.Project, regio region.Region) (int, error) {
 				RDCReader:     &rdcClient,
 				VDCWriter:     &testcompClient,
 				VDCStopper:    &restoClient,
+				RDCStopper:    &rdcClient,
 				VDCDownloader: &restoClient,
 				RDCDownloader: &rdcClient,
 			},

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -172,6 +172,7 @@ func runPlaywright(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 				RDCReader:     &rdcClient,
 				VDCWriter:     &testcompClient,
 				VDCStopper:    &restoClient,
+				RDCStopper:    &rdcClient,
 				VDCDownloader: &restoClient,
 			},
 			TunnelService:   &restoClient,

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -145,6 +145,7 @@ func runPuppeteerReplayInSauce(p replay.Project, regio region.Region) (int, erro
 				RDCReader:     &rdcClient,
 				VDCWriter:     &testcompClient,
 				VDCStopper:    &restoClient,
+				RDCStopper:    &rdcClient,
 				VDCDownloader: &restoClient,
 			},
 			TunnelService:   &restoClient,

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -197,6 +197,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 				RDCReader:     &rdcClient,
 				VDCWriter:     &testcompClient,
 				VDCStopper:    &restoClient,
+				RDCStopper:    &rdcClient,
 				VDCDownloader: &restoClient,
 			},
 			TunnelService:   &restoClient,

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -158,6 +158,7 @@ func runXcuitestInCloud(p xcuitest.Project, regio region.Region) (int, error) {
 				RDCReader:     &rdcClient,
 				VDCWriter:     &testcompClient,
 				VDCStopper:    &restoClient,
+				RDCStopper:    &rdcClient,
 				VDCDownloader: &restoClient,
 				RDCDownloader: &rdcClient,
 			},

--- a/internal/saucecloud/cloud_test.go
+++ b/internal/saucecloud/cloud_test.go
@@ -252,6 +252,11 @@ func TestRunJobTimeoutRDC(t *testing.T) {
 					return job.Job{ID: id, TimedOut: true}, nil
 				},
 			},
+			RDCStopper: &mocks.FakeJobStopper{
+				StopJobFn: func(ctx context.Context, id string) (job.Job, error) {
+					return job.Job{ID: id, TimedOut: true}, nil
+				},
+			},
 		},
 	}
 
@@ -266,7 +271,7 @@ func TestRunJobTimeoutRDC(t *testing.T) {
 	}
 	close(opts)
 	res := <-results
-	assert.Error(t, res.err, "suite 'dummy' has reached timeout")
+	assert.Error(t, res.err)
 	assert.True(t, res.job.TimedOut)
 }
 

--- a/internal/saucecloud/jobservice.go
+++ b/internal/saucecloud/jobservice.go
@@ -21,6 +21,7 @@ type JobService struct {
 	VDCWriter job.Writer
 
 	VDCStopper job.Stopper
+	RDCStopper job.Stopper
 
 	VDCDownloader job.ArtifactDownloader
 	RDCDownloader job.ArtifactDownloader
@@ -36,7 +37,7 @@ func (s JobService) DownloadArtifact(jobID, suiteName string, realDevice bool) [
 
 func (s JobService) StopJob(ctx context.Context, jobID string, realDevice bool) (job.Job, error) {
 	if realDevice {
-		return job.Job{ID: jobID}, nil
+		return s.RDCStopper.StopJob(ctx, jobID, realDevice)
 	}
 
 	return s.VDCStopper.StopJob(ctx, jobID, realDevice)


### PR DESCRIPTION
## Proposed changes

This change introduces the ability for saucectl to automatically _attempt_ to stop a timed out RDC job. It was already doing this for VDC.

I emphasize the word _attempt_ here, because I also changed the wording in the implementation (both RDC/VDC), as there are too many state related edge cases where the device, be it real or virtual, seemingly cannot be stopped. Anecdotally, during my testing, the platform negatively responded to my stop request, only to actually stop the job a few moments later with the UI properly showing that the job was stopped by the user.