### PR TITLE
fix: Should download artifacts when no retries

### DIFF
--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -93,5 +93,5 @@ type Service interface {
 // ArtifactDownloader represents the interface for downloading artifacts.
 type ArtifactDownloader interface {
 	// DownloadArtifact downloads artifacts and returns a list of what was downloaded.
-	DownloadArtifact(job Job, attempt int, retries int, isRetriedJob bool) []string
+	DownloadArtifact(job Job, isLastAttempt bool) []string
 }

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -93,5 +93,5 @@ type Service interface {
 // ArtifactDownloader represents the interface for downloading artifacts.
 type ArtifactDownloader interface {
 	// DownloadArtifact downloads artifacts and returns a list of what was downloaded.
-	DownloadArtifact(job Job, attempt int, retries int) []string
+	DownloadArtifact(job Job, attempt int, retries int, isRetriedJob bool) []string
 }

--- a/internal/mocks/download.go
+++ b/internal/mocks/download.go
@@ -8,6 +8,6 @@ type FakeArtifactDownloader struct {
 }
 
 // DownloadArtifact defines a fake function for FakeDownloader
-func (f *FakeArtifactDownloader) DownloadArtifact(jobData job.Job, attempt int, retries int) []string {
+func (f *FakeArtifactDownloader) DownloadArtifact(jobData job.Job, attempt int, retries int, isRetriedJob bool) []string {
 	return f.DownloadArtifactFn(jobData, attempt, retries)
 }

--- a/internal/mocks/download.go
+++ b/internal/mocks/download.go
@@ -4,10 +4,10 @@ import "github.com/saucelabs/saucectl/internal/job"
 
 // FakeArtifactDownloader defines a fake Downloader
 type FakeArtifactDownloader struct {
-	DownloadArtifactFn func(jobData job.Job, attempt int, retries int) []string
+	DownloadArtifactFn func(jobData job.Job, isLastAttempt bool) []string
 }
 
 // DownloadArtifact defines a fake function for FakeDownloader
-func (f *FakeArtifactDownloader) DownloadArtifact(jobData job.Job, attempt int, retries int, isRetriedJob bool) []string {
-	return f.DownloadArtifactFn(jobData, attempt, retries)
+func (f *FakeArtifactDownloader) DownloadArtifact(jobData job.Job, isLastAttempt bool) []string {
+	return f.DownloadArtifactFn(jobData, isLastAttempt)
 }

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -299,6 +299,17 @@ func (r *CloudRunner) runJob(opts job.StartOptions) (j job.Job, skipped bool, er
 	return j, false, nil
 }
 
+// shouldRetry determines whether a job should be retried based on
+// the given options, job data, and whether the job was skipped.
+//
+// The job should be retried if:
+// - The current attempt is less than the allowed retries, and either:
+//   - The job did not pass and was not skipped, or
+//   - The current pass count is below the required threshold.
+func shouldRetry(opts job.StartOptions, jobData job.Job, skipped bool) bool {
+	return opts.Attempt < opts.Retries && ((!jobData.Passed && !skipped) || (opts.CurrentPassCount < opts.PassThreshold))
+}
+
 func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- result) {
 	for opts := range jobOpts {
 		start := time.Now()
@@ -333,8 +344,8 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 			opts.CurrentPassCount++
 		}
 
-		if opts.Attempt < opts.Retries && ((!jobData.Passed && !skipped) || (opts.CurrentPassCount < opts.PassThreshold)) {
-			go r.JobService.DownloadArtifact(jobData, opts.Attempt, opts.Retries)
+		if shouldRetry(opts, jobData, skipped) {
+			go r.JobService.DownloadArtifact(jobData, opts.Attempt, opts.Retries, true)
 			if !jobData.Passed {
 				log.Warn().Err(err).Msg("Suite errored.")
 			}
@@ -370,7 +381,7 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 			}
 		}
 
-		files := r.JobService.DownloadArtifact(jobData, opts.Attempt, opts.Retries)
+		files := r.JobService.DownloadArtifact(jobData, opts.Attempt, opts.Retries, false)
 		var artifacts []report.Artifact
 		for _, f := range files {
 			artifacts = append(artifacts, report.Artifact{

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -299,13 +299,11 @@ func (r *CloudRunner) runJob(opts job.StartOptions) (j job.Job, skipped bool, er
 	return j, false, nil
 }
 
-// shouldRetry determines whether a job should be retried based on
-// the given options, job data, and whether the job was skipped.
+// shouldRetry determines whether a job should be retried.
 //
-// The job should be retried if:
-// - The current attempt is less than the allowed retries, and either:
-//   - The job did not pass and was not skipped, or
-//   - The current pass count is below the required threshold.
+// The job should be retried if both of the following conditions are met:
+// - The current attempt is less than the allowed retries.
+// - The job was not passed nor skipped, or the pass count is below the threshold.
 func shouldRetry(opts job.StartOptions, jobData job.Job, skipped bool) bool {
 	return opts.Attempt < opts.Retries && ((!jobData.Passed && !skipped) || (opts.CurrentPassCount < opts.PassThreshold))
 }

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -354,7 +354,7 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 		}
 
 		if shouldRetry(opts, jobData, skipped) {
-			go r.JobService.DownloadArtifact(jobData, opts.Attempt, opts.Retries, true)
+			go r.JobService.DownloadArtifact(jobData, false)
 			if !jobData.Passed {
 				log.Warn().Err(err).Msg("Suite errored.")
 			}
@@ -390,7 +390,7 @@ func (r *CloudRunner) runJobs(jobOpts chan job.StartOptions, results chan<- resu
 			}
 		}
 
-		files := r.JobService.DownloadArtifact(jobData, opts.Attempt, opts.Retries, false)
+		files := r.JobService.DownloadArtifact(jobData, true)
 		var artifacts []report.Artifact
 		for _, f := range files {
 			artifacts = append(artifacts, report.Artifact{

--- a/internal/saucecloud/cloud_test.go
+++ b/internal/saucecloud/cloud_test.go
@@ -166,10 +166,10 @@ func TestRunJobTimeout(t *testing.T) {
 			VDCWriter: &mocks.FakeJobWriter{UploadAssetFn: func(jobID string, fileName string, contentType string, content []byte) error {
 				return nil
 			}},
-			VDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+			VDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, isLastAttempt bool) []string {
 				return []string{}
 			}},
-			RDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+			RDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, isLastAttempt bool) []string {
 				return []string{}
 			}},
 		},
@@ -227,10 +227,10 @@ func TestRunJobRetries(t *testing.T) {
 				VDCWriter: &mocks.FakeJobWriter{UploadAssetFn: func(jobID string, fileName string, contentType string, content []byte) error {
 					return nil
 				}},
-				VDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+				VDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, islastAttempt bool) []string {
 					return []string{}
 				}},
-				RDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+				RDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, islastAttempt bool) []string {
 					return []string{}
 				}},
 			},
@@ -269,10 +269,10 @@ func TestRunJobTimeoutRDC(t *testing.T) {
 					return job.Job{ID: id, TimedOut: true}, nil
 				},
 			},
-			VDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+			VDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, islastAttempt bool) []string {
 				return []string{}
 			}},
-			RDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+			RDCDownloader: &mocks.FakeArtifactDownloader{DownloadArtifactFn: func(jobData job.Job, islastAttempt bool) []string {
 				return []string{}
 			}},
 		},

--- a/internal/saucecloud/cypress_test.go
+++ b/internal/saucecloud/cypress_test.go
@@ -78,7 +78,7 @@ func TestRunSuites(t *testing.T) {
 					},
 				},
 				VDCDownloader: &mocks.FakeArtifactDownloader{
-					DownloadArtifactFn: func(jobData job.Job, attempt int, retries int) []string {
+					DownloadArtifactFn: func(jobData job.Job, islastAttempt bool) []string {
 						return []string{}
 					},
 				},

--- a/internal/saucecloud/downloader/downloader.go
+++ b/internal/saucecloud/downloader/downloader.go
@@ -23,11 +23,11 @@ func NewArtifactDownloader(reader job.Reader, artifactConfig config.ArtifactDown
 	}
 }
 
-func (d *ArtifactDownloader) DownloadArtifact(jobData job.Job, attemptNumber int, retries int) []string {
+func (d *ArtifactDownloader) DownloadArtifact(jobData job.Job, attemptNumber int, retries int, isRetriedJob bool) []string {
 	if jobData.ID == "" ||
 		jobData.TimedOut || !job.Done(jobData.Status) ||
 		!d.config.When.IsNow(jobData.Passed) ||
-		(!d.config.AllAttempts && attemptNumber < retries) {
+		(isRetriedJob && !d.config.AllAttempts) {
 		return []string{}
 	}
 

--- a/internal/saucecloud/downloader/downloader.go
+++ b/internal/saucecloud/downloader/downloader.go
@@ -23,11 +23,11 @@ func NewArtifactDownloader(reader job.Reader, artifactConfig config.ArtifactDown
 	}
 }
 
-func (d *ArtifactDownloader) DownloadArtifact(jobData job.Job, attemptNumber int, retries int, isRetriedJob bool) []string {
+func (d *ArtifactDownloader) DownloadArtifact(jobData job.Job, isLastAttempt bool) []string {
 	if jobData.ID == "" ||
 		jobData.TimedOut || !job.Done(jobData.Status) ||
 		!d.config.When.IsNow(jobData.Passed) ||
-		(isRetriedJob && !d.config.AllAttempts && attemptNumber < retries) {
+		(!isLastAttempt && !d.config.AllAttempts) {
 		return []string{}
 	}
 

--- a/internal/saucecloud/downloader/downloader.go
+++ b/internal/saucecloud/downloader/downloader.go
@@ -27,7 +27,7 @@ func (d *ArtifactDownloader) DownloadArtifact(jobData job.Job, attemptNumber int
 	if jobData.ID == "" ||
 		jobData.TimedOut || !job.Done(jobData.Status) ||
 		!d.config.When.IsNow(jobData.Passed) ||
-		(isRetriedJob && !d.config.AllAttempts) {
+		(isRetriedJob && !d.config.AllAttempts && attemptNumber < retries) {
 		return []string{}
 	}
 

--- a/internal/saucecloud/downloader/downloader.go
+++ b/internal/saucecloud/downloader/downloader.go
@@ -23,11 +23,15 @@ func NewArtifactDownloader(reader job.Reader, artifactConfig config.ArtifactDown
 	}
 }
 
-func (d *ArtifactDownloader) DownloadArtifact(jobData job.Job, isLastAttempt bool) []string {
-	if jobData.ID == "" ||
+func (d *ArtifactDownloader) skipDownload(jobData job.Job, isLastAttempt bool) bool {
+	return jobData.ID == "" ||
 		jobData.TimedOut || !job.Done(jobData.Status) ||
 		!d.config.When.IsNow(jobData.Passed) ||
-		(!isLastAttempt && !d.config.AllAttempts) {
+		(!isLastAttempt && !d.config.AllAttempts)
+}
+
+func (d *ArtifactDownloader) DownloadArtifact(jobData job.Job, isLastAttempt bool) []string {
+	if d.skipDownload(jobData, isLastAttempt) {
 		return []string{}
 	}
 

--- a/internal/saucecloud/downloader/downloader_test.go
+++ b/internal/saucecloud/downloader/downloader_test.go
@@ -53,7 +53,7 @@ func TestArtifactDownloader_DownloadArtifact(t *testing.T) {
 			Name:   "suite name",
 			IsRDC:  true,
 			Status: job.StateComplete,
-		}, 0, 0,
+		}, 0, 0, false,
 	)
 
 	fileName := filepath.Join(tempDir, "suite_name", "junit.xml")

--- a/internal/saucecloud/downloader/downloader_test.go
+++ b/internal/saucecloud/downloader/downloader_test.go
@@ -53,7 +53,7 @@ func TestArtifactDownloader_DownloadArtifact(t *testing.T) {
 			Name:   "suite name",
 			IsRDC:  true,
 			Status: job.StateComplete,
-		}, false,
+		}, true,
 	)
 
 	fileName := filepath.Join(tempDir, "suite_name", "junit.xml")

--- a/internal/saucecloud/downloader/downloader_test.go
+++ b/internal/saucecloud/downloader/downloader_test.go
@@ -53,7 +53,7 @@ func TestArtifactDownloader_DownloadArtifact(t *testing.T) {
 			Name:   "suite name",
 			IsRDC:  true,
 			Status: job.StateComplete,
-		}, 0, 0, false,
+		}, false,
 	)
 
 	fileName := filepath.Join(tempDir, "suite_name", "junit.xml")

--- a/internal/saucecloud/jobservice.go
+++ b/internal/saucecloud/jobservice.go
@@ -23,12 +23,12 @@ type JobService struct {
 	RDCDownloader job.ArtifactDownloader
 }
 
-func (s JobService) DownloadArtifact(jobData job.Job, attemptNumber int, retries int) []string {
+func (s JobService) DownloadArtifact(jobData job.Job, attemptNumber int, retries int, isRetriedJob bool) []string {
 	if jobData.IsRDC {
-		return s.RDCDownloader.DownloadArtifact(jobData, attemptNumber, retries)
+		return s.RDCDownloader.DownloadArtifact(jobData, attemptNumber, retries, isRetriedJob)
 	}
 
-	return s.VDCDownloader.DownloadArtifact(jobData, attemptNumber, retries)
+	return s.VDCDownloader.DownloadArtifact(jobData, attemptNumber, retries, isRetriedJob)
 }
 
 func (s JobService) StopJob(ctx context.Context, jobID string, realDevice bool) (job.Job, error) {

--- a/internal/saucecloud/jobservice.go
+++ b/internal/saucecloud/jobservice.go
@@ -23,12 +23,12 @@ type JobService struct {
 	RDCDownloader job.ArtifactDownloader
 }
 
-func (s JobService) DownloadArtifact(jobData job.Job, attemptNumber int, retries int, isRetriedJob bool) []string {
+func (s JobService) DownloadArtifact(jobData job.Job, isLastAttempt bool) []string {
 	if jobData.IsRDC {
-		return s.RDCDownloader.DownloadArtifact(jobData, attemptNumber, retries, isRetriedJob)
+		return s.RDCDownloader.DownloadArtifact(jobData, isLastAttempt)
 	}
 
-	return s.VDCDownloader.DownloadArtifact(jobData, attemptNumber, retries, isRetriedJob)
+	return s.VDCDownloader.DownloadArtifact(jobData, isLastAttempt)
 }
 
 func (s JobService) StopJob(ctx context.Context, jobID string, realDevice bool) (job.Job, error) {


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

The root cause is that when setting retries and downloading artifacts simultaneously, the code determines whether to proceed with the download by checking `AllAttempts` and whether it's the last attempt (`attempts < total retries`).

However, if the job doesn’t run out of retries (e.g., if the first job has passed or the job passes threshold before hitting the retry limit), the number of attempts is smaller than the total retries, leading to the download being skipped.

To fix this issue, I updated the download function as we've known if the job is the last attempt.

This solves https://github.com/saucelabs/saucectl/issues/939 and https://github.com/saucelabs/saucectl/issues/938