### PR TITLE
fix: Don't try to download assets and logs if none are available

### DIFF
--- a/internal/imagerunner/imagerunner.go
+++ b/internal/imagerunner/imagerunner.go
@@ -79,15 +79,13 @@ type FileData struct {
 	Data string `json:"data,omitempty"`
 }
 
-type RunnerAssetStatus string
-
 const (
-	Waiting RunnerAssetStatus = "Waiting"
-	Errored RunnerAssetStatus = "Errored"
+	RunnerAssetStateWaiting = "Waiting"
+	RunnerAssetStateErrored = "Errored"
 )
 
 type RunnerAssets struct {
-	Status RunnerAssetStatus `json:"status,omitempty"`
+	Status string `json:"status,omitempty"`
 }
 
 type Runner struct {

--- a/internal/imagerunner/imagerunner.go
+++ b/internal/imagerunner/imagerunner.go
@@ -79,13 +79,25 @@ type FileData struct {
 	Data string `json:"data,omitempty"`
 }
 
+type RunnerAssetStatus string
+
+const (
+	Waiting RunnerAssetStatus = "Waiting"
+	Errored RunnerAssetStatus = "Errored"
+)
+
+type RunnerAssets struct {
+	Status RunnerAssetStatus `json:"status,omitempty"`
+}
+
 type Runner struct {
-	ID                string `json:"id,omitempty"`
-	Status            string `json:"status,omitempty"`
-	Image             string `json:"image,omitempty"`
-	CreationTime      int64  `json:"creation_time,omitempty"`
-	TerminationTime   int64  `json:"termination_time,omitempty"`
-	TerminationReason string `json:"termination_reason,omitempty"`
+	ID                string       `json:"id,omitempty"`
+	Status            string       `json:"status,omitempty"`
+	Image             string       `json:"image,omitempty"`
+	CreationTime      int64        `json:"creation_time,omitempty"`
+	TerminationTime   int64        `json:"termination_time,omitempty"`
+	TerminationReason string       `json:"termination_reason,omitempty"`
+	Assets            RunnerAssets `json:"assets,omitempty"`
 }
 
 type ArtifactList struct {

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -369,7 +369,7 @@ func (r *ImgRunner) collectResults(results chan execResult, expected int) bool {
 
 		var artifacts []report.Artifact
 		if res.assetsStatus == imagerunner.RunnerAssetStateErrored {
-			log.Warn().Msg("Logs and artifacts could not be uploaded due to an error, skipping download")
+			log.Warn().Msg("Logs and artifacts are not available due to an error.")
 		} else {
 			if !r.Project.LiveLogs {
 				// only print logs if live logs are disabled

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -72,14 +72,15 @@ func NewImgRunner(project imagerunner.Project, runnerService ImageRunner, tunnel
 }
 
 type execResult struct {
-	name      string
-	runID     string
-	status    string
-	err       error
-	duration  time.Duration
-	startTime time.Time
-	endTime   time.Time
-	attempts  []report.Attempt
+	name         string
+	runID        string
+	status       string
+	assetsStatus string
+	err          error
+	duration     time.Duration
+	startTime    time.Time
+	endTime      time.Time
+	attempts     []report.Attempt
 }
 
 func (r *ImgRunner) RunProject() (int, error) {
@@ -169,13 +170,14 @@ func (r *ImgRunner) runSuites(suites chan imagerunner.Suite, results chan<- exec
 		duration := time.Since(startTime)
 
 		results <- execResult{
-			name:      suite.Name,
-			runID:     run.ID,
-			status:    run.Status,
-			err:       err,
-			startTime: startTime,
-			endTime:   endTime,
-			duration:  duration,
+			name:         suite.Name,
+			runID:        run.ID,
+			status:       run.Status,
+			assetsStatus: run.Assets.Status,
+			err:          err,
+			startTime:    startTime,
+			endTime:      endTime,
+			duration:     duration,
 			attempts: []report.Attempt{{
 				ID:        run.ID,
 				Duration:  duration,

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -366,14 +366,19 @@ func (r *ImgRunner) collectResults(results chan execResult, expected int) bool {
 		}
 
 		r.PrintResult(res)
-		if !r.Project.LiveLogs {
-			// only print logs if live logs are disabled
-			r.PrintLogs(res.runID, res.name)
-		}
-		files := r.DownloadArtifacts(res.runID, res.name, res.status, res.err != nil)
+
 		var artifacts []report.Artifact
-		for _, f := range files {
-			artifacts = append(artifacts, report.Artifact{FilePath: f})
+		if res.assetsStatus == imagerunner.RunnerAssetStateErrored {
+			log.Warn().Msg("Logs and artifacts could not be uploaded due to an error, skipping download")
+		} else {
+			if !r.Project.LiveLogs {
+				// only print logs if live logs are disabled
+				r.PrintLogs(res.runID, res.name)
+			}
+			files := r.DownloadArtifacts(res.runID, res.name, res.status, res.err != nil)
+			for _, f := range files {
+				artifacts = append(artifacts, report.Artifact{FilePath: f})
+			}
 		}
 
 		for _, r := range r.Reporters {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

When a run on sauce orchestrate fails such that no logs or artifacts are available, saucectl still tries to download these assets when the run concludes. The API used to poll the job has information about the status of those assets. So use that info to skip asset download as needed.

## Types of changes
<!--
What types of changes does your code introduce to saucectl?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the json schema (if appropriate)

[DEVX-2759]

[DEVX-2759]: https://saucedev.atlassian.net/browse/DEVX-2759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ