### PR TITLE
feat: add warning about cypress.reporters

### DIFF
--- a/internal/cypress/v1/config.go
+++ b/internal/cypress/v1/config.go
@@ -223,6 +223,10 @@ func (p *Project) Validate() error {
 		return fmt.Errorf(msg.InvalidLaunchingOption, p.Sauce.LaunchOrder, string(config.LaunchOrderFailRate))
 	}
 
+	if len(p.Cypress.Reporters) > 0 {
+		log.Warn().Msg("cypress.reporters has been deprecated. Migrate your reporting configuration to your cypress config file.")
+	}
+
 	// Validate suites.
 	if len(p.Suites) == 0 {
 		return errors.New(msg.EmptySuite)


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Start migrating users away from the `cypress.reporters` configuration in favour of configuring reporters via their cypress config.

[DEVX-2914]

[DEVX-2914]: https://saucedev.atlassian.net/browse/DEVX-2914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ