### PR TITLE
feat: Support more npm registry auth fields

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -139,7 +139,7 @@
                           "type": "string"
                         },
                         "auth": {
-                          "description": "Base64-encoded authentication token for the registry entry",
+                          "description": "Base64-encoded authentication string for the registry entry",
                           "type": "string"
                         },
                         "username": {
@@ -660,7 +660,7 @@
                           "type": "string"
                         },
                         "auth": {
-                          "description": "Base64-encoded authentication token for the registry entry",
+                          "description": "Base64-encoded authentication string for the registry entry",
                           "type": "string"
                         },
                         "username": {

--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -135,7 +135,23 @@
                           "type": "string"
                         },
                         "authToken": {
-                          "description": "authToken for the registry entry",
+                          "description": "Authentication token for the registry entry",
+                          "type": "string"
+                        },
+                        "auth": {
+                          "description": "Base64-encoded authentication token for the registry entry",
+                          "type": "string"
+                        },
+                        "username": {
+                          "description": "Username for authentication with the registry",
+                          "type": "string"
+                        },
+                        "password": {
+                          "description": "Password for authentication with the registry",
+                          "type": "string"
+                        },
+                        "email": {
+                          "description": "Email for authentication with the registry",
                           "type": "string"
                         }
                       },
@@ -640,7 +656,23 @@
                           "type": "string"
                         },
                         "authToken": {
-                          "description": "authToken for the registry entry",
+                          "description": "Authentication token for the registry entry",
+                          "type": "string"
+                        },
+                        "auth": {
+                          "description": "Base64-encoded authentication token for the registry entry",
+                          "type": "string"
+                        },
+                        "username": {
+                          "description": "Username for authentication with the registry",
+                          "type": "string"
+                        },
+                        "password": {
+                          "description": "Password for authentication with the registry",
+                          "type": "string"
+                        },
+                        "email": {
+                          "description": "Email for authentication with the registry",
                           "type": "string"
                         }
                       },

--- a/api/v1/subschema/npm.schema.json
+++ b/api/v1/subschema/npm.schema.json
@@ -41,7 +41,23 @@
                 "type": "string"
               },
               "authToken": {
-                "description": "authToken for the registry entry",
+                "description": "Authentication token for the registry entry",
+                "type": "string"
+              },
+              "auth": {
+                "description": "Base64-encoded authentication token for the registry entry",
+                "type": "string"
+              },
+              "username": {
+                "description": "Username for authentication with the registry",
+                "type": "string"
+              },
+              "password": {
+                "description": "Password for authentication with the registry",
+                "type": "string"
+              },
+              "email": {
+                "description": "Email for authentication with the registry",
                 "type": "string"
               }
             },

--- a/api/v1/subschema/npm.schema.json
+++ b/api/v1/subschema/npm.schema.json
@@ -45,7 +45,7 @@
                 "type": "string"
               },
               "auth": {
-                "description": "Base64-encoded authentication token for the registry entry",
+                "description": "Base64-encoded authentication string for the registry entry",
                 "type": "string"
               },
               "username": {

--- a/api/v1alpha/subschema/npm.schema.json
+++ b/api/v1alpha/subschema/npm.schema.json
@@ -41,7 +41,23 @@
                 "type": "string"
               },
               "authToken": {
-                "description": "authToken for the registry entry",
+                "description": "Authentication token for the registry entry",
+                "type": "string"
+              },
+              "auth": {
+                "description": "Base64-encoded authentication token for the registry entry",
+                "type": "string"
+              },
+              "username": {
+                "description": "Username for authentication with the registry",
+                "type": "string"
+              },
+              "password": {
+                "description": "Password for authentication with the registry",
+                "type": "string"
+              },
+              "email": {
+                "description": "Email for authentication with the registry",
                 "type": "string"
               }
             },

--- a/api/v1alpha/subschema/npm.schema.json
+++ b/api/v1alpha/subschema/npm.schema.json
@@ -45,7 +45,7 @@
                 "type": "string"
               },
               "auth": {
-                "description": "Base64-encoded authentication token for the registry entry",
+                "description": "Base64-encoded authentication string for the registry entry",
                 "type": "string"
               },
               "username": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -188,7 +188,11 @@ type TypeDef struct {
 type Registry struct {
 	Scope     string `yaml:"scope,omitempty" json:"scope,omitempty"`
 	URL       string `yaml:"url,omitempty" json:"url,omitempty"`
+	Auth      string `yaml:"auth,omitempty" json:"auth,omitempty"`
 	AuthToken string `yaml:"authToken,omitempty" json:"authToken,omitempty"`
+	Username  string `yaml:"username,omitempty" json:"username,omitempty"`
+	Password  string `yaml:"password,omitempty" json:"password,omitempty"`
+	Email     string `yaml:"email,omitempty" json:"email,omitempty"`
 }
 
 // Npm represents the npm settings


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Support npm auth fields:
- `auth`
- `username`
- `password`
- `email`
