### PR TITLE
build: replace deprecated goreleaser setting

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ brews:
   - repository:
       owner: saucelabs
       name: homebrew-saucectl
-    folder: Formula
+    directory: Formula
     test: |
       system "#{bin}/goreleaser", "-v"
     name: saucectl


### PR DESCRIPTION
## Description

`brews.folder` [has been deprecated](https://goreleaser.com/deprecations/#brewsfolder).