### PR TITLE
feat: skip smart retry on errored jobs

### DIFF
--- a/internal/cucumber/config.go
+++ b/internal/cucumber/config.go
@@ -342,11 +342,13 @@ func getFailedSpecFiles(report saucereport.SauceReport) ([]string, error) {
 	if report.Status != saucereport.StatusFailed {
 		return failedSpecs, nil
 	}
+
+	re, err := regexp.Compile(".*.feature$")
+	if err != nil {
+		return failedSpecs, err
+	}
+
 	for _, s := range report.Suites {
-		re, err := regexp.Compile(".*.feature$")
-		if err != nil {
-			return failedSpecs, err
-		}
 		if s.Status == saucereport.StatusFailed && re.MatchString(s.Name) {
 			failedSpecs = append(failedSpecs, filepath.Clean(s.Name))
 		}

--- a/internal/cucumber/config.go
+++ b/internal/cucumber/config.go
@@ -327,8 +327,9 @@ func (p *Project) FilterFailedTests(suiteName string, report saucereport.SauceRe
 		if s.Name != suiteName {
 			continue
 		}
-		found = true
 		p.Suites[i].Options.Paths = specs
+		found = true
+		break
 	}
 
 	if !found {

--- a/internal/cypress/v1/config.go
+++ b/internal/cypress/v1/config.go
@@ -569,12 +569,12 @@ func (p *Project) FilterFailedTests(suiteName string, report saucereport.SauceRe
 		if s.Name != suiteName {
 			continue
 		}
-		found = true
 		if p.Suites[i].Config.Env == nil {
 			p.Suites[i].Config.Env = map[string]string{}
 		}
 		p.Suites[i].Config.Env["grep"] = strings.Join(failedTests, ";")
-
+		found = true
+		break
 	}
 	if !found {
 		return fmt.Errorf("suite(%s) not found", suiteName)

--- a/internal/msg/errormsg.go
+++ b/internal/msg/errormsg.go
@@ -204,6 +204,9 @@ const (
 	UnableToArchiveRunnerConfig = "Unable to archive sauce runner config file"
 	// UnableToUploadConfig indicates a failure to upload config
 	UnableToUploadConfig = "Unable to upload sauce runner config file %q"
+	// UnreliableReport indicates that the job is not smart-retryable due to its
+	// status.
+	UnreliableReport = "Test reports from errored jobs are not a reliable source to correctly determine failed tests."
 )
 
 // container

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -433,8 +433,9 @@ func (p *Project) FilterFailedTests(suiteName string, report saucereport.SauceRe
 		if s.Name != suiteName {
 			continue
 		}
-		found = true
 		p.Suites[i].Params.Grep = strings.Join(failedTests, "|")
+		found = true
+		break
 	}
 	if !found {
 		return fmt.Errorf("suite(%s) not found", suiteName)

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -958,7 +958,7 @@ func (r *CloudRunner) reportSuiteToInsights(res result) {
 	res.details.Device = j.DeviceName
 
 	var testRuns []insights.TestRun
-	if arrayContains(assets, saucereport.SauceReportFileName) {
+	if arrayContains(assets, saucereport.FileName) {
 		report, err := r.loadSauceTestReport(res.job.ID, res.job.IsRDC)
 		if err != nil {
 			log.Warn().Err(err).Str("action", "parsingJSON").Str("jobID", res.job.ID).Msg(msg.InsightsReportError)
@@ -982,7 +982,7 @@ func (r *CloudRunner) reportSuiteToInsights(res result) {
 }
 
 func (r *CloudRunner) loadSauceTestReport(jobID string, isRDC bool) (saucereport.SauceReport, error) {
-	fileContent, err := r.JobService.GetJobAssetFileContent(context.Background(), jobID, saucereport.SauceReportFileName, isRDC)
+	fileContent, err := r.JobService.GetJobAssetFileContent(context.Background(), jobID, saucereport.FileName, isRDC)
 	if err != nil {
 		log.Warn().Err(err).Str("action", "loading-json-report").Msg(msg.InsightsReportError)
 		return saucereport.SauceReport{}, err

--- a/internal/saucecloud/cloud_test.go
+++ b/internal/saucecloud/cloud_test.go
@@ -491,10 +491,10 @@ func TestCloudRunner_loadSauceTestReport(t *testing.T) {
 			},
 			fields: fields{
 				GetJobAssetFileNamesFn: func(ctx context.Context, jobID string) ([]string, error) {
-					return []string{saucereport.SauceReportFileName}, nil
+					return []string{saucereport.FileName}, nil
 				},
 				GetJobAssetFileContentFn: func(ctx context.Context, jobID, fileName string) ([]byte, error) {
-					if fileName == saucereport.SauceReportFileName {
+					if fileName == saucereport.FileName {
 						return []byte(`{"status":"failed","attachments":[],"suites":[{"name":"cypress/e2e/examples/actions.cy.js","status":"failed","metadata":{},"suites":[{"name":"Actions","status":"failed","metadata":{},"suites":[],"attachments":[],"tests":[{"name":".type() - type into a DOM element","status":"passed","startTime":"2022-12-22T10:10:11.083Z","duration":1802,"metadata":{},"output":null,"attachments":[],"code":{"lines":["() => {","    // https://on.cypress.io/type","    cy.get('.action-email').type('fake@email.com').should('have.value', 'fake@email.com');","  }"]},"videoTimestamp":26.083},{"name":".type() - type into a wrong DOM element","status":"failed","startTime":"2022-12-22T10:10:12.907Z","duration":5010,"metadata":{},"output":"AssertionError: Timed out retrying after 4000ms: expected '<input#email1.form-control.action-email>' to have value 'wrongy@email.com', but the value was 'fake@email.com'\n\n  11 |     // https://on.cypress.io/type\n  12 |     cy.get('.action-email')\n> 13 |         .type('fake@email.com').should('have.value', 'wrongy@email.com')\n     |                                 ^\n  14 |   })\n  15 | })\n  16 | ","attachments":[{"name":"screenshot","path":"Actions -- .type() - type into a wrong DOM element (failed).png","contentType":"image/png"}],"code":{"lines":["() => {","    // https://on.cypress.io/type","    cy.get('.action-email').type('fake@email.com').should('have.value', 'wrongy@email.com');","  }"]},"videoTimestamp":27.907}]}],"attachments":[],"tests":[]}],"metadata":{}}`), nil
 					}
 					return []byte{}, errors.New("not-found")

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -28,6 +28,9 @@ func (b *JunitRetrier) Retry(jobOpts chan<- job.StartOptions, opt job.StartOptio
 		}
 
 		tests = b.retryFailedTests(jobReader, &opt, previous)
+		if len(tests) == 0 {
+			log.Info().Msg(msg.SkippingSmartRetries)
+		}
 	}
 
 	lg := log.Info().

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -70,13 +70,13 @@ func setClassesToRetry(opt *job.StartOptions, testcases []junit.TestCase) {
 }
 
 func (b *JunitRetrier) Retry(jobOpts chan<- job.StartOptions, opt job.StartOptions, previous job.Job) {
-	if b.RDCReader != nil && previous.IsRDC && opt.SmartRetry.FailedOnly {
-		b.retryFailedTests(b.RDCReader, jobOpts, opt, previous)
-		return
-	}
+	if opt.SmartRetry.FailedOnly {
+		jobReader := b.VDCReader
+		if previous.IsRDC {
+			jobReader = b.RDCReader
+		}
 
-	if b.VDCReader != nil && !previous.IsRDC && opt.SmartRetry.FailedOnly {
-		b.retryFailedTests(b.VDCReader, jobOpts, opt, previous)
+		b.retryFailedTests(jobReader, jobOpts, opt, previous)
 		return
 	}
 

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -36,6 +36,13 @@ func (b *JunitRetrier) Retry(jobOpts chan<- job.StartOptions, opt job.StartOptio
 }
 
 func (b *JunitRetrier) retryFailedTests(reader job.Reader, jobOpts chan<- job.StartOptions, opt job.StartOptions, previous job.Job) {
+	if previous.Status == job.StateError {
+		log.Warn().Msg(msg.UnreliableReport)
+		log.Info().Msg(msg.SkippingSmartRetries)
+		jobOpts <- opt
+		return
+	}
+
 	content, err := reader.GetJobAssetFileContent(context.Background(), previous.ID, junit.FileName, previous.IsRDC)
 	if err != nil {
 		log.Err(err).Msgf(msg.UnableToFetchFile, junit.FileName)

--- a/internal/saucecloud/retry/junitretrier_test.go
+++ b/internal/saucecloud/retry/junitretrier_test.go
@@ -204,37 +204,6 @@ func TestAppsRetrier_Retry(t *testing.T) {
 			},
 		},
 		{
-			name: "Job not retrying if RDC and config is VDC + SmartRetry",
-			init: init{
-				RetryVDC: true,
-			},
-			args: args{
-				jobOpts: make(chan job.StartOptions),
-				opt: job.StartOptions{
-					DisplayName: "Dummy Test",
-					SmartRetry: job.SmartRetry{
-						FailedOnly: true,
-					},
-					TestOptions: map[string]interface{}{
-						"class": []string{"Demo.Class1", "Demo.Class2", "Demo.Class3"},
-					},
-				},
-				previous: job.Job{
-					ID:    "fake-job-id",
-					IsRDC: true,
-				},
-			},
-			expected: job.StartOptions{
-				DisplayName: "Dummy Test",
-				TestOptions: map[string]interface{}{
-					"class": []string{"Demo.Class1", "Demo.Class2", "Demo.Class3"},
-				},
-				SmartRetry: job.SmartRetry{
-					FailedOnly: true,
-				},
-			},
-		},
-		{
 			name: "Job is retrying when VDC + SmartRetry",
 			init: init{
 				VDCReader: &mocks.FakeJobReader{

--- a/internal/saucecloud/retry/saucereportretrier.go
+++ b/internal/saucecloud/retry/saucereportretrier.go
@@ -74,6 +74,10 @@ func (r *SauceReportRetrier) retryFailedTests(opt *job.StartOptions, previous jo
 	if len(opt.OtherApps) == 0 {
 		opt.OtherApps = []string{fmt.Sprintf("storage:%s", storageID)}
 	} else {
+		// FIXME(AlexP): Code smell! The order of elements in OtherApps is
+		// defined by CloudRunner. While the order itself is not important, the
+		// type of app is. We should not rely on the order of elements in the
+		// slice. If we need to know the type, we should use a map.
 		opt.OtherApps[0] = fmt.Sprintf("storage:%s", storageID)
 	}
 

--- a/internal/saucecloud/retry/saucereportretrier.go
+++ b/internal/saucecloud/retry/saucereportretrier.go
@@ -65,16 +65,16 @@ func (r *SauceReportRetrier) retryFailedTests(opt *job.StartOptions, previous jo
 		return false
 	}
 
-	fileURL, err := r.uploadConfig(runnerFile)
+	storageID, err := r.uploadConfig(runnerFile)
 	if err != nil {
 		log.Err(err).Msgf(msg.UnableToUploadConfig, runnerFile)
 		return false
 	}
 
 	if len(opt.OtherApps) == 0 {
-		opt.OtherApps = []string{fmt.Sprintf("storage:%s", fileURL)}
+		opt.OtherApps = []string{fmt.Sprintf("storage:%s", storageID)}
 	} else {
-		opt.OtherApps[0] = fmt.Sprintf("storage:%s", fileURL)
+		opt.OtherApps[0] = fmt.Sprintf("storage:%s", storageID)
 	}
 
 	return true

--- a/internal/saucecloud/retry/saucereportretrier.go
+++ b/internal/saucecloud/retry/saucereportretrier.go
@@ -24,7 +24,7 @@ type SauceReportRetrier struct {
 }
 
 func (r *SauceReportRetrier) Retry(jobOpts chan<- job.StartOptions, opt job.StartOptions, previous job.Job) {
-	if r.VDCReader != nil && opt.SmartRetry.FailedOnly {
+	if opt.SmartRetry.FailedOnly {
 		r.RetryFailedTests(&opt, previous)
 	}
 

--- a/internal/saucecloud/retry/saucereportretrier.go
+++ b/internal/saucecloud/retry/saucereportretrier.go
@@ -58,6 +58,7 @@ func (r *SauceReportRetrier) retryFailedTests(opt *job.StartOptions, previous jo
 		log.Err(err).Msg(msg.UnableToCreateRunnerConfig)
 		return false
 	}
+	defer os.RemoveAll(tempDir)
 
 	runnerFile, err := zip.ArchiveRunnerConfig(r.Project, tempDir)
 	if err != nil {

--- a/internal/saucecloud/retry/saucereportretrier.go
+++ b/internal/saucecloud/retry/saucereportretrier.go
@@ -36,6 +36,13 @@ func (r *SauceReportRetrier) Retry(jobOpts chan<- job.StartOptions, opt job.Star
 }
 
 func (r *SauceReportRetrier) RetryFailedTests(jobOpts chan<- job.StartOptions, opt job.StartOptions, previous job.Job) {
+	if previous.Status == job.StateError {
+		log.Warn().Msg(msg.UnreliableReport)
+		log.Info().Msg(msg.SkippingSmartRetries)
+		jobOpts <- opt
+		return
+	}
+
 	report, err := r.getSauceReport(previous)
 	if err != nil {
 		log.Err(err).Msgf(msg.UnableToFetchFile, saucereport.SauceReportFileName)

--- a/internal/saucecloud/retry/saucereportretrier.go
+++ b/internal/saucecloud/retry/saucereportretrier.go
@@ -44,7 +44,7 @@ func (r *SauceReportRetrier) retryFailedTests(opt *job.StartOptions, previous jo
 
 	report, err := r.getSauceReport(previous)
 	if err != nil {
-		log.Err(err).Msgf(msg.UnableToFetchFile, saucereport.SauceReportFileName)
+		log.Err(err).Msgf(msg.UnableToFetchFile, saucereport.FileName)
 		return false
 	}
 
@@ -104,7 +104,7 @@ func (r *SauceReportRetrier) uploadConfig(filename string) (string, error) {
 }
 
 func (r *SauceReportRetrier) getSauceReport(job job.Job) (saucereport.SauceReport, error) {
-	content, err := r.VDCReader.GetJobAssetFileContent(context.Background(), job.ID, saucereport.SauceReportFileName, false)
+	content, err := r.VDCReader.GetJobAssetFileContent(context.Background(), job.ID, saucereport.FileName, false)
 	if err != nil {
 		return saucereport.SauceReport{}, err
 	}

--- a/internal/saucecloud/retry/saucereportretrier.go
+++ b/internal/saucecloud/retry/saucereportretrier.go
@@ -47,14 +47,15 @@ func (r *SauceReportRetrier) retryFailedTests(opt *job.StartOptions, previous jo
 		log.Err(err).Msgf(msg.UnableToFetchFile, saucereport.SauceReportFileName)
 		return false
 	}
-	tempDir, err := os.MkdirTemp(os.TempDir(), "saucectl-app-payload-")
-	if err != nil {
-		log.Err(err).Msg(msg.UnableToCreateRunnerConfig)
-		return false
-	}
 
 	if err := r.Project.FilterFailedTests(opt.Name, report); err != nil {
 		log.Err(err).Msg(msg.UnableToFilterFailedTests)
+		return false
+	}
+
+	tempDir, err := os.MkdirTemp(os.TempDir(), "saucectl-app-payload-")
+	if err != nil {
+		log.Err(err).Msg(msg.UnableToCreateRunnerConfig)
 		return false
 	}
 

--- a/internal/saucecloud/retry/saucereportretrier.go
+++ b/internal/saucecloud/retry/saucereportretrier.go
@@ -25,7 +25,7 @@ type SauceReportRetrier struct {
 
 func (r *SauceReportRetrier) Retry(jobOpts chan<- job.StartOptions, opt job.StartOptions, previous job.Job) {
 	if opt.SmartRetry.FailedOnly {
-		r.RetryFailedTests(&opt, previous)
+		r.retryFailedTests(&opt, previous)
 	}
 
 	log.Info().Str("suite", opt.DisplayName).
@@ -34,7 +34,7 @@ func (r *SauceReportRetrier) Retry(jobOpts chan<- job.StartOptions, opt job.Star
 	jobOpts <- opt
 }
 
-func (r *SauceReportRetrier) RetryFailedTests(opt *job.StartOptions, previous job.Job) {
+func (r *SauceReportRetrier) retryFailedTests(opt *job.StartOptions, previous job.Job) {
 	if previous.Status == job.StateError {
 		log.Warn().Msg(msg.UnreliableReport)
 		log.Info().Msg(msg.SkippingSmartRetries)

--- a/internal/saucereport/saucereport.go
+++ b/internal/saucereport/saucereport.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-// SauceReportFileName is the name for Sauce Labs report.
-const SauceReportFileName = "sauce-test-report.json"
+// FileName is the name for Sauce Labs report.
+const FileName = "sauce-test-report.json"
 
 // The different states that a job can be in.
 const (

--- a/internal/testcafe/config.go
+++ b/internal/testcafe/config.go
@@ -429,8 +429,9 @@ func (p *Project) FilterFailedTests(suiteName string, report saucereport.SauceRe
 		if s.Name != suiteName {
 			continue
 		}
-		found = true
 		p.Suites[i].Filter.TestGrep = strings.Join(failedTests, "|")
+		found = true
+		break
 	}
 	if !found {
 		return fmt.Errorf("suite(%s) not found", suiteName)


### PR DESCRIPTION
## Description

The Sauce platform distinguishes failures from errors. Failures to tend indicate test failures, aka assertion failures. Errors on the other hand are more “fatal” and pertain to the execution of the Job itself.

Our investigation has shown that if a job errors, it's safer to not rely on a test framework's test report for the specific use case of failed-test-filtering via _smart retry_, because the report itself may not contain all tests that were supposed to run and only results up to the point of failure. Saucectl would then retry the failed test(s), but the unexecuted tests will remain unexecuted.

With this change, _smart retry_ will retry errored jobs much a like a regular retry, without any "smart filtering".