### PR TITLE
build: Use Go 1.22

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,10 +46,7 @@ jobs:
 
       - name: Run tests
         run: |
-          go test -coverprofile=coverage.txt -covermode=atomic ./...
-          coverage=$(go tool cover -func=coverage.txt | tail -n 1 | awk '{ print $3 }' | tr -d '%' | cut -d . -f 1)
-          threshold=40
-          if [ $coverage -lt $threshold ]; then echo 'Code coverage below threshold!' && exit 1; fi
+          go test ./...
 
   check-schema:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
 
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
 
       - name: Run tests
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: true
 
       - name: Build Project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the binary here
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/saucelabs/saucectl
 
-go 1.21
+go 1.22
 
 replace github.com/spf13/viper v1.14.0 => github.com/saucelabs/viper v1.14.0
 


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
Use Go 1.22.

Notes:
Our pipeline failed because it didn't meet the test coverage threshold, as detailed here: [GitHub Actions Log](https://github.com/saucelabs/saucectl/actions/runs/9103170213/job/25024429237?pr=909).

This issue arose due to changes in Go 1.22, which updated how test coverage reports are generated. Previously, Go did not include packages without test files in coverage calculations. With Go 1.22, these packages are now counted, each showing 0% coverage, causing our test coverage in `saucectl` to drop from around 43% to 34%. While this provides a more realistic measure of coverage.

Talked with @alexplischke , as we've discussed repeatedly, test coverage is merely a numerical metric and does not accurately reflect the true quality of the product. Therefore, we should consider removing the coverage threshold.