### PR TITLE
ci: upgrade actions/cache@v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           go-version: '1.22'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build


### PR DESCRIPTION
## Description

`actions/cache@v3` is still using Node.js 16, which will soon cease to function on GitHub.
`actions/cache@v4` runs on Node.js 20.