### PR TITLE
fix: sauceignore pattern matching on windows

### DIFF
--- a/internal/sauceignore/files.go
+++ b/internal/sauceignore/files.go
@@ -12,13 +12,17 @@ import (
 func ExcludeSauceIgnorePatterns(files []string, sauceignoreFile string) []string {
 	matcher, err := NewMatcherFromFile(sauceignoreFile)
 	if err != nil {
-		log.Warn().Err(err).Msgf("An error occurred when filtering specs with %s. No filter will be applied", sauceignoreFile)
+		log.Warn().Err(err).Msgf(
+			"An error occurred when filtering specs with %s. No filter will be applied",
+			sauceignoreFile,
+		)
 		return files
 	}
 
 	var selectedFiles []string
 	for _, filename := range files {
-		if !matcher.Match(strings.Split(filename, string(filepath.Separator)), false) {
+		normalized := filepath.ToSlash(filename)
+		if !matcher.Match(strings.Split(normalized, "/"), false) {
 			selectedFiles = append(selectedFiles, filename)
 		}
 	}

--- a/internal/sauceignore/matcher.go
+++ b/internal/sauceignore/matcher.go
@@ -51,15 +51,6 @@ func NewPattern(p string) Pattern {
 	return Pattern{P: p}
 }
 
-func convPtrnsToGitignorePtrns(pp []Pattern) []gitignore.Pattern {
-	res := make([]gitignore.Pattern, len(pp))
-	for i := 0; i < len(pp); i++ {
-		res[i] = gitignore.ParsePattern(pp[i].P, nil)
-	}
-
-	return res
-}
-
 // Matcher defines matcher for sauceignore patterns.
 type Matcher interface {
 	Match(path []string, isDir bool) bool
@@ -75,9 +66,13 @@ func (m *matcher) Match(path []string, isDir bool) bool {
 }
 
 // NewMatcher constructs a new matcher.
-func NewMatcher(ps []Pattern) Matcher {
-	gps := convPtrnsToGitignorePtrns(ps)
-	return &matcher{matcher: gitignore.NewMatcher(gps)}
+func NewMatcher(patterns []Pattern) Matcher {
+	pp := make([]gitignore.Pattern, len(patterns))
+	for i, p := range patterns {
+		pp[i] = gitignore.ParsePattern(p.P, nil)
+	}
+
+	return &matcher{matcher: gitignore.NewMatcher(pp)}
 }
 
 // NewMatcherFromFile constructs a new matcher from file.


### PR DESCRIPTION
## Description

`ExcludeSauceIgnorePatterns()` would perform a gitignore match against the filename, which is a relative path, that was “correctly” split according to the OS file path separator—a back-slash on Windows. However, if filename is a forward-slash path (which is actually the case in our code!), then the split will fail on Windows, resulting in a singular forward-slash path wrapped in an array being passed into the matcher, which causes a reverse-gitignore pattern to unintentionally match.

E.g. this will return `true` on windows:

```go
package main

import (
	"fmt"

	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
)

type Matcher struct {
	matcher gitignore.Matcher
}

func (m *Matcher) Match(path []string, isDir bool) bool {
	return m.matcher.Match(path, isDir)
}

func main() {
	matcher := gitignore.NewMatcher([]gitignore.Pattern{
		gitignore.ParsePattern("/*", nil),
		gitignore.ParsePattern("!/cypress", nil),
		gitignore.ParsePattern("!/.sauce", nil),
		gitignore.ParsePattern("!cypress.config.js", nil),
		gitignore.ParsePattern("!/cypress!package.json", nil),
		gitignore.ParsePattern("!cypress.env.json", nil),
		gitignore.ParsePattern("!cucumber-html-report.js", nil),
		gitignore.ParsePattern("!cucumber-json-formater.exe", nil),
		gitignore.ParsePattern("/cypress/videos/", nil),
		gitignore.ParsePattern("/cypress/report/", nil),
		gitignore.ParsePattern("/cypress/downloads/", nil),
		gitignore.ParsePattern(".vscode/", nil),
		gitignore.ParsePattern(".gitignore", nil),
		gitignore.ParsePattern("/cypress/.gitignore", nil),
		gitignore.ParsePattern("/__assets__/report/", nil),
	})
	fmt.Println(matcher.Match([]string{"cypress/e2e/features/roles/ServicerUser.feature"}, false))
}
```

As mentioned, `files` already contains forward-slash paths. However, instead of simply modifying the split to use a forward-slash and documenting that this function requires forward-slash paths, I normalize the path first for the gitignore matcher, which is less brittle over time.