### PR TITLE
refactor: builds

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,22 +1,19 @@
 package build
 
-import "context"
+import (
+	"context"
+)
 
 // Build represents a grouping of jobs.
 type Build struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+
+	URL string `json:"-"`
 }
-
-// Source defines the type of test device associated with the job and build.
-type Source string
-
-const (
-	VDC Source = "vdc"
-	RDC Source = "rdc"
-)
 
 // Service is the interface for requesting build information.
 type Service interface {
+	// FindBuild returns a Build that's associated with jobID.
 	FindBuild(ctx context.Context, jobID string, realDevice bool) (Build, error)
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -18,5 +18,7 @@ const (
 
 // Service is the interface for requesting build information.
 type Service interface {
-	FindBuild(ctx context.Context, jobID string, buildSource Source) (string, error)
+	FindBuild(ctx context.Context, jobID string, buildSource Source) (
+		Build, error,
+	)
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -16,8 +16,7 @@ const (
 	RDC Source = "rdc"
 )
 
-// Reader is the interface for requesting build information.
-type Reader interface {
-	// GetBuildID returns the build id for a given job id.
-	GetBuildID(ctx context.Context, jobID string, buildSource Source) (string, error)
+// Service is the interface for requesting build information.
+type Service interface {
+	FindBuild(ctx context.Context, jobID string, buildSource Source) (string, error)
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -18,7 +18,5 @@ const (
 
 // Service is the interface for requesting build information.
 type Service interface {
-	FindBuild(ctx context.Context, jobID string, buildSource Source) (
-		Build, error,
-	)
+	FindBuild(ctx context.Context, jobID string, realDevice bool) (Build, error)
 }

--- a/internal/cmd/run/cucumber.go
+++ b/internal/cmd/run/cucumber.go
@@ -129,6 +129,9 @@ func runCucumber(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 		TestComposer:           testcompClient,
 		ArtifactDownloadConfig: p.Artifacts.Download,
 	}
+	buildService := http.NewBuildService(
+		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+	)
 
 	log.Info().Msg("Running Playwright-Cucumberjs in Sauce Labs")
 	r := saucecloud.CucumberRunner{
@@ -140,7 +143,7 @@ func runCucumber(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 			MetadataService: &testcompClient,
 			InsightsService: &insightsClient,
 			UserService:     &iamClient,
-			BuildService:    &restoClient,
+			BuildService:    &buildService,
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(

--- a/internal/cmd/run/cucumber.go
+++ b/internal/cmd/run/cucumber.go
@@ -130,7 +130,7 @@ func runCucumber(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 		ArtifactDownloadConfig: p.Artifacts.Download,
 	}
 	buildService := http.NewBuildService(
-		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+		regio, creds.Username, creds.AccessKey, buildTimeout,
 	)
 
 	log.Info().Msg("Running Playwright-Cucumberjs in Sauce Labs")

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -165,7 +165,7 @@ func runCypress(cmd *cobra.Command, cflags cypressFlags, isCLIDriven bool) (int,
 		ArtifactDownloadConfig: p.GetArtifactsCfg().Download,
 	}
 	buildService := http.NewBuildService(
-		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+		regio, creds.Username, creds.AccessKey, buildTimeout,
 	)
 
 	log.Info().Msg("Running Cypress in Sauce Labs")

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -164,6 +164,9 @@ func runCypress(cmd *cobra.Command, cflags cypressFlags, isCLIDriven bool) (int,
 		TestComposer:           testcompClient,
 		ArtifactDownloadConfig: p.GetArtifactsCfg().Download,
 	}
+	buildService := http.NewBuildService(
+		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+	)
 
 	log.Info().Msg("Running Cypress in Sauce Labs")
 	r := saucecloud.CypressRunner{
@@ -175,7 +178,7 @@ func runCypress(cmd *cobra.Command, cflags cypressFlags, isCLIDriven bool) (int,
 			TunnelService:   &restoClient,
 			InsightsService: &insightsClient,
 			UserService:     &iamClient,
-			BuildService:    &restoClient,
+			BuildService:    &buildService,
 			Region:          regio,
 			ShowConsoleLog:  p.IsShowConsoleLog(),
 			Reporters: createReporters(

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -151,7 +151,7 @@ func runEspressoInCloud(p espresso.Project, regio region.Region) (int, error) {
 		ArtifactDownloadConfig: p.Artifacts.Download,
 	}
 	buildService := http.NewBuildService(
-		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+		regio, creds.Username, creds.AccessKey, buildTimeout,
 	)
 
 	r := saucecloud.EspressoRunner{

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -150,6 +150,9 @@ func runEspressoInCloud(p espresso.Project, regio region.Region) (int, error) {
 		TestComposer:           testcompClient,
 		ArtifactDownloadConfig: p.Artifacts.Download,
 	}
+	buildService := http.NewBuildService(
+		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+	)
 
 	r := saucecloud.EspressoRunner{
 		Project: p,
@@ -160,7 +163,7 @@ func runEspressoInCloud(p espresso.Project, regio region.Region) (int, error) {
 			MetadataService: &testcompClient,
 			InsightsService: &insightsClient,
 			UserService:     &iamClient,
-			BuildService:    &restoClient,
+			BuildService:    &buildService,
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -176,7 +176,7 @@ func runPlaywright(cmd *cobra.Command, pf playwrightFlags, isCLIDriven bool) (in
 		ArtifactDownloadConfig: p.Artifacts.Download,
 	}
 	buildService := http.NewBuildService(
-		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+		regio, creds.Username, creds.AccessKey, buildTimeout,
 	)
 
 	log.Info().Msg("Running Playwright in Sauce Labs")

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -175,6 +175,9 @@ func runPlaywright(cmd *cobra.Command, pf playwrightFlags, isCLIDriven bool) (in
 		TestComposer:           testcompClient,
 		ArtifactDownloadConfig: p.Artifacts.Download,
 	}
+	buildService := http.NewBuildService(
+		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+	)
 
 	log.Info().Msg("Running Playwright in Sauce Labs")
 	r := saucecloud.PlaywrightRunner{
@@ -186,7 +189,7 @@ func runPlaywright(cmd *cobra.Command, pf playwrightFlags, isCLIDriven bool) (in
 			MetadataService: &testcompClient,
 			InsightsService: &insightsClient,
 			UserService:     &iamClient,
-			BuildService:    &restoClient,
+			BuildService:    &buildService,
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -132,7 +132,7 @@ func runPuppeteerReplayInSauce(p replay.Project, regio region.Region) (int, erro
 	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
 	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
 	buildService := http.NewBuildService(
-		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+		regio, creds.Username, creds.AccessKey, buildTimeout,
 	)
 
 	r := saucecloud.ReplayRunner{

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -131,6 +131,9 @@ func runPuppeteerReplayInSauce(p replay.Project, regio region.Region) (int, erro
 	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
 	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
 	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
+	buildService := http.NewBuildService(
+		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+	)
 
 	r := saucecloud.ReplayRunner{
 		Project: p,
@@ -147,7 +150,7 @@ func runPuppeteerReplayInSauce(p replay.Project, regio region.Region) (int, erro
 			MetadataService: &testcompClient,
 			InsightsService: &insightsClient,
 			UserService:     &iamClient,
-			BuildService:    &restoClient,
+			BuildService:    &buildService,
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -48,6 +48,7 @@ var (
 	webdriverTimeout    = 15 * time.Minute
 	rdcTimeout          = 15 * time.Minute
 	insightsTimeout     = 10 * time.Second
+	buildTimeout        = 10 * time.Second
 	iamTimeout          = 10 * time.Second
 	apitestingTimeout   = 30 * time.Second
 	imgExecTimeout      = 30 * time.Second

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -199,7 +199,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 		ArtifactDownloadConfig: p.Artifacts.Download,
 	}
 	buildService := http.NewBuildService(
-		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+		regio, creds.Username, creds.AccessKey, buildTimeout,
 	)
 
 	log.Info().Msg("Running Testcafe in Sauce Labs")

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -198,6 +198,9 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 		TestComposer:           testcompClient,
 		ArtifactDownloadConfig: p.Artifacts.Download,
 	}
+	buildService := http.NewBuildService(
+		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+	)
 
 	log.Info().Msg("Running Testcafe in Sauce Labs")
 	r := saucecloud.TestcafeRunner{
@@ -209,7 +212,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 			MetadataService: &testcompClient,
 			InsightsService: &insightsClient,
 			UserService:     &iamClient,
-			BuildService:    &restoClient,
+			BuildService:    &buildService,
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -151,6 +151,9 @@ func runXcuitestInCloud(p xcuitest.Project, regio region.Region) (int, error) {
 		TestComposer:           testcompClient,
 		ArtifactDownloadConfig: p.Artifacts.Download,
 	}
+	buildService := http.NewBuildService(
+		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+	)
 
 	r := saucecloud.XcuitestRunner{
 		Project: p,
@@ -161,7 +164,7 @@ func runXcuitestInCloud(p xcuitest.Project, regio region.Region) (int, error) {
 			MetadataService: &testcompClient,
 			InsightsService: &insightsClient,
 			UserService:     &iamClient,
-			BuildService:    &restoClient,
+			BuildService:    &buildService,
 			Region:          regio,
 			ShowConsoleLog:  p.ShowConsoleLog,
 			Reporters: createReporters(

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -152,7 +152,7 @@ func runXcuitestInCloud(p xcuitest.Project, regio region.Region) (int, error) {
 		ArtifactDownloadConfig: p.Artifacts.Download,
 	}
 	buildService := http.NewBuildService(
-		regio.APIBaseURL(), creds.Username, creds.AccessKey, buildTimeout,
+		regio, creds.Username, creds.AccessKey, buildTimeout,
 	)
 
 	r := saucecloud.XcuitestRunner{

--- a/internal/http/build.go
+++ b/internal/http/build.go
@@ -1,0 +1,61 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/saucelabs/saucectl/internal/build"
+)
+
+func NewBuildService(
+	url, username, accessKey string, timeout time.Duration,
+) BuildService {
+	return BuildService{
+		Client:    NewRetryableClient(timeout),
+		URL:       url,
+		Username:  username,
+		AccessKey: accessKey,
+	}
+}
+
+type BuildService struct {
+	Client    *retryablehttp.Client
+	URL       string
+	Username  string
+	AccessKey string
+}
+
+func (c *BuildService) GetBuildID(
+	ctx context.Context, jobID string, buildSource build.Source,
+) (string, error) {
+	req, err := NewRetryableRequestWithContext(
+		ctx, http.MethodGet, fmt.Sprintf(
+			"%s/v2/builds/%s/jobs/%s/build/", c.URL, buildSource, jobID,
+		), nil,
+	)
+	if err != nil {
+		return "", err
+	}
+	req.SetBasicAuth(c.Username, c.AccessKey)
+
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("unexpected statusCode: %v", resp.StatusCode)
+	}
+
+	var br build.Build
+	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+		return "", err
+	}
+
+	return br.ID, nil
+}

--- a/internal/http/build.go
+++ b/internal/http/build.go
@@ -29,7 +29,7 @@ type BuildService struct {
 	AccessKey string
 }
 
-func (c *BuildService) GetBuildID(
+func (c *BuildService) FindBuild(
 	ctx context.Context, jobID string, buildSource build.Source,
 ) (string, error) {
 	req, err := NewRetryableRequestWithContext(

--- a/internal/http/build.go
+++ b/internal/http/build.go
@@ -30,11 +30,16 @@ type BuildService struct {
 }
 
 func (c *BuildService) FindBuild(
-	ctx context.Context, jobID string, buildSource build.Source,
+	ctx context.Context, jobID string, realDevice bool,
 ) (build.Build, error) {
+	src := "vdc"
+	if realDevice {
+		src = "rdc"
+	}
+
 	req, err := NewRetryableRequestWithContext(
 		ctx, http.MethodGet, fmt.Sprintf(
-			"%s/v2/builds/%s/jobs/%s/build/", c.URL, buildSource, jobID,
+			"%s/v2/builds/%s/jobs/%s/build/", c.URL, src, jobID,
 		), nil,
 	)
 	if err != nil {

--- a/internal/http/build_test.go
+++ b/internal/http/build_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/saucelabs/saucectl/internal/build"
+	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,6 +52,8 @@ func TestBuildService_GetBuildID(t *testing.T) {
 		},
 	}
 	for _, tt := range testCases {
+		// FIXME must be wrapped in t.Run(tt.name, func(t *testing.T) { ... }) !
+
 		// arrange
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(tt.statusCode)
@@ -58,7 +61,8 @@ func TestBuildService_GetBuildID(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewBuildService(ts.URL, "user", "key", 3*time.Second)
+		client := NewBuildService(region.None, "user", "key", 3*time.Second)
+		client.URL = ts.URL
 		client.Client.RetryWaitMax = 1 * time.Millisecond
 
 		// act
@@ -67,8 +71,9 @@ func TestBuildService_GetBuildID(t *testing.T) {
 		)
 
 		// assert
-		assert.Equal(t, bid, tt.want)
+		assert.Equal(t, tt.want, bid)
 		if err != nil {
+			println(tt.name)
 			assert.True(t, strings.Contains(err.Error(), tt.wantErr.Error()))
 		}
 	}

--- a/internal/http/build_test.go
+++ b/internal/http/build_test.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/saucelabs/saucectl/internal/build"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildService_GetBuildID(t *testing.T) {
+	testCases := []struct {
+		name         string
+		statusCode   int
+		responseBody []byte
+		want         string
+		wantErr      error
+	}{
+		{
+			name:         "happy case",
+			statusCode:   http.StatusOK,
+			responseBody: []byte(`{"id": "happy-build-id"}`),
+			want:         "happy-build-id",
+			wantErr:      nil,
+		},
+		{
+			name:         "job not found",
+			statusCode:   http.StatusNotFound,
+			responseBody: nil,
+			want:         "",
+			wantErr:      errors.New("unexpected statusCode: 404"),
+		},
+		{
+			name:         "validation error",
+			statusCode:   http.StatusUnprocessableEntity,
+			responseBody: nil,
+			want:         "",
+			wantErr:      errors.New("unexpected statusCode: 422"),
+		},
+		{
+			name:         "unparseable response",
+			statusCode:   http.StatusOK,
+			responseBody: []byte(`{"id": "bad-json-response"`),
+			want:         "",
+			wantErr:      errors.New("unexpected EOF"),
+		},
+	}
+	for _, tt := range testCases {
+		// arrange
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(tt.statusCode)
+			_, _ = w.Write(tt.responseBody)
+		}))
+		defer ts.Close()
+
+		client := NewBuildService(ts.URL, "user", "key", 3*time.Second)
+		client.Client.RetryWaitMax = 1 * time.Millisecond
+
+		// act
+		bid, err := client.GetBuildID(context.Background(), "some-job-id", build.VDC)
+
+		// assert
+		assert.Equal(t, bid, tt.want)
+		if err != nil {
+			assert.True(t, strings.Contains(err.Error(), tt.wantErr.Error()))
+		}
+	}
+}

--- a/internal/http/build_test.go
+++ b/internal/http/build_test.go
@@ -18,35 +18,35 @@ func TestBuildService_GetBuildID(t *testing.T) {
 		name         string
 		statusCode   int
 		responseBody []byte
-		want         string
+		want         build.Build
 		wantErr      error
 	}{
 		{
 			name:         "happy case",
 			statusCode:   http.StatusOK,
 			responseBody: []byte(`{"id": "happy-build-id"}`),
-			want:         "happy-build-id",
+			want:         build.Build{ID: "happy-build-id"},
 			wantErr:      nil,
 		},
 		{
 			name:         "job not found",
 			statusCode:   http.StatusNotFound,
 			responseBody: nil,
-			want:         "",
+			want:         build.Build{},
 			wantErr:      errors.New("unexpected statusCode: 404"),
 		},
 		{
 			name:         "validation error",
 			statusCode:   http.StatusUnprocessableEntity,
 			responseBody: nil,
-			want:         "",
+			want:         build.Build{},
 			wantErr:      errors.New("unexpected statusCode: 422"),
 		},
 		{
 			name:         "unparseable response",
 			statusCode:   http.StatusOK,
 			responseBody: []byte(`{"id": "bad-json-response"`),
-			want:         "",
+			want:         build.Build{},
 			wantErr:      errors.New("unexpected EOF"),
 		},
 	}
@@ -62,7 +62,9 @@ func TestBuildService_GetBuildID(t *testing.T) {
 		client.Client.RetryWaitMax = 1 * time.Millisecond
 
 		// act
-		bid, err := client.FindBuild(context.Background(), "some-job-id", build.VDC)
+		bid, err := client.FindBuild(
+			context.Background(), "some-job-id", false,
+		)
 
 		// assert
 		assert.Equal(t, bid, tt.want)

--- a/internal/http/build_test.go
+++ b/internal/http/build_test.go
@@ -62,7 +62,7 @@ func TestBuildService_GetBuildID(t *testing.T) {
 		client.Client.RetryWaitMax = 1 * time.Millisecond
 
 		// act
-		bid, err := client.GetBuildID(context.Background(), "some-job-id", build.VDC)
+		bid, err := client.FindBuild(context.Background(), "some-job-id", build.VDC)
 
 		// assert
 		assert.Equal(t, bid, tt.want)

--- a/internal/http/build_test.go
+++ b/internal/http/build_test.go
@@ -30,7 +30,7 @@ func TestBuildService_GetBuildID(t *testing.T) {
 				ID:  "happy-build-id",
 				URL: "https://app.saucelabs.com/builds/vdc/happy-build-id",
 			},
-			wantErr:      nil,
+			wantErr: nil,
 		},
 		{
 			name:         "job not found",

--- a/internal/http/resto.go
+++ b/internal/http/resto.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/saucelabs/saucectl/internal/build"
 	"github.com/saucelabs/saucectl/internal/job"
 	tunnels "github.com/saucelabs/saucectl/internal/tunnel"
 	"github.com/saucelabs/saucectl/internal/vmd"
@@ -391,31 +390,6 @@ func (c *Resto) GetVirtualDevices(ctx context.Context, kind string) ([]vmd.Virtu
 		return dev[i].Name < dev[j].Name
 	})
 	return dev, nil
-}
-
-func (c *Resto) GetBuildID(ctx context.Context, jobID string, buildSource build.Source) (string, error) {
-	req, err := NewRetryableRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v2/builds/%s/jobs/%s/build/", c.URL, buildSource, jobID), nil)
-	if err != nil {
-		return "", err
-	}
-	req.SetBasicAuth(c.Username, c.AccessKey)
-
-	resp, err := c.Client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("unexpected statusCode: %v", resp.StatusCode)
-	}
-
-	var br build.Build
-	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
-		return "", err
-	}
-
-	return br.ID, nil
 }
 
 // parseJob parses the body into restoJob and converts it to job.Job.

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -52,7 +52,7 @@ type CloudRunner struct {
 	MetadataSearchStrategy framework.MetadataSearchStrategy
 	InsightsService        insights.Service
 	UserService            iam.UserService
-	BuildService           build.Reader
+	BuildService           build.Service
 	Retrier                retry.Retrier
 
 	Reporters []report.Reporter
@@ -212,7 +212,7 @@ func (r *CloudRunner) getBuildURL(jobID string, isRDC bool) string {
 		buildSource = build.RDC
 	}
 
-	bID, err := r.BuildService.GetBuildID(context.Background(), jobID, buildSource)
+	bID, err := r.BuildService.FindBuild(context.Background(), jobID, buildSource)
 	if err != nil {
 		log.Warn().Err(err).Msgf("Failed to retrieve build id for job (%s)", jobID)
 		return ""
@@ -935,7 +935,7 @@ func (r *CloudRunner) reportSuiteToInsights(res result) {
 	}
 
 	if res.details.BuildID == "" {
-		buildID, err := r.BuildService.GetBuildID(context.Background(), res.job.ID, getSource(res.job.IsRDC))
+		buildID, err := r.BuildService.FindBuild(context.Background(), res.job.ID, getSource(res.job.IsRDC))
 		if err != nil {
 			// leave BuildID empty when it failed to get build info
 			log.Warn().Err(err).Str("action", "getBuild").Str("jobID", res.job.ID).Msg(msg.EmptyBuildID)

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -212,13 +212,16 @@ func (r *CloudRunner) getBuildURL(jobID string, isRDC bool) string {
 		buildSource = build.RDC
 	}
 
-	bID, err := r.BuildService.FindBuild(context.Background(), jobID, buildSource)
+	b, err := r.BuildService.FindBuild(context.Background(), jobID, buildSource)
 	if err != nil {
 		log.Warn().Err(err).Msgf("Failed to retrieve build id for job (%s)", jobID)
 		return ""
 	}
 
-	bURL := fmt.Sprintf("%s/builds/%s/%s", r.Region.AppBaseURL(), buildSource, bID)
+	bURL := fmt.Sprintf(
+		"%s/builds/%s/%s", r.Region.AppBaseURL(), buildSource,
+		b.ID,
+	)
 	if !isRDC {
 		r.Cache.VDCBuildURL = bURL
 	} else {
@@ -935,12 +938,12 @@ func (r *CloudRunner) reportSuiteToInsights(res result) {
 	}
 
 	if res.details.BuildID == "" {
-		buildID, err := r.BuildService.FindBuild(context.Background(), res.job.ID, getSource(res.job.IsRDC))
+		b, err := r.BuildService.FindBuild(context.Background(), res.job.ID, getSource(res.job.IsRDC))
 		if err != nil {
 			// leave BuildID empty when it failed to get build info
 			log.Warn().Err(err).Str("action", "getBuild").Str("jobID", res.job.ID).Msg(msg.EmptyBuildID)
 		}
-		res.details.BuildID = buildID
+		res.details.BuildID = b.ID
 	}
 
 	assets, err := r.JobService.ArtifactNames(context.Background(), res.job.ID, res.job.IsRDC)

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -199,17 +199,14 @@ func (r *CloudRunner) collectResults(results chan result, expected int) bool {
 }
 
 func (r *CloudRunner) getBuildURL(jobID string, isRDC bool) string {
-	var buildSource build.Source
-	if !isRDC {
-		if r.Cache.VDCBuildURL != "" {
-			return r.Cache.VDCBuildURL
-		}
-		buildSource = build.VDC
-	} else {
+	if isRDC {
 		if r.Cache.RDCBuildURL != "" {
 			return r.Cache.RDCBuildURL
 		}
-		buildSource = build.RDC
+	} else {
+		if r.Cache.VDCBuildURL != "" {
+			return r.Cache.VDCBuildURL
+		}
 	}
 
 	b, err := r.BuildService.FindBuild(context.Background(), jobID, isRDC)
@@ -218,16 +215,13 @@ func (r *CloudRunner) getBuildURL(jobID string, isRDC bool) string {
 		return ""
 	}
 
-	bURL := fmt.Sprintf(
-		"%s/builds/%s/%s", r.Region.AppBaseURL(), buildSource,
-		b.ID,
-	)
-	if !isRDC {
-		r.Cache.VDCBuildURL = bURL
+	if isRDC {
+		r.Cache.RDCBuildURL = b.URL
 	} else {
-		r.Cache.RDCBuildURL = bURL
+		r.Cache.VDCBuildURL = b.URL
 	}
-	return bURL
+
+	return b.URL
 }
 
 func (r *CloudRunner) runJob(opts job.StartOptions) (j job.Job, skipped bool, err error) {


### PR DESCRIPTION
## Description

Improve the Builds API.

### How?

- The `Build` API was moved out of the `Resto` client, where it was falsely implemented. This API is not provided by that particular web service.
- `GetBuildID` was completely revamped to return a full `Build` struct and was aptly renamed to `FindBuild`. The `Find` prefix meant to signify the uncertainty, since Jobs don't have to be associated with Builds—and we're technically speaking performing a search.
- Determining the `Build` URL is now the responsibility of the client that returns this entity.
- The `reportInsights` function used to retrieve the `Build` URL from scratch, once per Job, which resulted in a lot of duplicate calls. It's now using the same cache that was introduced for the build report summary.
- Fixed `Build` tests that were not calling the correct test "run" sub-function (which is what you must do when using table driven tests), making it impossible to figure out which tests were passing/failing. From a reporting perspective, it was all or nothing.
- Reduced spaghetti code by consolidating responsibilities