### PR TITLE
refactor: job url propagation

### DIFF
--- a/internal/cmd/artifacts/cmd.go
+++ b/internal/cmd/artifacts/cmd.go
@@ -46,10 +46,10 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 			artifactSvc = ArtifactService{
 				JobService: saucecloud.JobService{
 					Resto: http.NewResto(
-						url, creds.Username, creds.AccessKey, restoTimeout,
+						reg, creds.Username, creds.AccessKey, restoTimeout,
 					),
 					RDC: http.NewRDCService(
-						url, creds.Username, creds.AccessKey, rdcTimeout,
+						reg, creds.Username, creds.AccessKey, rdcTimeout,
 					),
 					TestComposer: http.NewTestComposer(
 						url, creds, testComposerTimeout,

--- a/internal/cmd/ini/initializer.go
+++ b/internal/cmd/ini/initializer.go
@@ -59,8 +59,8 @@ type initializer struct {
 func newInitializer(stdio terminal.Stdio, creds iam.Credentials, cfg *initConfig) *initializer {
 	r := region.FromString(cfg.region)
 	tc := http.NewTestComposer(r.APIBaseURL(), creds, testComposerTimeout)
-	rc := http.NewRDCService(r.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
-	rs := http.NewResto(r.APIBaseURL(), creds.Username, creds.AccessKey, restoTimeout)
+	rc := http.NewRDCService(r, creds.Username, creds.AccessKey, rdcTimeout)
+	rs := http.NewResto(r, creds.Username, creds.AccessKey, restoTimeout)
 	us := http.NewUserService(r.APIBaseURL(), creds, 5*time.Second)
 
 	return &initializer{

--- a/internal/cmd/run/apitest.go
+++ b/internal/cmd/run/apitest.go
@@ -40,7 +40,7 @@ func runApitest(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 	creds := regio.Credentials()
 
 	apitestingClient := http.NewAPITester(regio.APIBaseURL(), creds.Username, creds.AccessKey, apitestingTimeout)
-	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
+	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)
 
 	r := apitest.Runner{
 		Project: p,

--- a/internal/cmd/run/cucumber.go
+++ b/internal/cmd/run/cucumber.go
@@ -115,11 +115,11 @@ func runCucumber(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 
 	creds := regio.Credentials()
 
-	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
+	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)
 	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)
-	webdriverClient := http.NewWebdriver(regio.WebDriverBaseURL(), creds, webdriverTimeout)
+	webdriverClient := http.NewWebdriver(regio, creds, webdriverTimeout)
 	appsClient := *http.NewAppStore(regio.APIBaseURL(), creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
-	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
+	rdcClient := http.NewRDCService(regio, creds.Username, creds.AccessKey, rdcTimeout)
 	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
 	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
 	jobService := saucecloud.JobService{

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -150,11 +150,11 @@ func runCypress(cmd *cobra.Command, cflags cypressFlags, isCLIDriven bool) (int,
 
 	creds := regio.Credentials()
 
-	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
+	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)
 	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)
-	webdriverClient := http.NewWebdriver(regio.WebDriverBaseURL(), creds, webdriverTimeout)
+	webdriverClient := http.NewWebdriver(regio, creds, webdriverTimeout)
 	appsClient := *http.NewAppStore(regio.APIBaseURL(), creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
-	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
+	rdcClient := http.NewRDCService(regio, creds.Username, creds.AccessKey, rdcTimeout)
 	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
 	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
 	jobService := saucecloud.JobService{

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -136,11 +136,11 @@ func runEspressoInCloud(p espresso.Project, regio region.Region) (int, error) {
 	log.Info().Msg("Running Espresso in Sauce Labs")
 
 	creds := regio.Credentials()
-	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
+	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)
 	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)
-	webdriverClient := http.NewWebdriver(regio.WebDriverBaseURL(), creds, webdriverTimeout)
+	webdriverClient := http.NewWebdriver(regio, creds, webdriverTimeout)
 	appsClient := *http.NewAppStore(regio.APIBaseURL(), creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
-	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
+	rdcClient := http.NewRDCService(regio, creds.Username, creds.AccessKey, rdcTimeout)
 	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
 	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
 	jobService := saucecloud.JobService{

--- a/internal/cmd/run/imagerunner.go
+++ b/internal/cmd/run/imagerunner.go
@@ -73,7 +73,7 @@ func runImageRunner(cmd *cobra.Command) (int, error) {
 	}
 
 	imageRunnerClient := http.NewImageRunner(regio.APIBaseURL(), creds, imgExecTimeout, asyncEventManager)
-	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
+	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)
 
 	r := saucecloud.NewImgRunner(p, &imageRunnerClient, &restoClient, asyncEventManager,
 		reporters, gFlags.async)

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -161,11 +161,11 @@ func runPlaywright(cmd *cobra.Command, pf playwrightFlags, isCLIDriven bool) (in
 
 	creds := regio.Credentials()
 
-	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
+	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)
 	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)
-	webdriverClient := http.NewWebdriver(regio.WebDriverBaseURL(), creds, webdriverTimeout)
+	webdriverClient := http.NewWebdriver(regio, creds, webdriverTimeout)
 	appsClient := *http.NewAppStore(regio.APIBaseURL(), creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
-	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
+	rdcClient := http.NewRDCService(regio, creds.Username, creds.AccessKey, rdcTimeout)
 	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
 	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
 	jobService := saucecloud.JobService{

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -124,11 +124,11 @@ func runPuppeteerReplayInSauce(p replay.Project, regio region.Region) (int, erro
 	log.Info().Msg("Replaying chrome devtools recordings")
 
 	creds := regio.Credentials()
-	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
+	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)
 	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)
-	webdriverClient := http.NewWebdriver(regio.WebDriverBaseURL(), creds, webdriverTimeout)
+	webdriverClient := http.NewWebdriver(regio, creds, webdriverTimeout)
 	appsClient := *http.NewAppStore(regio.APIBaseURL(), creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
-	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
+	rdcClient := http.NewRDCService(regio, creds.Username, creds.AccessKey, rdcTimeout)
 	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
 	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
 	buildService := http.NewBuildService(

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -184,11 +184,11 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 
 	creds := regio.Credentials()
 
-	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
+	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)
 	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)
-	webdriverClient := http.NewWebdriver(regio.WebDriverBaseURL(), creds, webdriverTimeout)
+	webdriverClient := http.NewWebdriver(regio, creds, webdriverTimeout)
 	appsClient := *http.NewAppStore(regio.APIBaseURL(), creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
-	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
+	rdcClient := http.NewRDCService(regio, creds.Username, creds.AccessKey, rdcTimeout)
 	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
 	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
 	jobService := saucecloud.JobService{

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -137,11 +137,11 @@ func runXcuitestInCloud(p xcuitest.Project, regio region.Region) (int, error) {
 
 	creds := regio.Credentials()
 
-	restoClient := http.NewResto(regio.APIBaseURL(), creds.Username, creds.AccessKey, 0)
+	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)
 	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)
-	webdriverClient := http.NewWebdriver(regio.WebDriverBaseURL(), creds, webdriverTimeout)
+	webdriverClient := http.NewWebdriver(regio, creds, webdriverTimeout)
 	appsClient := *http.NewAppStore(regio.APIBaseURL(), creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
-	rdcClient := http.NewRDCService(regio.APIBaseURL(), creds.Username, creds.AccessKey, rdcTimeout)
+	rdcClient := http.NewRDCService(regio, creds.Username, creds.AccessKey, rdcTimeout)
 	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
 	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
 	jobService := saucecloud.JobService{

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -23,7 +23,7 @@ func NewRetryableClient(timeout time.Duration) *retryablehttp.Client {
 			if e != nil {
 				return ok, e
 			}
-			if !ok && resp.StatusCode == http.StatusNotFound {
+			if !ok && resp.StatusCode == http.StatusNotFound { // FIXME potential null pointer
 				return true, nil
 			}
 			return ok, e

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -23,7 +23,7 @@ func NewRetryableClient(timeout time.Duration) *retryablehttp.Client {
 			if e != nil {
 				return ok, e
 			}
-			if !ok && resp.StatusCode == http.StatusNotFound { // FIXME potential null pointer
+			if !ok && resp != nil && resp.StatusCode == http.StatusNotFound {
 				return true, nil
 			}
 			return ok, e

--- a/internal/http/rdcservice.go
+++ b/internal/http/rdcservice.go
@@ -169,9 +169,10 @@ func (c *RDCService) StartJob(ctx context.Context, opts job.StartOptions) (job.J
 	}
 
 	return job.Job{
-		ID:  sessionStart.TestReport.ID,
-		IsRDC: true,
-		URL: fmt.Sprintf("%s/tests/%s", c.AppURL, sessionStart.TestReport.ID),
+		ID:     sessionStart.TestReport.ID,
+		IsRDC:  true,
+		Status: job.StateQueued,
+		URL:    fmt.Sprintf("%s/tests/%s", c.AppURL, sessionStart.TestReport.ID),
 	}, nil
 }
 

--- a/internal/http/rdcservice.go
+++ b/internal/http/rdcservice.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/saucelabs/saucectl/internal/slice"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -24,6 +25,7 @@ import (
 // RDCService http client.
 type RDCService struct {
 	Client    *retryablehttp.Client
+	AppURL    string
 	URL       string
 	Username  string
 	AccessKey string
@@ -83,17 +85,18 @@ type DeviceQuery struct {
 }
 
 // NewRDCService creates a new client.
-func NewRDCService(url, username, accessKey string, timeout time.Duration) RDCService {
+func NewRDCService(r region.Region, username, accessKey string, timeout time.Duration) RDCService {
 	return RDCService{
 		Client:    NewRetryableClient(timeout),
-		URL:       url,
+		AppURL:    r.AppBaseURL(),
+		URL:       r.APIBaseURL(),
 		Username:  username,
 		AccessKey: accessKey,
 	}
 }
 
 // StartJob creates a new job in Sauce Labs.
-func (c *RDCService) StartJob(ctx context.Context, opts job.StartOptions) (jobID string, err error) {
+func (c *RDCService) StartJob(ctx context.Context, opts job.StartOptions) (job.Job, error) {
 	url := fmt.Sprintf("%s/v1/rdc/native-composer/tests", c.URL)
 
 	var frameworkName string
@@ -129,31 +132,31 @@ func (c *RDCService) StartJob(ctx context.Context, opts job.StartOptions) (jobID
 	}
 
 	var b bytes.Buffer
-	err = json.NewEncoder(&b).Encode(jobReq)
+	err := json.NewEncoder(&b).Encode(jobReq)
 	if err != nil {
-		return
+		return job.Job{}, err
 	}
 
 	req, err := NewRequestWithContext(ctx, http.MethodPost, url, &b)
 	if err != nil {
-		return
+		return job.Job{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth(c.Username, c.AccessKey)
 
 	resp, err := c.Client.HTTPClient.Do(req)
 	if err != nil {
-		return
+		return job.Job{}, err
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return
+		return job.Job{}, err
 	}
 
 	if resp.StatusCode >= 300 {
 		err = fmt.Errorf("job start failed; unexpected response code:'%d', msg:'%v'", resp.StatusCode, strings.TrimSpace(string(body)))
-		return "", err
+		return job.Job{}, err
 	}
 
 	var sessionStart struct {
@@ -162,10 +165,14 @@ func (c *RDCService) StartJob(ctx context.Context, opts job.StartOptions) (jobID
 		} `json:"test_report"`
 	}
 	if err = json.Unmarshal(body, &sessionStart); err != nil {
-		return "", fmt.Errorf("job start status unknown: unable to parse server response: %w", err)
+		return job.Job{}, fmt.Errorf("job start status unknown: unable to parse server response: %w", err)
 	}
 
-	return sessionStart.TestReport.ID, nil
+	return job.Job{
+		ID:  sessionStart.TestReport.ID,
+		IsRDC: true,
+		URL: fmt.Sprintf("%s/tests/%s", c.AppURL, sessionStart.TestReport.ID),
+	}, nil
 }
 
 func (c *RDCService) StopJob(ctx context.Context, id string, realDevice bool) (job.Job, error) {
@@ -201,7 +208,11 @@ func (c *RDCService) StopJob(ctx context.Context, id string, realDevice bool) (j
 	}
 
 	// RDC does not return any job details in the response.
-	return job.Job{}, nil
+	return job.Job{
+		ID:     id,
+		Status: job.StateInProgress,
+		URL:    fmt.Sprintf("%s/tests/%s", c.AppURL, id),
+	}, nil
 }
 
 // Job returns the job details.
@@ -485,5 +496,6 @@ func (c *RDCService) parseJob(body io.ReadCloser) (job.Job, error) {
 		OS:         j.OS,
 		OSVersion:  j.OSVersion,
 		IsRDC:      true,
+		URL:        fmt.Sprintf("%s/tests/%s", c.AppURL, j.ID),
 	}, err
 }

--- a/internal/http/rdcservice_test.go
+++ b/internal/http/rdcservice_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/saucelabs/saucectl/internal/devices"
 	"github.com/saucelabs/saucectl/internal/job"
+	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +43,8 @@ func TestRDCService_ReadJob(t *testing.T) {
 	}))
 	defer ts.Close()
 	timeout := 3 * time.Second
-	client := NewRDCService(ts.URL, "test-user", "test-key", timeout)
+	client := NewRDCService(region.None, "test-user", "test-key", timeout)
+	client.URL = ts.URL
 	client.Client.RetryMax = 0
 
 	testCases := []struct {
@@ -52,37 +54,68 @@ func TestRDCService_ReadJob(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "passed job",
-			jobID:   "test1",
-			want:    job.Job{ID: "test1", Error: "", Status: "passed", Passed: true, IsRDC: true},
+			name:  "passed job",
+			jobID: "test1",
+			want: job.Job{
+				ID:     "test1",
+				Error:  "",
+				Status: "passed",
+				Passed: true,
+				IsRDC:  true,
+				URL:    "/tests/test1",
+			},
 			wantErr: nil,
 		},
 		{
-			name:    "failed job",
-			jobID:   "test2",
-			want:    job.Job{ID: "test2", Error: "no-device-found", Status: "failed", Passed: false, IsRDC: true},
+			name:  "failed job",
+			jobID: "test2",
+			want: job.Job{
+				ID:     "test2",
+				Error:  "no-device-found",
+				Status: "failed",
+				Passed: false,
+				IsRDC:  true,
+				URL:    "/tests/test2",
+			},
 			wantErr: nil,
 		},
 		{
-			name:    "in progress job",
-			jobID:   "test3",
-			want:    job.Job{ID: "test3", Error: "", Status: "in progress", Passed: false, IsRDC: true},
+			name:  "in progress job",
+			jobID: "test3",
+			want: job.Job{
+				ID:     "test3",
+				Error:  "",
+				Status: "in progress",
+				Passed: false,
+				IsRDC:  true,
+				URL:    "/tests/test3",
+			},
 			wantErr: nil,
 		},
 		{
-			name:    "non-existent job",
-			jobID:   "test4",
-			want:    job.Job{ID: "test4", Error: "", Status: "", Passed: false},
+			name:  "non-existent job",
+			jobID: "test4",
+			want: job.Job{
+				ID:     "test4",
+				Error:  "",
+				Status: "",
+				Passed: false,
+				URL:    "/tests/test4",
+			},
 			wantErr: ErrJobNotFound,
 		},
 	}
 
 	for _, tt := range testCases {
-		j, err := client.Job(context.Background(), tt.jobID, true)
-		assert.Equal(t, err, tt.wantErr)
-		if err == nil {
-			assert.Equal(t, tt.want, j)
-		}
+		t.Run(
+			tt.name, func(t *testing.T) {
+				j, err := client.Job(context.Background(), tt.jobID, true)
+				assert.Equal(t, err, tt.wantErr)
+				if err == nil {
+					assert.Equal(t, tt.want, j)
+				}
+			},
+		)
 	}
 }
 
@@ -131,6 +164,9 @@ func TestRDCService_PollJob(t *testing.T) {
 	defer ts.Close()
 	timeout := 3 * time.Second
 
+	rdc := NewRDCService(region.None, "test", "123", timeout)
+	rdc.URL = ts.URL
+
 	testCases := []struct {
 		name         string
 		client       RDCService
@@ -140,7 +176,7 @@ func TestRDCService_PollJob(t *testing.T) {
 	}{
 		{
 			name:   "get job details with ID 1 and status 'complete'",
-			client: NewRDCService(ts.URL, "test", "123", timeout),
+			client: rdc,
 			jobID:  "1",
 			expectedResp: job.Job{
 				ID:     "1",
@@ -148,12 +184,13 @@ func TestRDCService_PollJob(t *testing.T) {
 				Status: "complete",
 				Error:  "",
 				IsRDC:  true,
+				URL:    "/tests/1",
 			},
 			expectedErr: nil,
 		},
 		{
 			name:   "get job details with ID 2 and status 'error'",
-			client: NewRDCService(ts.URL, "test", "123", timeout),
+			client: rdc,
 			jobID:  "2",
 			expectedResp: job.Job{
 				ID:     "2",
@@ -161,33 +198,34 @@ func TestRDCService_PollJob(t *testing.T) {
 				Status: "error",
 				Error:  "User Abandoned Test -- User terminated",
 				IsRDC:  true,
+				URL:    "/tests/2",
 			},
 			expectedErr: nil,
 		},
 		{
 			name:         "job not found error from external API",
-			client:       NewRDCService(ts.URL, "test", "123", timeout),
+			client:       rdc,
 			jobID:        "3",
 			expectedResp: job.Job{},
 			expectedErr:  ErrJobNotFound,
 		},
 		{
 			name:         "http status is not 200, but 401 from external API",
-			client:       NewRDCService(ts.URL, "test", "123", timeout),
+			client:       rdc,
 			jobID:        "4",
 			expectedResp: job.Job{},
 			expectedErr:  errors.New("unexpected statusCode: 401"),
 		},
 		{
 			name:         "unexpected status code from external API",
-			client:       NewRDCService(ts.URL, "test", "123", timeout),
+			client:       rdc,
 			jobID:        "333",
 			expectedResp: job.Job{},
 			expectedErr:  errors.New("internal server error"),
 		},
 		{
 			name:   "get job details with ID 5. retry 2 times and succeed",
-			client: NewRDCService(ts.URL, "test", "123", timeout),
+			client: rdc,
 			jobID:  "5",
 			expectedResp: job.Job{
 				ID:     "5",
@@ -195,6 +233,7 @@ func TestRDCService_PollJob(t *testing.T) {
 				Status: job.StatePassed,
 				Error:  "",
 				IsRDC:  true,
+				URL:    "/tests/5",
 			},
 			expectedErr: nil,
 		},
@@ -239,7 +278,8 @@ func TestRDCService_GetJobAssetFileNames(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
-	client := NewRDCService(ts.URL, "test-user", "test-password", 1*time.Second)
+	client := NewRDCService(region.None, "test-user", "test-password", 1*time.Second)
+	client.URL = ts.URL
 
 	testCases := []struct {
 		name     string
@@ -312,7 +352,8 @@ func TestRDCService_GetJobAssetFileContent(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
-	client := NewRDCService(ts.URL, "test-user", "test-password", 1*time.Second)
+	client := NewRDCService(region.None, "test-user", "test-password", 1*time.Second)
+	client.URL = ts.URL
 	client.Client.RetryMax = 0
 
 	testCases := []struct {

--- a/internal/http/resto.go
+++ b/internal/http/resto.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/saucelabs/saucectl/internal/job"
+	"github.com/saucelabs/saucectl/internal/region"
 	tunnels "github.com/saucelabs/saucectl/internal/tunnel"
 	"github.com/saucelabs/saucectl/internal/vmd"
 )
@@ -48,6 +49,7 @@ type restoJob struct {
 // Resto http client.
 type Resto struct {
 	Client    *retryablehttp.Client
+	AppURL    string
 	URL       string
 	Username  string
 	AccessKey string
@@ -61,10 +63,11 @@ type tunnel struct {
 }
 
 // NewResto creates a new client.
-func NewResto(url, username, accessKey string, timeout time.Duration) Resto {
+func NewResto(r region.Region, username, accessKey string, timeout time.Duration) Resto {
 	return Resto{
 		Client:    NewRetryableClient(timeout),
-		URL:       url,
+		AppURL:    r.AppBaseURL(),
+		URL:       r.APIBaseURL(),
 		Username:  username,
 		AccessKey: accessKey,
 	}
@@ -424,5 +427,6 @@ func (c *Resto) parseJob(body io.ReadCloser) (job.Job, error) {
 		Framework:      j.AutomationBackend,
 		OS:             osName,
 		OSVersion:      osVersion,
+		URL:            fmt.Sprintf("%s/tests/%s", c.AppURL, j.ID),
 	}, nil
 }

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -61,6 +61,8 @@ type Job struct {
 
 	// TimedOut flags a job as an unfinished one.
 	TimedOut bool
+
+	URL string
 }
 
 // TotalStatus returns the total status of a job, combining the result of fields Status + Passed.
@@ -89,7 +91,7 @@ func Done(status string) bool {
 // Service represents the interface for Job interactions.
 type Service interface {
 	// StartJob starts a new Job.
-	StartJob(ctx context.Context, opts StartOptions) (jobID string, err error)
+	StartJob(ctx context.Context, opts StartOptions) (Job, error)
 
 	// StopJob stops a running Job.
 	StopJob(ctx context.Context, jobID string, realDevice bool) (Job, error)

--- a/internal/mocks/job.go
+++ b/internal/mocks/job.go
@@ -9,34 +9,18 @@ import (
 
 // FakeJobService resto mock
 type FakeJobService struct {
-	StartJobFn func(ctx context.Context, opts job.StartOptions) (string, error)
-	StopJobFn  func(
-		ctx context.Context, jobID string, realDevice bool,
-	) (job.Job, error)
-	ReadJobFn func(ctx context.Context, id string) (
-		job.Job, error,
-	)
-	PollJobFn func(
-		ctx context.Context, id string, interval time.Duration,
-		timeout time.Duration,
-	) (job.Job, error)
+	StartJobFn func(ctx context.Context, opts job.StartOptions) (job.Job, error)
+	StopJobFn  func(ctx context.Context, jobID string, realDevice bool) (job.Job, error)
+	ReadJobFn  func(ctx context.Context, id string) (job.Job, error)
+	PollJobFn  func(ctx context.Context, id string, interval time.Duration, timeout time.Duration) (job.Job, error)
 
-	UploadAssetFn func(
-		jobID string, realDevice bool, fileName string, contentType string,
-		content []byte,
-	) error
-	DownloadArtifactFn     func(job job.Job, isLastAttempt bool) []string
-	GetJobAssetFileNamesFn func(ctx context.Context, jobID string) (
-		[]string, error,
-	)
-	GetJobAssetFileContentFn func(
-		ctx context.Context, jobID, fileName string,
-	) ([]byte, error)
+	UploadAssetFn            func(jobID string, realDevice bool, fileName string, contentType string, content []byte) error
+	DownloadArtifactFn       func(job job.Job, isLastAttempt bool) []string
+	GetJobAssetFileNamesFn   func(ctx context.Context, jobID string) ([]string, error)
+	GetJobAssetFileContentFn func(ctx context.Context, jobID, fileName string) ([]byte, error)
 }
 
-func (s *FakeJobService) StartJob(
-	ctx context.Context, opts job.StartOptions,
-) (jobID string, err error) {
+func (s *FakeJobService) StartJob(ctx context.Context, opts job.StartOptions) (job.Job, error) {
 	return s.StartJobFn(ctx, opts)
 }
 

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -250,7 +250,6 @@ func (r *CloudRunner) runJob(opts job.StartOptions) (j job.Job, skipped bool, er
 
 	// Async mode. Return the current status without waiting for the final result.
 	if r.Async {
-		// FIXME can we use the job from before now?
 		return j, false, nil
 	}
 

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -149,10 +149,6 @@ func (r *CloudRunner) collectResults(results chan result, expected int) bool {
 
 			r.FetchJUnitReports(&res, res.artifacts)
 
-			var url string
-			if res.job.ID != "" {
-				url = fmt.Sprintf("%s/tests/%s", r.Region.AppBaseURL(), res.job.ID)
-			}
 			tr := report.TestResult{
 				Name:       res.name,
 				Duration:   res.duration,
@@ -162,7 +158,7 @@ func (r *CloudRunner) collectResults(results chan result, expected int) bool {
 				Browser:    browser,
 				Platform:   platform,
 				DeviceName: res.job.DeviceName,
-				URL:        url,
+				URL:        res.job.URL,
 				Artifacts:  res.artifacts,
 				Origin:     "sauce",
 				RDC:        res.job.IsRDC,
@@ -222,27 +218,26 @@ func (r *CloudRunner) runJob(opts job.StartOptions) (j job.Job, skipped bool, er
 		Str("tunnel", opts.Tunnel.Name).
 		Msg("Starting suite.")
 
-	id, err := r.JobService.StartJob(context.Background(), opts)
+	j, err = r.JobService.StartJob(context.Background(), opts)
 	if err != nil {
 		return job.Job{Status: job.StateError}, false, err
 	}
 
-	sigChan := r.registerInterruptOnSignal(id, opts.RealDevice, opts.DisplayName)
+	sigChan := r.registerInterruptOnSignal(j.ID, opts.RealDevice, opts.DisplayName)
 	defer unregisterSignalCapture(sigChan)
 
-	r.uploadSauceConfig(id, opts.RealDevice, opts.ConfigFilePath)
-	r.uploadCLIFlags(id, opts.RealDevice, opts.CLIFlags)
+	r.uploadSauceConfig(j.ID, opts.RealDevice, opts.ConfigFilePath)
+	r.uploadCLIFlags(j.ID, opts.RealDevice, opts.CLIFlags)
 
 	// os.Interrupt can arrive before the signal.Notify() is registered. In that case,
 	// if a soft exit is requested during startContainer phase, it gently exits.
 	if r.interrupted {
-		r.stopSuiteExecution(id, opts.RealDevice, opts.DisplayName)
-		j, err = r.JobService.PollJob(context.Background(), id, 15*time.Second, opts.Timeout, opts.RealDevice)
+		r.stopSuiteExecution(j.ID, opts.RealDevice, opts.DisplayName)
+		j, err = r.JobService.PollJob(context.Background(), j.ID, 15*time.Second, opts.Timeout, opts.RealDevice)
 		return j, true, err
 	}
 
-	jobDetailsPage := fmt.Sprintf("%s/tests/%s", r.Region.AppBaseURL(), id)
-	l := log.Info().Str("url", jobDetailsPage).Str("suite", opts.DisplayName).Str("platform", opts.PlatformName)
+	l := log.Info().Str("url", j.URL).Str("suite", opts.DisplayName).Str("platform", opts.PlatformName)
 
 	if opts.RealDevice {
 		l.Str("deviceName", opts.DeviceName).Str("platformVersion", opts.PlatformVersion).Str("deviceId", opts.DeviceID)
@@ -253,13 +248,14 @@ func (r *CloudRunner) runJob(opts job.StartOptions) (j job.Job, skipped bool, er
 
 	l.Msg("Suite started.")
 
-	// Async mode. Mark the job as started without waiting for the result.
+	// Async mode. Return the current status without waiting for the final result.
 	if r.Async {
-		return job.Job{ID: id, IsRDC: opts.RealDevice, Status: job.StateInProgress}, false, nil
+		// FIXME can we use the job from before now?
+		return j, false, nil
 	}
 
 	// High interval poll to not oversaturate the job reader with requests
-	j, err = r.JobService.PollJob(context.Background(), id, 15*time.Second, opts.Timeout, opts.RealDevice)
+	j, err = r.JobService.PollJob(context.Background(), j.ID, 15*time.Second, opts.Timeout, opts.RealDevice)
 	if err != nil {
 		return job.Job{}, r.interrupted, fmt.Errorf("failed to retrieve job status for suite %s: %s", opts.DisplayName, err.Error())
 	}
@@ -271,7 +267,7 @@ func (r *CloudRunner) runJob(opts job.StartOptions) (j job.Job, skipped bool, er
 			Str("timeout", opts.Timeout.String()).
 			Msg("Suite timed out.")
 
-		r.stopSuiteExecution(id, opts.RealDevice, opts.DisplayName)
+		r.stopSuiteExecution(j.ID, opts.RealDevice, opts.DisplayName)
 
 		j.Passed = false
 		j.TimedOut = true

--- a/internal/saucecloud/jobservice.go
+++ b/internal/saucecloud/jobservice.go
@@ -110,7 +110,7 @@ func (s JobService) Artifact(ctx context.Context, jobID, fileName string, realDe
 	return s.Resto.Artifact(ctx, jobID, fileName, realDevice)
 }
 
-func (s JobService) StartJob(ctx context.Context, opts job.StartOptions) (jobID string, err error) {
+func (s JobService) StartJob(ctx context.Context, opts job.StartOptions) (job.Job, error) {
 	if opts.RealDevice {
 		return s.RDC.StartJob(ctx, opts)
 	}

--- a/internal/saucecloud/jobservice_test.go
+++ b/internal/saucecloud/jobservice_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/config"
 	httpServices "github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/job"
+	"github.com/saucelabs/saucectl/internal/region"
 	"gotest.tools/v3/assert"
 )
 
@@ -41,14 +42,18 @@ func TestJobService_DownloadArtifact(t *testing.T) {
 		_ = os.RemoveAll(tempDir)
 	}()
 
-	rc := httpServices.NewRDCService(ts.URL, "dummy-user", "dummy-key", 10*time.Second)
+	rdc := httpServices.NewRDCService(
+		region.None, "dummy-user", "dummy-key", 10*time.Second,
+	)
+	rdc.URL = ts.URL
+
 	artifactCfg := config.ArtifactDownload{
 		Directory: tempDir,
 		Match:     []string{"junit.xml"},
 		When:      config.WhenAlways,
 	}
 	downloader := JobService{
-		RDC:                    rc,
+		RDC:                    rdc,
 		ArtifactDownloadConfig: artifactCfg,
 	}
 	downloader.DownloadArtifacts(

--- a/internal/saucecloud/jobservice_test.go
+++ b/internal/saucecloud/jobservice_test.go
@@ -43,7 +43,10 @@ func TestJobService_DownloadArtifact(t *testing.T) {
 	}()
 
 	rdc := httpServices.NewRDCService(
-		region.None, "dummy-user", "dummy-key", 10*time.Second,
+		region.None,
+		"dummy-user",
+		"dummy-key",
+		10*time.Second,
 	)
 	rdc.URL = ts.URL
 

--- a/internal/saucecloud/retry/saucereportretrier_test.go
+++ b/internal/saucecloud/retry/saucereportretrier_test.go
@@ -44,9 +44,7 @@ type JobServiceStub struct {
 	SauceReport saucereport.SauceReport
 }
 
-func (f *JobServiceStub) StartJob(
-	context.Context, job.StartOptions,
-) (jobID string, err error) {
+func (f *JobServiceStub) StartJob(context.Context, job.StartOptions) (job.Job, error) {
 	panic("implement me")
 }
 


### PR DESCRIPTION
## Description

Give Jobs the same treatment that [Builds received recently](https://github.com/saucelabs/saucectl/pull/962) by moving some of the responsibilities, such as propagating the Job URL, to the clients that create them.