### PR TITLE
refactor: Encapsulate artifact downloading

### DIFF
--- a/internal/cmd/artifacts/cmd.go
+++ b/internal/cmd/artifacts/cmd.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/saucelabs/saucectl/internal/artifacts"
-	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
@@ -45,7 +44,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 			creds := credentials.Get()
 			url := reg.APIBaseURL()
 			restoClient := http.NewResto(url, creds.Username, creds.AccessKey, restoTimeout)
-			rdcClient := http.NewRDCService(url, creds.Username, creds.AccessKey, rdcTimeout, config.ArtifactDownload{})
+			rdcClient := http.NewRDCService(url, creds.Username, creds.AccessKey, rdcTimeout)
 			testcompClient := http.NewTestComposer(url, creds, testComposerTimeout)
 
 			artifactSvc = saucecloud.NewArtifactService(&restoClient, &rdcClient, &testcompClient)

--- a/internal/cmd/ini/initializer.go
+++ b/internal/cmd/ini/initializer.go
@@ -59,7 +59,7 @@ type initializer struct {
 func newInitializer(stdio terminal.Stdio, creds iam.Credentials, cfg *initConfig) *initializer {
 	r := region.FromString(cfg.region)
 	tc := http.NewTestComposer(r.APIBaseURL(), creds, testComposerTimeout)
-	rc := http.NewRDCService(r.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout, config.ArtifactDownload{})
+	rc := http.NewRDCService(r.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
 	rs := http.NewResto(r.APIBaseURL(), creds.Username, creds.AccessKey, restoTimeout)
 	us := http.NewUserService(r.APIBaseURL(), creds, 5*time.Second)
 

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -19,6 +19,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/saucelabs/saucectl/internal/saucecloud"
+	"github.com/saucelabs/saucectl/internal/saucecloud/downloader"
 	"github.com/saucelabs/saucectl/internal/saucecloud/retry"
 	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/saucelabs/saucectl/internal/usage"
@@ -137,13 +138,15 @@ func runEspressoInCloud(p espresso.Project, regio region.Region) (int, error) {
 
 	creds := regio.Credentials()
 	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
-	restoClient.ArtifactConfig = p.Artifacts.Download
 	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)
 	webdriverClient := http.NewWebdriver(regio.WebDriverBaseURL(), creds, webdriverTimeout)
 	appsClient := *http.NewAppStore(regio.APIBaseURL(), creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
-	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout, p.Artifacts.Download)
+	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
 	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
 	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
+
+	vdcDownloader := downloader.NewArtifactDownloader(&restoClient, p.Artifacts.Download)
+	rdcDownloader := downloader.NewArtifactDownloader(&rdcClient, p.Artifacts.Download)
 
 	r := saucecloud.EspressoRunner{
 		Project: p,
@@ -157,8 +160,8 @@ func runEspressoInCloud(p espresso.Project, regio region.Region) (int, error) {
 				VDCWriter:     &testcompClient,
 				VDCStopper:    &restoClient,
 				RDCStopper:    &rdcClient,
-				VDCDownloader: &restoClient,
-				RDCDownloader: &rdcClient,
+				VDCDownloader: &vdcDownloader,
+				RDCDownloader: &rdcDownloader,
 			},
 			TunnelService:   &restoClient,
 			MetadataService: &testcompClient,

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -21,6 +21,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/puppeteer/replay"
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/saucelabs/saucectl/internal/saucecloud"
+	"github.com/saucelabs/saucectl/internal/saucecloud/downloader"
 	"github.com/saucelabs/saucectl/internal/saucecloud/retry"
 	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/saucelabs/saucectl/internal/usage"
@@ -125,13 +126,14 @@ func runPuppeteerReplayInSauce(p replay.Project, regio region.Region) (int, erro
 
 	creds := regio.Credentials()
 	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
-	restoClient.ArtifactConfig = p.Artifacts.Download
 	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)
 	webdriverClient := http.NewWebdriver(regio.WebDriverBaseURL(), creds, webdriverTimeout)
 	appsClient := *http.NewAppStore(regio.APIBaseURL(), creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
-	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout, config.ArtifactDownload{})
+	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
 	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
 	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
+
+	vdcDownloader := downloader.NewArtifactDownloader(&restoClient, p.Artifacts.Download)
 
 	r := saucecloud.ReplayRunner{
 		Project: p,
@@ -145,7 +147,7 @@ func runPuppeteerReplayInSauce(p replay.Project, regio region.Region) (int, erro
 				VDCWriter:     &testcompClient,
 				VDCStopper:    &restoClient,
 				RDCStopper:    &rdcClient,
-				VDCDownloader: &restoClient,
+				VDCDownloader: &vdcDownloader,
 			},
 			TunnelService:   &restoClient,
 			MetadataService: &testcompClient,

--- a/internal/http/rdcservice_test.go
+++ b/internal/http/rdcservice_test.go
@@ -350,50 +350,6 @@ func TestRDCService_GetJobAssetFileContent(t *testing.T) {
 	}
 }
 
-// func TestRDCService_DownloadArtifact(t *testing.T) {
-// 	fileContent := "<xml>junit.xml</xml>"
-// 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-// 		var err error
-// 		switch r.URL.Path {
-// 		case "/v1/rdc/jobs/test-123":
-// 			_, err = w.Write([]byte(`{"automation_backend":"espresso"}`))
-// 		case "/v1/rdc/jobs/test-123/junit.xml":
-// 			_, err = w.Write([]byte(fileContent))
-// 		default:
-// 			w.WriteHeader(http.StatusNotFound)
-// 		}
-// 
-// 		if err != nil {
-// 			t.Errorf("failed to respond: %v", err)
-// 		}
-// 	}))
-// 	defer ts.Close()
-// 
-// 	tempDir, err := os.MkdirTemp("", "saucectl-download-artifact")
-// 	if err != nil {
-// 		t.Errorf("Failed to create temp dir: %v", err)
-// 	}
-// 	defer func() {
-// 		_ = os.RemoveAll(tempDir)
-// 	}()
-// 
-// 	rc := NewRDCService(ts.URL, "dummy-user", "dummy-key", 10*time.Second, config.ArtifactDownload{
-// 		Directory: tempDir,
-// 		Match:     []string{"junit.xml"},
-// 	})
-// 	rc.DownloadArtifact("test-123", "suite name", true)
-// 
-// 	fileName := filepath.Join(tempDir, "suite_name", "junit.xml")
-// 	d, err := os.ReadFile(fileName)
-// 	if err != nil {
-// 		t.Errorf("file '%s' not found: %v", fileName, err)
-// 	}
-// 
-// 	if string(d) != fileContent {
-// 		t.Errorf("file content mismatch: got '%v', expects: '%v'", d, fileContent)
-// 	}
-// }
-
 func TestRDCService_GetDevices(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var err error

--- a/internal/http/rdcservice_test.go
+++ b/internal/http/rdcservice_test.go
@@ -7,15 +7,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/devices"
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/stretchr/testify/assert"
@@ -45,7 +42,7 @@ func TestRDCService_ReadJob(t *testing.T) {
 	}))
 	defer ts.Close()
 	timeout := 3 * time.Second
-	client := NewRDCService(ts.URL, "test-user", "test-key", timeout, config.ArtifactDownload{})
+	client := NewRDCService(ts.URL, "test-user", "test-key", timeout)
 
 	testCases := []struct {
 		name    string
@@ -142,7 +139,7 @@ func TestRDCService_PollJob(t *testing.T) {
 	}{
 		{
 			name:   "get job details with ID 1 and status 'complete'",
-			client: NewRDCService(ts.URL, "test", "123", timeout, config.ArtifactDownload{}),
+			client: NewRDCService(ts.URL, "test", "123", timeout),
 			jobID:  "1",
 			expectedResp: job.Job{
 				ID:     "1",
@@ -155,7 +152,7 @@ func TestRDCService_PollJob(t *testing.T) {
 		},
 		{
 			name:   "get job details with ID 2 and status 'error'",
-			client: NewRDCService(ts.URL, "test", "123", timeout, config.ArtifactDownload{}),
+			client: NewRDCService(ts.URL, "test", "123", timeout),
 			jobID:  "2",
 			expectedResp: job.Job{
 				ID:     "2",
@@ -168,28 +165,28 @@ func TestRDCService_PollJob(t *testing.T) {
 		},
 		{
 			name:         "job not found error from external API",
-			client:       NewRDCService(ts.URL, "test", "123", timeout, config.ArtifactDownload{}),
+			client:       NewRDCService(ts.URL, "test", "123", timeout),
 			jobID:        "3",
 			expectedResp: job.Job{},
 			expectedErr:  ErrJobNotFound,
 		},
 		{
 			name:         "http status is not 200, but 401 from external API",
-			client:       NewRDCService(ts.URL, "test", "123", timeout, config.ArtifactDownload{}),
+			client:       NewRDCService(ts.URL, "test", "123", timeout),
 			jobID:        "4",
 			expectedResp: job.Job{},
 			expectedErr:  errors.New("unexpected statusCode: 401"),
 		},
 		{
 			name:         "unexpected status code from external API",
-			client:       NewRDCService(ts.URL, "test", "123", timeout, config.ArtifactDownload{}),
+			client:       NewRDCService(ts.URL, "test", "123", timeout),
 			jobID:        "333",
 			expectedResp: job.Job{},
 			expectedErr:  errors.New("internal server error"),
 		},
 		{
 			name:   "get job details with ID 5. retry 2 times and succeed",
-			client: NewRDCService(ts.URL, "test", "123", timeout, config.ArtifactDownload{}),
+			client: NewRDCService(ts.URL, "test", "123", timeout),
 			jobID:  "5",
 			expectedResp: job.Job{
 				ID:     "5",
@@ -241,7 +238,7 @@ func TestRDCService_GetJobAssetFileNames(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
-	client := NewRDCService(ts.URL, "test-user", "test-password", 1*time.Second, config.ArtifactDownload{})
+	client := NewRDCService(ts.URL, "test-user", "test-password", 1*time.Second)
 
 	testCases := []struct {
 		name     string
@@ -314,7 +311,7 @@ func TestRDCService_GetJobAssetFileContent(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
-	client := NewRDCService(ts.URL, "test-user", "test-password", 1*time.Second, config.ArtifactDownload{})
+	client := NewRDCService(ts.URL, "test-user", "test-password", 1*time.Second)
 
 	testCases := []struct {
 		name     string
@@ -353,49 +350,49 @@ func TestRDCService_GetJobAssetFileContent(t *testing.T) {
 	}
 }
 
-func TestRDCService_DownloadArtifact(t *testing.T) {
-	fileContent := "<xml>junit.xml</xml>"
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var err error
-		switch r.URL.Path {
-		case "/v1/rdc/jobs/test-123":
-			_, err = w.Write([]byte(`{"automation_backend":"espresso"}`))
-		case "/v1/rdc/jobs/test-123/junit.xml":
-			_, err = w.Write([]byte(fileContent))
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-
-		if err != nil {
-			t.Errorf("failed to respond: %v", err)
-		}
-	}))
-	defer ts.Close()
-
-	tempDir, err := os.MkdirTemp("", "saucectl-download-artifact")
-	if err != nil {
-		t.Errorf("Failed to create temp dir: %v", err)
-	}
-	defer func() {
-		_ = os.RemoveAll(tempDir)
-	}()
-
-	rc := NewRDCService(ts.URL, "dummy-user", "dummy-key", 10*time.Second, config.ArtifactDownload{
-		Directory: tempDir,
-		Match:     []string{"junit.xml"},
-	})
-	rc.DownloadArtifact("test-123", "suite name", true)
-
-	fileName := filepath.Join(tempDir, "suite_name", "junit.xml")
-	d, err := os.ReadFile(fileName)
-	if err != nil {
-		t.Errorf("file '%s' not found: %v", fileName, err)
-	}
-
-	if string(d) != fileContent {
-		t.Errorf("file content mismatch: got '%v', expects: '%v'", d, fileContent)
-	}
-}
+// func TestRDCService_DownloadArtifact(t *testing.T) {
+// 	fileContent := "<xml>junit.xml</xml>"
+// 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 		var err error
+// 		switch r.URL.Path {
+// 		case "/v1/rdc/jobs/test-123":
+// 			_, err = w.Write([]byte(`{"automation_backend":"espresso"}`))
+// 		case "/v1/rdc/jobs/test-123/junit.xml":
+// 			_, err = w.Write([]byte(fileContent))
+// 		default:
+// 			w.WriteHeader(http.StatusNotFound)
+// 		}
+// 
+// 		if err != nil {
+// 			t.Errorf("failed to respond: %v", err)
+// 		}
+// 	}))
+// 	defer ts.Close()
+// 
+// 	tempDir, err := os.MkdirTemp("", "saucectl-download-artifact")
+// 	if err != nil {
+// 		t.Errorf("Failed to create temp dir: %v", err)
+// 	}
+// 	defer func() {
+// 		_ = os.RemoveAll(tempDir)
+// 	}()
+// 
+// 	rc := NewRDCService(ts.URL, "dummy-user", "dummy-key", 10*time.Second, config.ArtifactDownload{
+// 		Directory: tempDir,
+// 		Match:     []string{"junit.xml"},
+// 	})
+// 	rc.DownloadArtifact("test-123", "suite name", true)
+// 
+// 	fileName := filepath.Join(tempDir, "suite_name", "junit.xml")
+// 	d, err := os.ReadFile(fileName)
+// 	if err != nil {
+// 		t.Errorf("file '%s' not found: %v", fileName, err)
+// 	}
+// 
+// 	if string(d) != fileContent {
+// 		t.Errorf("file content mismatch: got '%v', expects: '%v'", d, fileContent)
+// 	}
+// }
 
 func TestRDCService_GetDevices(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/saucecloud/downloader/downloader.go
+++ b/internal/saucecloud/downloader/downloader.go
@@ -1,0 +1,61 @@
+package downloader
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/fpath"
+	"github.com/saucelabs/saucectl/internal/job"
+)
+
+type ArtifactDownloader struct {
+	reader job.Reader
+	config config.ArtifactDownload
+}
+
+func NewArtifactDownloader(reader job.Reader, artifactConfig config.ArtifactDownload) ArtifactDownloader {
+	return ArtifactDownloader{
+		reader: reader,
+		config: artifactConfig,
+	}
+}
+
+func (d *ArtifactDownloader) DownloadArtifact(jobID string, suiteName string, realDevice bool) []string {
+	targetDir, err := config.GetSuiteArtifactFolder(suiteName, d.config)
+	if err != nil {
+		log.Error().Msgf("Unable to create artifacts folder (%v)", err)
+		return []string{}
+	}
+	files, err := d.reader.GetJobAssetFileNames(context.Background(), jobID, realDevice)
+	if err != nil {
+		log.Error().Msgf("Unable to fetch artifacts list (%v)", err)
+		return []string{}
+	}
+
+	filepaths := fpath.MatchFiles(files, d.config.Match)
+	var artifacts []string
+	for _, f := range filepaths {
+		targetFile, err := d.downloadArtifact(targetDir, jobID, f, realDevice)
+		if err != nil {
+			log.Err(err).Msg("Unable to download artifacts")
+			return artifacts
+		}
+		artifacts = append(artifacts, targetFile)
+	}
+
+	return artifacts
+}
+	
+func (d *ArtifactDownloader) downloadArtifact(targetDir, jobID, fileName string, realDevice bool) (string, error) {
+	content, err := d.reader.GetJobAssetFileContent(context.Background(), jobID, fileName, realDevice)
+	if err != nil {
+		return "", err
+	}
+	targetFile := filepath.Join(targetDir, fileName)
+	return targetFile, os.WriteFile(targetFile, content, 0644)
+}
+
+

--- a/internal/saucecloud/downloader/downloader.go
+++ b/internal/saucecloud/downloader/downloader.go
@@ -48,7 +48,7 @@ func (d *ArtifactDownloader) DownloadArtifact(jobID string, suiteName string, re
 
 	return artifacts
 }
-	
+
 func (d *ArtifactDownloader) downloadArtifact(targetDir, jobID, fileName string, realDevice bool) (string, error) {
 	content, err := d.reader.GetJobAssetFileContent(context.Background(), jobID, fileName, realDevice)
 	if err != nil {
@@ -57,5 +57,3 @@ func (d *ArtifactDownloader) downloadArtifact(targetDir, jobID, fileName string,
 	targetFile := filepath.Join(targetDir, fileName)
 	return targetFile, os.WriteFile(targetFile, content, 0644)
 }
-
-

--- a/internal/saucecloud/downloader/downloader_test.go
+++ b/internal/saucecloud/downloader/downloader_test.go
@@ -1,0 +1,60 @@
+package downloader
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/saucelabs/saucectl/internal/config"
+	httpServices "github.com/saucelabs/saucectl/internal/http"
+)
+
+func TestArtifactDownloader_DownloadArtifact(t *testing.T) {
+ 	fileContent := "<xml>junit.xml</xml>"
+ 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+ 		var err error
+ 		switch r.URL.Path {
+ 		case "/v1/rdc/jobs/test-123":
+ 			_, err = w.Write([]byte(`{"automation_backend":"espresso"}`))
+ 		case "/v1/rdc/jobs/test-123/junit.xml":
+ 			_, err = w.Write([]byte(fileContent))
+ 		default:
+ 			w.WriteHeader(http.StatusNotFound)
+ 		}
+ 
+ 		if err != nil {
+ 			t.Errorf("failed to respond: %v", err)
+ 		}
+ 	}))
+ 	defer ts.Close()
+ 
+ 	tempDir, err := os.MkdirTemp("", "saucectl-download-artifact")
+ 	if err != nil {
+ 		t.Errorf("Failed to create temp dir: %v", err)
+ 	}
+ 	defer func() {
+ 		_ = os.RemoveAll(tempDir)
+ 	}()
+ 
+ 	rc := httpServices.NewRDCService(ts.URL, "dummy-user", "dummy-key", 10*time.Second)
+	artifactCfg := config.ArtifactDownload{
+ 		Directory: tempDir,
+ 		Match:     []string{"junit.xml"},
+ 	}
+
+	downloader := NewArtifactDownloader(&rc, artifactCfg)
+ 	downloader.DownloadArtifact("test-123", "suite name", true)
+ 
+ 	fileName := filepath.Join(tempDir, "suite_name", "junit.xml")
+ 	d, err := os.ReadFile(fileName)
+ 	if err != nil {
+ 		t.Errorf("file '%s' not found: %v", fileName, err)
+ 	}
+ 
+ 	if string(d) != fileContent {
+ 		t.Errorf("file content mismatch: got '%v', expects: '%v'", d, fileContent)
+ 	}
+}

--- a/internal/saucecloud/downloader/downloader_test.go
+++ b/internal/saucecloud/downloader/downloader_test.go
@@ -13,48 +13,48 @@ import (
 )
 
 func TestArtifactDownloader_DownloadArtifact(t *testing.T) {
- 	fileContent := "<xml>junit.xml</xml>"
- 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
- 		var err error
- 		switch r.URL.Path {
- 		case "/v1/rdc/jobs/test-123":
- 			_, err = w.Write([]byte(`{"automation_backend":"espresso"}`))
- 		case "/v1/rdc/jobs/test-123/junit.xml":
- 			_, err = w.Write([]byte(fileContent))
- 		default:
- 			w.WriteHeader(http.StatusNotFound)
- 		}
- 
- 		if err != nil {
- 			t.Errorf("failed to respond: %v", err)
- 		}
- 	}))
- 	defer ts.Close()
- 
- 	tempDir, err := os.MkdirTemp("", "saucectl-download-artifact")
- 	if err != nil {
- 		t.Errorf("Failed to create temp dir: %v", err)
- 	}
- 	defer func() {
- 		_ = os.RemoveAll(tempDir)
- 	}()
- 
- 	rc := httpServices.NewRDCService(ts.URL, "dummy-user", "dummy-key", 10*time.Second)
+	fileContent := "<xml>junit.xml</xml>"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		switch r.URL.Path {
+		case "/v1/rdc/jobs/test-123":
+			_, err = w.Write([]byte(`{"automation_backend":"espresso"}`))
+		case "/v1/rdc/jobs/test-123/junit.xml":
+			_, err = w.Write([]byte(fileContent))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+
+		if err != nil {
+			t.Errorf("failed to respond: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	tempDir, err := os.MkdirTemp("", "saucectl-download-artifact")
+	if err != nil {
+		t.Errorf("Failed to create temp dir: %v", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	rc := httpServices.NewRDCService(ts.URL, "dummy-user", "dummy-key", 10*time.Second)
 	artifactCfg := config.ArtifactDownload{
- 		Directory: tempDir,
- 		Match:     []string{"junit.xml"},
- 	}
+		Directory: tempDir,
+		Match:     []string{"junit.xml"},
+	}
 
 	downloader := NewArtifactDownloader(&rc, artifactCfg)
- 	downloader.DownloadArtifact("test-123", "suite name", true)
- 
- 	fileName := filepath.Join(tempDir, "suite_name", "junit.xml")
- 	d, err := os.ReadFile(fileName)
- 	if err != nil {
- 		t.Errorf("file '%s' not found: %v", fileName, err)
- 	}
- 
- 	if string(d) != fileContent {
- 		t.Errorf("file content mismatch: got '%v', expects: '%v'", d, fileContent)
- 	}
+	downloader.DownloadArtifact("test-123", "suite name", true)
+
+	fileName := filepath.Join(tempDir, "suite_name", "junit.xml")
+	d, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Errorf("file '%s' not found: %v", fileName, err)
+	}
+
+	if string(d) != fileContent {
+		t.Errorf("file content mismatch: got '%v', expects: '%v'", d, fileContent)
+	}
 }


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

The implementation for downloading artifacts was duplicated between resto client and  rdc service client. Move downloading to a separate package to reduce duplication, maintain a better separation of concerns, and make it easier for the incoming change to downloading logic.

[DEVX-3006]


[DEVX-3006]: https://saucedev.atlassian.net/browse/DEVX-3006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ