### PR TITLE
feat: expand package.json files in npm.dependencies

### DIFF
--- a/internal/human/bytes.go
+++ b/internal/human/bytes.go
@@ -1,0 +1,14 @@
+package human
+
+import (
+	"fmt"
+	"math"
+)
+
+func Bytes(b int64) string {
+	sizes := []string{"B", "kB", "MB", "GB"}
+	e := math.Floor(math.Log(float64(b)) / math.Log(1000))
+	suffix := sizes[int(math.Min(e, float64(len(sizes)-1)))]
+	val := float64(b) / math.Pow(1000, e)
+	return fmt.Sprintf("%.0f %s", val, suffix)
+}

--- a/internal/human/bytes_test.go
+++ b/internal/human/bytes_test.go
@@ -1,0 +1,18 @@
+package human
+
+import "fmt"
+
+func ExampleBytes_gigaByte() {
+	fmt.Println(Bytes(3000000000))
+	// Output: 3 GB
+}
+
+func ExampleBytes_megaByte() {
+	fmt.Println(Bytes(82854982))
+	// Output: 83 MB
+}
+
+func ExampleBytes_kiloByte() {
+	fmt.Println(Bytes(828549))
+	// Output: 829 kB
+}

--- a/internal/saucecloud/zip/archive.go
+++ b/internal/saucecloud/zip/archive.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/archive/zip"
+	"github.com/saucelabs/saucectl/internal/human"
 	"github.com/saucelabs/saucectl/internal/jsonio"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/node"
@@ -92,8 +93,8 @@ func ArchiveFiles(targetFileName string, targetDir string, sourceDir string, fil
 	}
 
 	log.Info().
-		Dur("durationMs", time.Since(start)).
-		Int64("size", f.Size()).
+		Str("duration", time.Since(start).Round(time.Second).String()).
+		Str("size", human.Bytes(f.Size())).
 		Int("fileCount", totalFileCount).
 		Int("longestPathLength", longestPathLength).
 		Msg("Archive created.")

--- a/internal/saucecloud/zip/archive.go
+++ b/internal/saucecloud/zip/archive.go
@@ -133,7 +133,7 @@ func ArchiveNodeModules(targetDir string, sourceDir string, matcher sauceignore.
 	var files []string
 
 	// does the user only want a subset of dependencies?
-	if hasMods && wantMods {
+	if wantMods {
 		reqs := node.Requirements(filepath.Join(sourceDir, "node_modules"), dependencies...)
 		if len(reqs) == 0 {
 			return "", fmt.Errorf("unable to find required dependencies; please check 'node_modules' folder and make sure the dependencies exist")
@@ -146,7 +146,7 @@ func ArchiveNodeModules(targetDir string, sourceDir string, matcher sauceignore.
 
 	// node_modules exists, has not been ignored and a subset has not been specified, so include the entire folder.
 	// This is the legacy behavior (backwards compatible) of saucectl.
-	if hasMods && !ignored && !wantMods {
+	if !wantMods {
 		log.Warn().Msg("Adding the entire node_modules folder to the payload. " +
 			"This behavior is deprecated, not recommended and will be removed in the future. " +
 			"Please address your dependency needs via https://docs.saucelabs.com/dev/cli/saucectl/usage/use-cases/#set-npm-packages-in-configyml")

--- a/internal/saucecloud/zip/archive_test.go
+++ b/internal/saucecloud/zip/archive_test.go
@@ -1,0 +1,33 @@
+package zip
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gotest.tools/v3/fs"
+)
+
+func TestExpandDependencies(t *testing.T) {
+	dir := fs.NewDir(t, "test-project",
+		fs.WithFile("package.json", `{
+  "dependencies": {
+    "i-am-regular": "0.1.2"
+  },
+  "devDependencies": {
+    "i-am-dev": "0.1.2"
+  }
+}
+`))
+	defer dir.Remove()
+
+	deps := []string{"i-am-extra", "package.json"}
+	expanded, err := ExpandDependencies(dir.Path(), deps)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := []string{"i-am-extra", "i-am-regular", "i-am-dev"}
+	if !cmp.Equal(expected, expanded) {
+		t.Errorf("unexpected expanded dependencies: %s", cmp.Diff(expected, expanded))
+	}
+}


### PR DESCRIPTION
## Description

The main highlight of this PR is to allow the expansion of package.json files inside `npm.dependencies` (not `npm.packages`).

As a bonus UX improvement, certain log lines will now use human readable units, which makes it easier for the user to spot mistakes or oddities at runtime:
```
10:21:31 INF Archive created. duration=2s fileCount=5232 longestPathLength=136 size="21 MB"
```