### PR TITLE
feat: Add option to download matching artifacts for all job attempts

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -70,6 +70,10 @@
                       "directory": {
                         "description": "Specifies the path to the folder in which to download artifacts. A separate subdirectory is generated in this location for each suite.",
                         "type": "string"
+                      },
+                      "allAttempts": {
+                        "description": "If true and a test is retried, artifacts for every attempt will be downloaded. Otherwise, only artifacts for the final attempt will be downloaded.",
+                        "type": "boolean"
                       }
                     },
                     "required": [

--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -729,6 +729,10 @@
                       "directory": {
                         "description": "Specifies the path to the folder in which to download artifacts. A separate subdirectory is generated in this location for each suite.",
                         "type": "string"
+                      },
+                      "allAttempts": {
+                        "description": "If true and a test is retried, artifacts for every attempt will be downloaded. Otherwise, only artifacts for the final attempt will be downloaded.",
+                        "type": "boolean"
                       }
                     },
                     "required": [

--- a/api/v1/subschema/artifacts.schema.json
+++ b/api/v1/subschema/artifacts.schema.json
@@ -32,6 +32,10 @@
             "directory": {
               "description": "Specifies the path to the folder in which to download artifacts. A separate subdirectory is generated in this location for each suite.",
               "type": "string"
+            },
+            "allAttempts": {
+              "description": "If true and a test is retried, artifacts for every attempt will be downloaded. Otherwise, only artifacts for the final attempt will be downloaded.",
+              "type": "boolean"
             }
           },
           "required": [

--- a/api/v1alpha/subschema/artifacts.schema.json
+++ b/api/v1alpha/subschema/artifacts.schema.json
@@ -32,6 +32,10 @@
             "directory": {
               "description": "Specifies the path to the folder in which to download artifacts. A separate subdirectory is generated in this location for each suite.",
               "type": "string"
+            },
+            "allAttempts": {
+              "description": "If true and a test is retried, artifacts for every attempt will be downloaded. Otherwise, only artifacts for the final attempt will be downloaded.",
+              "type": "boolean"
             }
           },
           "required": [

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -128,6 +128,7 @@ func Command() *cobra.Command {
 	sc.String("artifacts.download.when", "artifacts::download::when", "never", "Specifies when to download test artifacts")
 	sc.StringSlice("artifacts.download.match", "artifacts::download::match", []string{}, "Specifies which test artifacts to download")
 	sc.String("artifacts.download.directory", "artifacts::download::directory", "", "Specifies the location where to download test artifacts to")
+	sc.Bool("artifacts.download.allAttempts", "artifacts::download::allAttempts", false, "Specifies whether to download artifacts for all attempted tests if a test needs to be retried. If false, only the artifacts of the last attempt will be downloaded.")
 	sc.Bool("artifacts.cleanup", "artifacts::cleanup", false, "Specifies whether to remove all contents of artifacts directory")
 
 	// Reporters

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,9 +124,10 @@ func (w When) IsNow(passed bool) bool {
 
 // ArtifactDownload represents the test artifacts configuration.
 type ArtifactDownload struct {
-	Match     []string `yaml:"match,omitempty" json:"match"`
-	When      When     `yaml:"when,omitempty" json:"when"`
-	Directory string   `yaml:"directory,omitempty" json:"directory"`
+	Match       []string `yaml:"match,omitempty" json:"match"`
+	When        When     `yaml:"when,omitempty" json:"when"`
+	Directory   string   `yaml:"directory,omitempty" json:"directory"`
+	AllAttempts bool     `yaml:"allAttempts,omitempty" json:"allAttempts"`
 }
 
 // Notifications represents the test notifications configuration.

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -93,7 +93,5 @@ type Service interface {
 // ArtifactDownloader represents the interface for downloading artifacts.
 type ArtifactDownloader interface {
 	// DownloadArtifact downloads artifacts and returns a list of what was downloaded.
-	// DownloadArtifact(jobID, suiteName string, realDevice bool, attempt int) []string
-	// DownloadArtifact(jobID string, destDir string, realDevice bool) []string
 	DownloadArtifact(jobID string, suiteName string, realDevice bool, attemptNumber int, retries int, timedOut bool, status string) []string
 }

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -95,5 +95,5 @@ type ArtifactDownloader interface {
 	// DownloadArtifact downloads artifacts and returns a list of what was downloaded.
 	// DownloadArtifact(jobID, suiteName string, realDevice bool, attempt int) []string
 	// DownloadArtifact(jobID string, destDir string, realDevice bool) []string
-	DownloadArtifact(jobID string, suiteName string, realDevice bool, attemptNumber int, timedOut bool, status string) []string
+	DownloadArtifact(jobID string, suiteName string, realDevice bool, attemptNumber int, retries int, timedOut bool, status string) []string
 }

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -93,5 +93,5 @@ type Service interface {
 // ArtifactDownloader represents the interface for downloading artifacts.
 type ArtifactDownloader interface {
 	// DownloadArtifact downloads artifacts and returns a list of what was downloaded.
-	DownloadArtifact(jobID string, suiteName string, realDevice bool, attemptNumber int, retries int, timedOut bool, status string) []string
+	DownloadArtifact(job Job, attempt int, retries int) []string
 }

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -93,5 +93,7 @@ type Service interface {
 // ArtifactDownloader represents the interface for downloading artifacts.
 type ArtifactDownloader interface {
 	// DownloadArtifact downloads artifacts and returns a list of what was downloaded.
-	DownloadArtifact(jobID, suiteName string, realDevice bool) []string
+	// DownloadArtifact(jobID, suiteName string, realDevice bool, attempt int) []string
+	// DownloadArtifact(jobID string, destDir string, realDevice bool) []string
+	DownloadArtifact(jobID string, suiteName string, realDevice bool, attemptNumber int, timedOut bool, status string) []string
 }

--- a/internal/mocks/download.go
+++ b/internal/mocks/download.go
@@ -1,11 +1,13 @@
 package mocks
 
+import "github.com/saucelabs/saucectl/internal/job"
+
 // FakeArtifactDownloader defines a fake Downloader
 type FakeArtifactDownloader struct {
-	DownloadArtifactFn func(jobID, suiteName string) []string
+	DownloadArtifactFn func(jobData job.Job, attempt int, retries int) []string
 }
 
 // DownloadArtifact defines a fake function for FakeDownloader
-func (f *FakeArtifactDownloader) DownloadArtifact(jobID, suiteName string, realDevice bool) []string {
-	return f.DownloadArtifactFn(jobID, suiteName)
+func (f *FakeArtifactDownloader) DownloadArtifact(jobData job.Job, attempt int, retries int) []string {
+	return f.DownloadArtifactFn(jobData, attempt, retries)
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -20,8 +20,6 @@ type Attempt struct {
 	// TestSuites contains the junit test suites that were generated as part of
 	// the attempt.
 	TestSuites junit.TestSuites `json:"-"`
-	TimedOut   bool             `json:"-"`
-	IsRDC      bool             `json:"-"`
 }
 
 // TestResult represents the test result.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -20,6 +20,8 @@ type Attempt struct {
 	// TestSuites contains the junit test suites that were generated as part of
 	// the attempt.
 	TestSuites junit.TestSuites `json:"-"`
+	TimedOut   bool             `json:"-"`
+	IsRDC      bool             `json:"-"`
 }
 
 // TestResult represents the test result.

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -334,6 +334,7 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 		}
 
 		if opts.Attempt < opts.Retries && ((!jobData.Passed && !skipped) || (opts.CurrentPassCount < opts.PassThreshold)) {
+			go r.JobService.DownloadArtifact(jobData.ID, jobData.Name, jobData.IsRDC, opts.Attempt, opts.Retries, jobData.TimedOut, jobData.Status)
 			if !jobData.Passed {
 				log.Warn().Err(err).Msg("Suite errored.")
 			}
@@ -349,7 +350,6 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 			})
 			go r.Retrier.Retry(jobOpts, opts, jobData)
 
-			r.JobService.DownloadArtifact(jobData.ID, jobData.Name, jobData.IsRDC, opts.Attempt, jobData.TimedOut, jobData.Status)
 			continue
 		}
 
@@ -370,7 +370,7 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 			}
 		}
 
-		files := r.JobService.DownloadArtifact(jobData.ID, jobData.Name, jobData.IsRDC, opts.Attempt, jobData.TimedOut, jobData.Status)
+		files := r.JobService.DownloadArtifact(jobData.ID, jobData.Name, jobData.IsRDC, opts.Attempt, opts.Retries, jobData.TimedOut, jobData.Status)
 		var artifacts []report.Artifact
 		for _, f := range files {
 			artifacts = append(artifacts, report.Artifact{

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -1003,14 +1003,6 @@ func (r *CloudRunner) loadJUnitReport(jobID string, isRDC bool) (junit.TestSuite
 	return junit.Parse(fileContent)
 }
 
-// func (r *CloudRunner) downloadArtifacts(suiteName string, attempt report.Attempt, artifactConfig config.ArtifactDownload, attemptNumber int) []string {
-// 	// if attempt.ID == "" || attempt.TimedOut || r.Async || !artifactConfig.When.IsNow(attempt.Status == job.StatePassed) {
-// 	// 	return []string{}
-// 	// }
-//
-// 	return r.JobService.DownloadArtifact(attempt.ID, destDir, attempt.IsRDC)
-// }
-
 func arrayContains(list []string, want string) bool {
 	for _, item := range list {
 		if item == want {

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -334,7 +334,7 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 		}
 
 		if opts.Attempt < opts.Retries && ((!jobData.Passed && !skipped) || (opts.CurrentPassCount < opts.PassThreshold)) {
-			go r.JobService.DownloadArtifact(jobData.ID, jobData.Name, jobData.IsRDC, opts.Attempt, opts.Retries, jobData.TimedOut, jobData.Status)
+			go r.JobService.DownloadArtifact(jobData, opts.Attempt, opts.Retries)
 			if !jobData.Passed {
 				log.Warn().Err(err).Msg("Suite errored.")
 			}
@@ -370,7 +370,7 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 			}
 		}
 
-		files := r.JobService.DownloadArtifact(jobData.ID, jobData.Name, jobData.IsRDC, opts.Attempt, opts.Retries, jobData.TimedOut, jobData.Status)
+		files := r.JobService.DownloadArtifact(jobData, opts.Attempt, opts.Retries)
 		var artifacts []report.Artifact
 		for _, f := range files {
 			artifacts = append(artifacts, report.Artifact{

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -354,8 +354,6 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 				EndTime:    time.Now(),
 				Status:     jobData.Status,
 				TestSuites: junit.TestSuites{},
-				TimedOut:   jobData.TimedOut,
-				IsRDC:      jobData.IsRDC,
 			})
 			go r.Retrier.Retry(jobOpts, opts, jobData)
 
@@ -400,8 +398,6 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 				StartTime: opts.StartTime,
 				EndTime:   time.Now(),
 				Status:    jobData.Status,
-				TimedOut:  jobData.TimedOut,
-				IsRDC:     jobData.IsRDC,
 			}),
 		}
 	}

--- a/internal/saucecloud/cloud_test.go
+++ b/internal/saucecloud/cloud_test.go
@@ -166,6 +166,12 @@ func TestRunJobTimeout(t *testing.T) {
 			VDCWriter: &mocks.FakeJobWriter{UploadAssetFn: func(jobID string, fileName string, contentType string, content []byte) error {
 				return nil
 			}},
+			VDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+				return []string{}
+			}},
+			RDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+				return []string{}
+			}},
 		},
 	}
 
@@ -221,6 +227,12 @@ func TestRunJobRetries(t *testing.T) {
 				VDCWriter: &mocks.FakeJobWriter{UploadAssetFn: func(jobID string, fileName string, contentType string, content []byte) error {
 					return nil
 				}},
+				VDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+					return []string{}
+				}},
+				RDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+					return []string{}
+				}},
 			},
 		}
 
@@ -257,6 +269,12 @@ func TestRunJobTimeoutRDC(t *testing.T) {
 					return job.Job{ID: id, TimedOut: true}, nil
 				},
 			},
+			VDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+				return []string{}
+			}},
+			RDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+				return []string{}
+			}},
 		},
 	}
 

--- a/internal/saucecloud/cypress_test.go
+++ b/internal/saucecloud/cypress_test.go
@@ -78,7 +78,7 @@ func TestRunSuites(t *testing.T) {
 					},
 				},
 				VDCDownloader: &mocks.FakeArtifactDownloader{
-					DownloadArtifactFn: func(jobID string, suiteName string) []string {
+					DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
 						return []string{}
 					},
 				},

--- a/internal/saucecloud/downloader/downloader.go
+++ b/internal/saucecloud/downloader/downloader.go
@@ -24,7 +24,10 @@ func NewArtifactDownloader(reader job.Reader, artifactConfig config.ArtifactDown
 }
 
 func (d *ArtifactDownloader) DownloadArtifact(jobData job.Job, attemptNumber int, retries int) []string {
-	if jobData.ID == "" || jobData.TimedOut || !d.config.When.IsNow(jobData.Passed) || jobData.Status == job.StateInProgress || (d.config.AllAttempts == false && attemptNumber < retries) {
+	if jobData.ID == "" ||
+		jobData.TimedOut ||
+		!d.config.When.IsNow(jobData.Passed) || jobData.Status == job.StateInProgress ||
+		(!d.config.AllAttempts && attemptNumber < retries) {
 		return []string{}
 	}
 

--- a/internal/saucecloud/downloader/downloader.go
+++ b/internal/saucecloud/downloader/downloader.go
@@ -25,8 +25,8 @@ func NewArtifactDownloader(reader job.Reader, artifactConfig config.ArtifactDown
 
 func (d *ArtifactDownloader) DownloadArtifact(jobData job.Job, attemptNumber int, retries int) []string {
 	if jobData.ID == "" ||
-		jobData.TimedOut ||
-		!d.config.When.IsNow(jobData.Passed) || jobData.Status == job.StateInProgress ||
+		jobData.TimedOut || !job.Done(jobData.Status) ||
+		!d.config.When.IsNow(jobData.Passed) ||
 		(!d.config.AllAttempts && attemptNumber < retries) {
 		return []string{}
 	}

--- a/internal/saucecloud/downloader/downloader_test.go
+++ b/internal/saucecloud/downloader/downloader_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/saucelabs/saucectl/internal/config"
 	httpServices "github.com/saucelabs/saucectl/internal/http"
+	"github.com/saucelabs/saucectl/internal/job"
 )
 
 func TestArtifactDownloader_DownloadArtifact(t *testing.T) {
@@ -43,10 +44,16 @@ func TestArtifactDownloader_DownloadArtifact(t *testing.T) {
 	artifactCfg := config.ArtifactDownload{
 		Directory: tempDir,
 		Match:     []string{"junit.xml"},
+		When:      config.WhenAlways,
 	}
-
 	downloader := NewArtifactDownloader(&rc, artifactCfg)
-	downloader.DownloadArtifact("test-123", "suite name", true)
+	downloader.DownloadArtifact(
+		job.Job{
+			ID:    "test-123",
+			Name:  "suite name",
+			IsRDC: true,
+		}, 0, 0,
+	)
 
 	fileName := filepath.Join(tempDir, "suite_name", "junit.xml")
 	d, err := os.ReadFile(fileName)

--- a/internal/saucecloud/downloader/downloader_test.go
+++ b/internal/saucecloud/downloader/downloader_test.go
@@ -52,6 +52,7 @@ func TestArtifactDownloader_DownloadArtifact(t *testing.T) {
 			ID:    "test-123",
 			Name:  "suite name",
 			IsRDC: true,
+			Status: job.StateComplete,
 		}, 0, 0,
 	)
 

--- a/internal/saucecloud/downloader/downloader_test.go
+++ b/internal/saucecloud/downloader/downloader_test.go
@@ -49,9 +49,9 @@ func TestArtifactDownloader_DownloadArtifact(t *testing.T) {
 	downloader := NewArtifactDownloader(&rc, artifactCfg)
 	downloader.DownloadArtifact(
 		job.Job{
-			ID:    "test-123",
-			Name:  "suite name",
-			IsRDC: true,
+			ID:     "test-123",
+			Name:   "suite name",
+			IsRDC:  true,
 			Status: job.StateComplete,
 		}, 0, 0,
 	)

--- a/internal/saucecloud/jobservice.go
+++ b/internal/saucecloud/jobservice.go
@@ -23,12 +23,12 @@ type JobService struct {
 	RDCDownloader job.ArtifactDownloader
 }
 
-func (s JobService) DownloadArtifact(jobID, suiteName string, realDevice bool) []string {
+func (s JobService) DownloadArtifact(jobID string, suiteName string, realDevice bool, attemptNumber int, timedOut bool, status string) []string {
 	if realDevice {
-		return s.RDCDownloader.DownloadArtifact(jobID, suiteName, realDevice)
+		return s.RDCDownloader.DownloadArtifact(jobID, suiteName, realDevice, attemptNumber, timedOut, status)
 	}
 
-	return s.VDCDownloader.DownloadArtifact(jobID, suiteName, realDevice)
+	return s.VDCDownloader.DownloadArtifact(jobID, suiteName, realDevice, attemptNumber, timedOut, status)
 }
 
 func (s JobService) StopJob(ctx context.Context, jobID string, realDevice bool) (job.Job, error) {

--- a/internal/saucecloud/jobservice.go
+++ b/internal/saucecloud/jobservice.go
@@ -23,12 +23,12 @@ type JobService struct {
 	RDCDownloader job.ArtifactDownloader
 }
 
-func (s JobService) DownloadArtifact(jobID string, suiteName string, realDevice bool, attemptNumber int, retries int, timedOut bool, status string) []string {
-	if realDevice {
-		return s.RDCDownloader.DownloadArtifact(jobID, suiteName, realDevice, attemptNumber, retries, timedOut, status)
+func (s JobService) DownloadArtifact(jobData job.Job, attemptNumber int, retries int) []string {
+	if jobData.IsRDC {
+		return s.RDCDownloader.DownloadArtifact(jobData, attemptNumber, retries)
 	}
 
-	return s.VDCDownloader.DownloadArtifact(jobID, suiteName, realDevice, attemptNumber, retries, timedOut, status)
+	return s.VDCDownloader.DownloadArtifact(jobData, attemptNumber, retries)
 }
 
 func (s JobService) StopJob(ctx context.Context, jobID string, realDevice bool) (job.Job, error) {

--- a/internal/saucecloud/jobservice.go
+++ b/internal/saucecloud/jobservice.go
@@ -23,12 +23,12 @@ type JobService struct {
 	RDCDownloader job.ArtifactDownloader
 }
 
-func (s JobService) DownloadArtifact(jobID string, suiteName string, realDevice bool, attemptNumber int, timedOut bool, status string) []string {
+func (s JobService) DownloadArtifact(jobID string, suiteName string, realDevice bool, attemptNumber int, retries int, timedOut bool, status string) []string {
 	if realDevice {
-		return s.RDCDownloader.DownloadArtifact(jobID, suiteName, realDevice, attemptNumber, timedOut, status)
+		return s.RDCDownloader.DownloadArtifact(jobID, suiteName, realDevice, attemptNumber, retries, timedOut, status)
 	}
 
-	return s.VDCDownloader.DownloadArtifact(jobID, suiteName, realDevice, attemptNumber, timedOut, status)
+	return s.VDCDownloader.DownloadArtifact(jobID, suiteName, realDevice, attemptNumber, retries, timedOut, status)
 }
 
 func (s JobService) StopJob(ctx context.Context, jobID string, realDevice bool) (job.Job, error) {


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
Add an option, `allAttempts`, to download matching artifacts for all job attempts. Downloads are grouped by suite name and retries will use the existing logic to prevent collisions (i.e. a numbered suffix is attached to the suite name). Since there could be a large number of downloads for a job and its retries, the downloading now happens after the job has executed.

[DEVX-3006]

[DEVX-3006]: https://saucedev.atlassian.net/browse/DEVX-3006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ