### PR TITLE
fix!: Update npm.strictSSL behavior

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,7 @@ brews:
       name: devx-sauce-bot
       email: devx.bot@saucelabs.com
 archives:
-  - version_template: >-
+  - name_template: >-
       {{ .ProjectName }}_{{ .Version }}_
       {{- if eq .Os "darwin"}}mac_
       {{- else if eq .Os "linux" }}linux_
@@ -50,7 +50,7 @@ archives:
     files:
       - LICENSE
 checksum:
-  version_template: 'checksums.txt'
+  name_template: 'checksums.txt'
 snapshot:
   version_template: "{{ .Tag }}-next"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,7 @@ brews:
       name: devx-sauce-bot
       email: devx.bot@saucelabs.com
 archives:
-  - name_template: >-
+  - version_template: >-
       {{ .ProjectName }}_{{ .Version }}_
       {{- if eq .Os "darwin"}}mac_
       {{- else if eq .Os "linux" }}linux_
@@ -50,9 +50,9 @@ archives:
     files:
       - LICENSE
 checksum:
-  name_template: 'checksums.txt'
+  version_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:

--- a/internal/cmd/docker/push.go
+++ b/internal/cmd/docker/push.go
@@ -129,8 +129,7 @@ func logPushProgress(reader io.ReadCloser) error {
 
 			// Create a progress spinner for statuses that don't have progress details, like 'Preparing'.
 			if msg.Progress == nil || msg.Progress.Total == 0 {
-				//nolint:govet
-				progress.Show(msg.Status)
+				progress.Show(msg.Status, nil)
 				continue
 			}
 

--- a/internal/cmd/docker/push.go
+++ b/internal/cmd/docker/push.go
@@ -129,6 +129,7 @@ func logPushProgress(reader io.ReadCloser) error {
 
 			// Create a progress spinner for statuses that don't have progress details, like 'Preparing'.
 			if msg.Progress == nil || msg.Progress.Total == 0 {
+				//nolint:govet
 				progress.Show(msg.Status)
 				continue
 			}

--- a/internal/cmd/ini/initializer_test.go
+++ b/internal/cmd/ini/initializer_test.go
@@ -1629,7 +1629,7 @@ func Test_checkCredentials(t *testing.T) {
 			name: "Invalid credentials",
 			frameworkFn: func(ctx context.Context) ([]string, error) {
 				errMsg := "unexpected status '401' from test-composer: Unauthorized\n"
-				return []string{}, fmt.Errorf(errMsg)
+				return []string{}, errors.New(errMsg)
 			},
 			wantErr: errors.New("invalid credentials provided"),
 		},

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -84,7 +84,7 @@ func NewCypressCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https.")
+	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
 
 	// Deprecated flags
 	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration file")

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -84,7 +84,7 @@ func NewCypressCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https (default: false)")
+	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https.")
 
 	// Deprecated flags
 	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration file")

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -89,7 +89,7 @@ func NewCypressCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	cmd.PersistentFlags().BoolVar(&cflags.npmStrictSSL, "npm.strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
+	cmd.Flags().BoolVar(&cflags.npmStrictSSL, "npm.strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
 
 	// Deprecated flags
 	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration file")

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -84,7 +84,10 @@ func NewCypressCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https")
+	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https (default: false)")
+
+	// Deprecated flags
+	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration")
 
 	return cmd
 }

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -27,9 +27,14 @@ import (
 	"github.com/saucelabs/saucectl/internal/viper"
 )
 
+type cypressFlags struct {
+	npmStrictSSL bool
+}
+
 // NewCypressCmd creates the 'run' command for Cypress.
 func NewCypressCmd() *cobra.Command {
 	sc := flags.SnakeCharmer{Fmap: map[string]*pflag.Flag{}}
+	var cflags cypressFlags
 
 	cmd := &cobra.Command{
 		Use:              "cypress",
@@ -45,7 +50,7 @@ func NewCypressCmd() *cobra.Command {
 			// Test patterns are passed in via positional args.
 			viper.Set("suite::config::specPattern", args)
 
-			exitCode, err := runCypress(cmd, true)
+			exitCode, err := runCypress(cmd, cflags, true)
 			if err != nil {
 				log.Err(err).Msg("failed to execute run command")
 			}
@@ -84,7 +89,7 @@ func NewCypressCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
+	cmd.PersistentFlags().BoolVar(&cflags.npmStrictSSL, "npm.strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
 
 	// Deprecated flags
 	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration file")
@@ -92,7 +97,7 @@ func NewCypressCmd() *cobra.Command {
 	return cmd
 }
 
-func runCypress(cmd *cobra.Command, isCLIDriven bool) (int, error) {
+func runCypress(cmd *cobra.Command, cflags cypressFlags, isCLIDriven bool) (int, error) {
 	if !isCLIDriven {
 		config.ValidateSchema(gFlags.cfgFilePath)
 	}
@@ -107,10 +112,8 @@ func runCypress(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 		return 1, err
 	}
 
-	// If npm.strictSSL is not explicitly set via the flag and not configured via the config file,
-	// `StrictSSL` should remain unset, which means it should be nil.
-	if !cmd.Flags().Changed("npm.strictSSL") && gFlags.cfgFilePath == "" {
-		p.SetNpmStrictSSL(nil)
+	if cmd.Flags().Changed("npm.strictSSL") {
+		p.SetNpmStrictSSL(&cflags.npmStrictSSL)
 	}
 
 	p.SetDefaults()

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -87,7 +87,7 @@ func NewCypressCmd() *cobra.Command {
 	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https (default: false)")
 
 	// Deprecated flags
-	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration")
+	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration file")
 
 	return cmd
 }

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -106,6 +106,13 @@ func runCypress(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 	if err := p.ApplyFlags(gFlags.selectedSuite); err != nil {
 		return 1, err
 	}
+
+	// If npm.strictSSL is not explicitly set via the flag and not configured via the config file,
+	// `StrictSSL` should remain unset, which means it should be nil.
+	if !cmd.Flags().Changed("npm.strictSSL") && gFlags.cfgFilePath == "" {
+		p.SetNpmStrictSSL(nil)
+	}
+
 	p.SetDefaults()
 	if !gFlags.noAutoTagging {
 		p.AppendTags(ci.GetTags())

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -92,7 +92,7 @@ func NewPlaywrightCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https (default: false)")
+	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https.")
 
 	// Deprecated flags
 	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration file")

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -97,7 +97,7 @@ func NewPlaywrightCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	cmd.PersistentFlags().BoolVar(&pf.npmStrictSSL, "npm.strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
+	cmd.Flags().BoolVar(&pf.npmStrictSSL, "npm.strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
 
 	// Deprecated flags
 	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration file")

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -111,6 +111,12 @@ func runPlaywright(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 
 	p.CLIFlags = flags.CaptureCommandLineFlags(cmd.Flags())
 
+	// If npm.strictSSL is not explicitly set via the flag and not configured via the config file,
+	// `StrictSSL` should remain unset, which means it should be nil.
+	if !cmd.Flags().Changed("npm.strictSSL") && gFlags.cfgFilePath == "" {
+		p.Npm.StrictSSL = nil
+	}
+
 	if err := applyPlaywrightFlags(&p); err != nil {
 		return 1, err
 	}

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -92,8 +92,10 @@ func NewPlaywrightCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https")
+	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https (default: false)")
 
+	// Deprecated flags
+	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration")
 	return cmd
 }
 

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -95,7 +95,7 @@ func NewPlaywrightCmd() *cobra.Command {
 	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https (default: false)")
 
 	// Deprecated flags
-	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration")
+	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration file")
 	return cmd
 }
 

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -92,7 +92,7 @@ func NewPlaywrightCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https.")
+	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
 
 	// Deprecated flags
 	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration file")

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -195,10 +195,10 @@ func preRun() error {
 // Run runs the command
 func Run(cmd *cobra.Command) (int, error) {
 	if typeDef.Kind == cypress.Kind {
-		return runCypress(cmd, false)
+		return runCypress(cmd, cypressFlags{}, false)
 	}
 	if typeDef.Kind == playwright.Kind {
-		return runPlaywright(cmd, false)
+		return runPlaywright(cmd, playwrightFlags{}, false)
 	}
 	if typeDef.Kind == testcafe.Kind {
 		return runTestcafe(cmd, testcafeFlags{}, false)

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -142,6 +142,12 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 
 	p.CLIFlags = flags.CaptureCommandLineFlags(cmd.Flags())
 
+	// If npm.strictSSL is not explicitly set via the flag and not configured via the config file,
+	// `StrictSSL` should remain unset, which means it should be nil.
+	if !cmd.Flags().Changed("npm.strictSSL") && gFlags.cfgFilePath == "" {
+		p.Npm.StrictSSL = nil
+	}
+
 	if err := applyTestcafeFlags(&p, tcFlags); err != nil {
 		return 1, err
 	}

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -119,7 +119,7 @@ func NewTestcafeCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https (default: false)")
+	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https.")
 
 	// Simulators
 	f.Var(&lflags.Simulator, "simulator", "Specifies the simulator to use for testing")

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -125,7 +125,7 @@ func NewTestcafeCmd() *cobra.Command {
 	f.Var(&lflags.Simulator, "simulator", "Specifies the simulator to use for testing")
 
 	// Deprecated flags
-	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration")
+	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration file")
 
 	return cmd
 }

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -31,6 +31,7 @@ import (
 type testcafeFlags struct {
 	QuarantineMode flags.QuarantineMode
 	Simulator      flags.Simulator
+	npmStrictSSL   bool
 }
 
 // NewTestcafeCmd creates the 'run' command for TestCafe.
@@ -119,7 +120,7 @@ func NewTestcafeCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
+	cmd.PersistentFlags().BoolVar(&lflags.npmStrictSSL, "npm.strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
 
 	// Simulators
 	f.Var(&lflags.Simulator, "simulator", "Specifies the simulator to use for testing")
@@ -142,10 +143,8 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 
 	p.CLIFlags = flags.CaptureCommandLineFlags(cmd.Flags())
 
-	// If npm.strictSSL is not explicitly set via the flag and not configured via the config file,
-	// `StrictSSL` should remain unset, which means it should be nil.
-	if !cmd.Flags().Changed("npm.strictSSL") && gFlags.cfgFilePath == "" {
-		p.Npm.StrictSSL = nil
+	if cmd.Flags().Changed("npm.strictSSL") {
+		p.Npm.StrictSSL = &tcFlags.npmStrictSSL
 	}
 
 	if err := applyTestcafeFlags(&p, tcFlags); err != nil {

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -120,7 +120,7 @@ func NewTestcafeCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	cmd.PersistentFlags().BoolVar(&lflags.npmStrictSSL, "npm.strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
+	cmd.Flags().BoolVar(&lflags.npmStrictSSL, "npm.strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
 
 	// Simulators
 	f.Var(&lflags.Simulator, "simulator", "Specifies the simulator to use for testing")

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -119,7 +119,7 @@ func NewTestcafeCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https.")
+	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https.")
 
 	// Simulators
 	f.Var(&lflags.Simulator, "simulator", "Specifies the simulator to use for testing")

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -119,10 +119,13 @@ func NewTestcafeCmd() *cobra.Command {
 	sc.String("npm.registry", "npm::registry", "", "Specify the npm registry URL")
 	sc.StringToString("npm.packages", "npm::packages", map[string]string{}, "Specify npm packages that are required to run tests")
 	sc.StringSlice("npm.dependencies", "npm::dependencies", []string{}, "Specify local npm dependencies for saucectl to upload. These dependencies must already be installed in the local node_modules directory.")
-	sc.Bool("npm.strictSSL", "npm::strictSSL", true, "Whether or not to do SSL key validation when making requests to the registry via https")
+	sc.Bool("npm.strictSSL", "npm::strictSSL", false, "Whether or not to do SSL key validation when making requests to the registry via https (default: false)")
 
 	// Simulators
 	f.Var(&lflags.Simulator, "simulator", "Specifies the simulator to use for testing")
+
+	// Deprecated flags
+	_ = sc.Fset.MarkDeprecated("npm.registry", "please set the npm registries field in the Sauce configuration")
 
 	return cmd
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,7 +203,7 @@ type Npm struct {
 	Registries   []Registry        `yaml:"registries" json:"registries,omitempty"`
 	Packages     map[string]string `yaml:"packages,omitempty" json:"packages"`
 	Dependencies []string          `yaml:"dependencies,omitempty" json:"dependencies"`
-	StrictSSL    bool              `yaml:"strictSSL,omitempty" json:"strictSSL"`
+	StrictSSL    *bool             `yaml:"strictSSL,omitempty" json:"strictSSL"`
 }
 
 // Defaults represents default suite settings.

--- a/internal/cypress/config.go
+++ b/internal/cypress/config.go
@@ -40,6 +40,7 @@ type Project interface {
 	GetReporters() config.Reporters
 	GetNotifications() config.Notifications
 	GetNpm() config.Npm
+	SetNpmStrictSSL(strictSSL *bool)
 	SetCLIFlags(map[string]interface{})
 	GetSuites() []suite.Suite
 	GetKind() string

--- a/internal/cypress/v1/config.go
+++ b/internal/cypress/v1/config.go
@@ -447,6 +447,10 @@ func (p *Project) GetNpm() config.Npm {
 	return p.Npm
 }
 
+func (p *Project) SetNpmStrictSSL(strictSSL *bool) {
+	p.Npm.StrictSSL = strictSSL
+}
+
 // SetCLIFlags sets cli flags
 func (p *Project) SetCLIFlags(flags map[string]interface{}) {
 	p.CLIFlags = flags

--- a/internal/http/proxy.go
+++ b/internal/http/proxy.go
@@ -66,7 +66,7 @@ func doCheckProxy(scheme string) error {
 			rawProxyURL = strings.Replace(rawProxyURL, pass, "****", -1)
 		}
 	}
-	log.Info().Msg(fmt.Sprintf("Using %s proxy: %s", strings.ToUpper(scheme), rawProxyURL))
+	log.Info().Msgf("Using %s proxy: %s", strings.ToUpper(scheme), rawProxyURL)
 	return nil
 }
 

--- a/internal/http/proxy.go
+++ b/internal/http/proxy.go
@@ -66,7 +66,7 @@ func doCheckProxy(scheme string) error {
 			rawProxyURL = strings.Replace(rawProxyURL, pass, "****", -1)
 		}
 	}
-	log.Info().Msgf(fmt.Sprintf("Using %s proxy: %s", strings.ToUpper(scheme), rawProxyURL))
+	log.Info().Msg(fmt.Sprintf("Using %s proxy: %s", strings.ToUpper(scheme), rawProxyURL))
 	return nil
 }
 


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
Update the `strictSSL` field to a boolean pointer to distinguish between three states: not set, `true`, or `false`.

When it's not set, the npm `strictSSL` default value of `true` will be used. 

`strictSSL` not set: https://app.saucelabs.com/tests/22db9a3effdc4d9cbd005839403df483
`strictSSL` is true: https://app.saucelabs.com/tests/5a57b6dc937c447ea22852c63d5d97c7
`strictSSL` is false: https://app.saucelabs.com/tests/1ac681507c9a4a8da2f14b1deb6169d9

This update should be merged after chef release. 

sauce-runner-utils updates: https://github.com/saucelabs/sauce-runner-utils/pull/76

Besides, mark `npm.registry` field as deprecated.