### PR TITLE
chore: Remove condition that denies using tunnels in US-East

### DIFF
--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -136,10 +136,6 @@ func Validate(p Project) error {
 		return errors.New(msg.MissingRegion)
 	}
 
-	if regio == region.USEast4 && p.Sauce.Tunnel.Name != "" {
-		return errors.New(msg.NoTunnelSupport)
-	}
-
 	if ok := config.ValidateVisibility(p.Sauce.Visibility); !ok {
 		return fmt.Errorf(msg.InvalidVisibility, p.Sauce.Visibility, strings.Join(config.ValidVisibilityValues, ","))
 	}

--- a/internal/msg/errormsg.go
+++ b/internal/msg/errormsg.go
@@ -86,8 +86,6 @@ const (
 	InvalidVisibility = "'%s' is not a valid visibility value. Must be one of [%s]"
 	// InvalidLaunchingOption indicates the launching option is invalid
 	InvalidLaunchingOption = "illegal launching option '%s', must be %s"
-	// NoTunnelSupport indicates lack of tunnel support for the specified region.
-	NoTunnelSupport = "tunnels are currently not supported in your specified region"
 	// NoEmulatorSupport indicates lack of emulator support for the specified region.
 	NoEmulatorSupport = "emulators are currently not supported in your specified region"
 	// NoFrameworkSupport indicates lack of framework support for the specified region.

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -210,10 +210,6 @@ func Validate(p Project) error {
 		return errors.New(msg.MissingRegion)
 	}
 
-	if regio == region.USEast4 && p.Sauce.Tunnel.Name != "" {
-		return errors.New(msg.NoTunnelSupport)
-	}
-
 	if p.Sauce.LaunchOrder != "" && p.Sauce.LaunchOrder != config.LaunchOrderFailRate {
 		return fmt.Errorf(msg.InvalidLaunchingOption, p.Sauce.LaunchOrder, string(config.LaunchOrderFailRate))
 	}


### PR DESCRIPTION
## Description
SauceConnect tunnels are now supported in US-East, this condition must be removed in order to allow their usage in that region.
