### PR TITLE
build: add workflow to auto bump version

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -46,6 +46,6 @@ jobs:
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
 
       - name: Generate release
-        run: echo "gh release create v${{ steps.next.outputs.version }} --generate-notes"
+        run: gh release create v${{ steps.next.outputs.version }} --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Validate input
         run: |
-          if [[ "${{ github.event.inputs.releaseType }}" == "<Choose one>" ]]; then
+          if [[ "<Choose one>" == "<Choose one>" ]]; then
             printf "You must choose a release type (patch, minor, or major)" >&2
             exit 1
           fi
@@ -54,8 +54,8 @@ jobs:
 
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
 
-      - name: Generate release
-        if: ${{ steps.next.outputs.version != '' }}
-        run: gh release create v${{ steps.next.outputs.version }} --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Generate release
+      #   if: ${{ steps.next.outputs.version != '' }}
+      #   run: gh release create v${{ steps.next.outputs.version }} --generate-notes
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -44,7 +44,7 @@ jobs:
 
           echo "version=$LATEST" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Get next version 
         id: next
@@ -57,4 +57,4 @@ jobs:
         if: ${{ steps.next.outputs.version != '' }}
         run: gh release create v${{ steps.next.outputs.version }} --generate-notes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,7 +1,6 @@
 name: Bump
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       releaseType:
@@ -21,7 +20,7 @@ jobs:
     steps:
       - name: Validate input
         run: |
-          if [[ "<Choose one>" == "<Choose one>" ]]; then
+          if [[ "${{ github.event.inputs.releaseType }}" == "<Choose one>" ]]; then
             printf "You must choose a release type (patch, minor, or major)" >&2
             exit 1
           fi
@@ -54,8 +53,8 @@ jobs:
 
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
 
-      # - name: Generate release
-      #   if: ${{ steps.next.outputs.version != '' }}
-      #   run: gh release create v${{ steps.next.outputs.version }} --generate-notes
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate release
+        if: ${{ steps.next.outputs.version != '' }}
+        run: gh release create v${{ steps.next.outputs.version }} --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -20,9 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Get tags
-        run: git fetch --tags
+        with:
+          fetch-tags: true
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -46,7 +46,7 @@ jobs:
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
 
       - name: Generate release
-         if: ${{ steps.next.outputs.version != '' }}
+        if: ${{ steps.next.outputs.version != '' }}
         run: gh release create v${{ steps.next.outputs.version }} --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,18 +1,17 @@
 name: Bump
 
 on:
-  pull_request:
-  # workflow_dispatch:
-  #   inputs:
-  #     releaseType:
-  #       description: 'Release type'
-  #       type: choice
-  #       required: true
-  #       default: patch
-  #       options:
-  #         - patch
-  #         - minor
-  #         - major
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: 'Release type'
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   bump:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,14 +1,16 @@
 name: Bump
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       releaseType:
         description: 'Release type'
         type: choice
         required: true
-        default: patch
+        default: '<Choose one>'
         options:
+          - <Choose one>
           - patch
           - minor
           - major
@@ -17,6 +19,13 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate input
+        run: |
+          if [[ "${{ github.event.inputs.releaseType }}" == "<Choose one>" ]]; then
+            printf "You must choose a release type (patch, minor, or major)" >&2
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,17 +1,18 @@
 name: Bump
 
 on:
-  workflow_dispatch:
-    inputs:
-      releaseType:
-        description: 'Release type'
-        type: choice
-        required: true
-        default: patch
-        options:
-          - patch
-          - minor
-          - major
+  pull_request:
+  # workflow_dispatch:
+  #   inputs:
+  #     releaseType:
+  #       description: 'Release type'
+  #       type: choice
+  #       required: true
+  #       default: patch
+  #       options:
+  #         - patch
+  #         - minor
+  #         - major
 
 jobs:
   bump:
@@ -42,6 +43,6 @@ jobs:
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
 
       - name: Generate release
-        run: echo "gh release create ${{ steps.next.outputs.version }} --generate-notes"
+        run: echo "gh release create v${{ steps.next.outputs.version }} --generate-notes"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -38,6 +38,8 @@ jobs:
             --jq '.[] | select(.isLatest == true) | .name')
 
           echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get next version 
         id: next

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -24,7 +24,7 @@ jobs:
           depth: 0 # Need all tags
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: lts
 

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -46,6 +46,7 @@ jobs:
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
 
       - name: Generate release
+         if: ${{ steps.next.outputs.version != '' }}
         run: gh release create v${{ steps.next.outputs.version }} --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          depth: 0 # Need all tags
+
+      - name: Get tags
+        run: git fetch --tags
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -31,7 +31,11 @@ jobs:
       - name: Get latest version
         id: latest
         run: |
-          LATEST=$(git describe --tags)
+          LATEST=$(gh release list \
+            --exclude-drafts \
+            --exclude-pre-releases \
+            --json name,isLatest \
+            --jq '.[] | select(.isLatest == true) | .name')
 
           echo "version=$LATEST" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: lts
+          node-version: v20
 
       - name: Get latest version
         id: latest

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,47 @@
+name: Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: 'Release type'
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          depth: 0 # Need all tags
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts
+
+      - name: Get latest version
+        id: latest
+        run: |
+          LATEST=$(git describe --tags)
+
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+
+      - name: Get next version 
+        id: next
+        run: |
+          NEXT=$(npx --yes semver -i ${{ github.event.inputs.releaseType }} ${{ steps.latest.outputs.version }})
+
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release
+        run: echo "gh release create ${{ steps.next.outputs.version }} --generate-notes"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - v*
+  release:
+    types:
+      - released
 
 env:
   GH_TOKEN: ${{secrets.GH_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  release:
-    types:
-      - released
+  push:
+    tags:
+      - v*
 
 env:
   GH_TOKEN: ${{secrets.GH_TOKEN}}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Add a new workflow to manually bump the version and create a new github release. Once the release and corresponding tag are created, the normal release workflow will be triggered.

I made the input a selection instead of a text box. I'm flip flopping between that and just a text input. No strong opinions either way.

[DEVX-2727]

[DEVX-2727]: https://saucedev.atlassian.net/browse/DEVX-2727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ