### PR TITLE
ci: pipeline hygiene

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-          cache: true
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: latest
+          version: '~> v1'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-          cache: true
 
       - name: Lint
         uses: golangci/golangci-lint-action@v6
@@ -42,7 +41,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-          cache: true
 
       - name: Run tests
         run: |
@@ -84,7 +82,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-          cache: true
 
       - name: Build Project
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout 3m
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
           cache: true
-
-      - name: Checkout
-        uses: actions/checkout@v4
 
       - name: Lint
         uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
## Description

Some hygiene for the pipelines which also addresses previous warnings that the actions were giving us.

In Summary:
- The lint job had the wrong step order of checkout vs. go code setup, which caused the setup to not utilize its dependency cache, because that requires the `go.sum` file and the checkout step has obviously not happened yet.
- Speaking of cache, the modules are cached by default since `v4`.
- Pin the version of goreleaser to the current major version, for obvious reasons.
- `golangci-lint-action` was fairly outdated and was still using Node.js 16