### PR TITLE
fix: apply correct resource profile to service containers

### DIFF
--- a/internal/imagerunner/config.go
+++ b/internal/imagerunner/config.go
@@ -149,7 +149,7 @@ func SetDefaults(p *Project) {
 			if service.ResourceProfile == "" {
 				service.ResourceProfile = "c1m1"
 			}
-			suite.Metadata[fmt.Sprintf("resourceProfile-%s", GetCanonicalServiceName(service.Name))] = suite.ResourceProfile
+			suite.Metadata[fmt.Sprintf("resourceProfile-%s", GetCanonicalServiceName(service.Name))] = service.ResourceProfile
 			if service.Env == nil {
 				service.Env = make(map[string]string)
 			}


### PR DESCRIPTION
## Description

The main container and the service container can each have a different resource profile. The current logic accidentally applies the main container's resource profile on the service container.