### PR TITLE
fix: reporters v1 api schema

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -832,7 +832,17 @@
                       "filename": {
                         "description": "Filename for the generated JSON report.",
                         "type": "string",
-                        "default": "saucectl-test-result.xml"
+                        "default": "saucectl-report.json"
+                      }
+                    }
+                  },
+                  "spotlight": {
+                    "type": "object",
+                    "description": "The spotlight reporter prints an overview of failed, or otherwise interesting, jobs.",
+                    "properties": {
+                      "enabled": {
+                        "description": "Toggles the reporter on/off.",
+                        "type": "boolean"
                       }
                     }
                   }

--- a/api/v1/subschema/reporters.schema.json
+++ b/api/v1/subschema/reporters.schema.json
@@ -37,7 +37,17 @@
             "filename": {
               "description": "Filename for the generated JSON report.",
               "type": "string",
-              "default": "saucectl-test-result.xml"
+              "default": "saucectl-report.json"
+            }
+          }
+        },
+        "spotlight": {
+          "type": "object",
+          "description": "The spotlight reporter prints an overview of failed, or otherwise interesting, jobs.",
+          "properties": {
+            "enabled": {
+              "description": "Toggles the reporter on/off.",
+              "type": "boolean"
             }
           }
         }


### PR DESCRIPTION
## Description

The v1 schema for reporters, which is just Cypress at the moment, should be identical to v1alpha. Because they have drifted apart, the current validation complains if a user tries to specify the `spotlight` reporter.