### PR TITLE
build: choose your own gobin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ default:
 #install: @ Install the CLI
 .PHONY: install
 install:
-	GOBIN=/usr/local/bin/ go install cmd/saucectl/saucectl.go
+	go install cmd/saucectl/saucectl.go
 
 #build: @ Build the CLI
 build:


### PR DESCRIPTION
## Description

Don't force a `GOBIN` folder onto other developers. Does not affect the release of saucectl, merely where the binary is placed when running `make install`.