### PR TITLE
refactor: espresso sharding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
         run: ./saucectl run -c .sauce/testcafe.yml --timeout 10m
 
       - name: Saucectl RUN - CLI Driven
-        run: ./saucectl run testcafe "*.test.js" -c "" --name "CLI Driven" --browser chrome --rootDir tests/e2e/testcafe/ --testcafe.version 3.5.0 --timeout 10m -r us-west-1
+        run: ./saucectl run testcafe "*.test.js" -c "" --name "CLI Driven" --browser chrome --browserVersion 128 --rootDir tests/e2e/testcafe/ --testcafe.version 3.5.0 --timeout 10m -r us-west-1
 
   cypress:
     needs: build

--- a/.sauce/testcafe.yml
+++ b/.sauce/testcafe.yml
@@ -15,6 +15,7 @@ rootDir: tests/e2e/testcafe/
 suites:
   - name: Chrome in sauce
     browserName: chrome
+    browserVersion: "128" # TODO(AlexP): Pinned due to TestCafe <= 3.6.2 not working with Chrome 130+.
     src:
       - "*.test.js"
     platformName: "macOS 12"

--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -51,6 +51,13 @@ type Espresso struct {
 	OtherApps          []string `yaml:"otherApps,omitempty" json:"otherApps"`
 }
 
+// ShardConfig represents the configuration for sharding. The config values come
+// from Suite.TestOptions.
+type ShardConfig struct {
+	Shards int
+	Index  int
+}
+
 // Suite represents the espresso test suite configuration.
 type Suite struct {
 	Name               string                 `yaml:"name,omitempty" json:"name"`
@@ -63,6 +70,28 @@ type Suite struct {
 	AppSettings        config.AppSettings     `yaml:"appSettings,omitempty" json:"appSettings"`
 	PassThreshold      int                    `yaml:"passThreshold,omitempty" json:"-"`
 	SmartRetry         config.SmartRetry      `yaml:"smartRetry,omitempty" json:"-"`
+}
+
+func (s *Suite) ShardConfig() ShardConfig {
+	shards := 0
+	index := 0
+
+	if numShards, ok := s.TestOptions["numShards"]; ok {
+		if v, err := strconv.Atoi(fmt.Sprintf("%v", numShards)); err == nil {
+			shards = v
+		}
+	}
+
+	if shardIndex, ok := s.TestOptions["shardIndex"]; ok {
+		if v, err := strconv.Atoi(fmt.Sprintf("%v", shardIndex)); err == nil {
+			index = v
+		}
+	}
+
+	return ShardConfig{
+		Shards: shards,
+		Index:  index,
+	}
 }
 
 // Android constant


### PR DESCRIPTION
## Description

Define a proper data structure for the sharding configuration of Espresso.
The result is a much cleaner API that has no need for names like `getNumShardsAndShardIndex`.

This new API is now a method of `Suite` instead of a function in the espresso package. Having it this way also improves the clarity of input params, i.e. no need for `testOptions map[string]interface{}`, which is only loosely defined.