### PR TITLE
ci: setup go before running codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "./go.mod"
+          go-version-file: ${{ github.workspace }}/go.mod
           cache: true
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "go.mod"
+          go-version-file: "./go.mod"
           cache: true
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ github.workspace }}/go.mod
+          go-version: '1.21'
           cache: true
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "./go.mod"
+          go-version-file: ${{ github.workspace }}/go.mod
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "go.mod"
+          go-version-file: "./go.mod"
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ github.workspace }}/go.mod
+          go-version: '1.21'
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: "go.mod"
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: "go.mod"
           cache: true
 
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: "go.mod"
           cache: true
 
       - name: Run tests
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: "go.mod"
           cache: true
 
       - name: Build Project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "go.mod"
+          go-version-file: "./go.mod"
           cache: true
 
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "go.mod"
+          go-version-file: "./go.mod"
           cache: true
 
       - name: Run tests
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "go.mod"
+          go-version-file: "./go.mod"
           cache: true
 
       - name: Build Project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "./go.mod"
+          go-version-file: ${{ github.workspace }}/go.mod
           cache: true
 
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "./go.mod"
+          go-version-file: ${{ github.workspace }}/go.mod
           cache: true
 
       - name: Run tests
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "./go.mod"
+          go-version-file: ${{ github.workspace }}/go.mod
           cache: true
 
       - name: Build Project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ github.workspace }}/go.mod
+          go-version: '1.21'
           cache: true
 
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ github.workspace }}/go.mod
+          go-version: '1.21'
           cache: true
 
       - name: Run tests
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ github.workspace }}/go.mod
+          go-version: '1.21'
           cache: true
 
       - name: Build Project


### PR DESCRIPTION
## Proposed changes

CodeQL seems to have its own go version. This can cause an issue when its version and the project's version differ:
![SCR-20240214-jkdx](https://github.com/saucelabs/saucectl/assets/1869292/f1347287-2952-48a5-b89b-f7cfec90851e)

PS: I tried to switch our "manual" version setting to that of a the go.mod file, [like documented here](https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file). Could not get it to work though (as you can see by my fruitless commits).