### PR TITLE
chore: Always warn user of npm registry deprecation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -406,7 +406,7 @@ func (t *Tunnel) SetDefaults() {
 }
 
 // SetDefaults updates npm default values
-func (n *Npm) SetDefaults(framework, version string) {
+func (n *Npm) SetDefaults() {
 	if n.Registry != "" {
 		log.Warn().Msg("npm.registry has been deprecated, please use npm.registries instead")
 		n.Registries = append(n.Registries, Registry{URL: n.Registry})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/fatih/color"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog/log"
@@ -406,32 +405,9 @@ func (t *Tunnel) SetDefaults() {
 	}
 }
 
-func hasMultiRegistrySupport(framework, version string) bool {
-	minVersions := map[string]string{
-		"cypress":               "12.14.0",
-		"playwright-cucumberjs": "1.35.1",
-		"playwright":            "1.35.1",
-		"testcafe":              "2.6.2",
-	}
-
-	v, ok := minVersions[framework]
-	if !ok {
-		return true
-	}
-	maxVersion := semver.MustParse(v)
-	curVersion, err := semver.NewVersion(version)
-	if err != nil {
-		// if value is non-version (like "package.json"), we assume this is an older version
-		// as this is, at the moment of the change, the only option possible. This needs to
-		// be returning false in a future framework update.
-		return false
-	}
-	return curVersion.GreaterThan(maxVersion)
-}
-
 // SetDefaults updates npm default values
 func (n *Npm) SetDefaults(framework, version string) {
-	if n.Registry != "" && hasMultiRegistrySupport(framework, version) {
+	if n.Registry != "" {
 		log.Warn().Msg("npm.registry has been deprecated, please use npm.registries instead")
 		n.Registries = append(n.Registries, Registry{URL: n.Registry})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -303,31 +303,6 @@ func TestNpm_SetDefaults(t *testing.T) {
 				{URL: "http://npmjs.org"},
 			},
 		},
-		{
-			name: "Legacy registry + Newer",
-			fields: fields{
-				Registry: "http://npmjs.org",
-				Registries: []Registry{
-					{URL: "http://npmjs-2.org"},
-				},
-				Framework:        "dummy",
-				FrameworkVersion: "",
-			},
-			want: []Registry{
-				{URL: "http://npmjs-2.org"},
-				{URL: "http://npmjs.org"},
-			},
-		},
-		{
-			name: "Do not migrate older versions",
-			fields: fields{
-				Registry:         "http://npmjs.org",
-				Registries:       []Registry{},
-				Framework:        "cypress",
-				FrameworkVersion: "12.14.0",
-			},
-			want: []Registry{},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(*testing.T) {
@@ -335,7 +310,7 @@ func TestNpm_SetDefaults(t *testing.T) {
 				Registry:   tt.fields.Registry,
 				Registries: tt.fields.Registries,
 			}
-			n.SetDefaults(tt.fields.Framework, tt.fields.FrameworkVersion)
+			n.SetDefaults()
 		})
 	}
 }

--- a/internal/cucumber/config.go
+++ b/internal/cucumber/config.go
@@ -134,7 +134,7 @@ func SetDefaults(p *Project) {
 
 	p.Sauce.Tunnel.SetDefaults()
 	p.Sauce.Metadata.SetDefaultBuild()
-	p.Npm.SetDefaults(p.Kind, p.Playwright.Version)
+	p.Npm.SetDefaults()
 
 	for k := range p.Suites {
 		suite := &p.Suites[k]

--- a/internal/cypress/v1/config.go
+++ b/internal/cypress/v1/config.go
@@ -143,7 +143,7 @@ func (p *Project) SetDefaults() {
 
 	p.Sauce.Tunnel.SetDefaults()
 	p.Sauce.Metadata.SetDefaultBuild()
-	p.Npm.SetDefaults(p.Kind, p.Cypress.Version)
+	p.Npm.SetDefaults()
 
 	for k := range p.Suites {
 		s := &p.Suites[k]

--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -145,7 +145,7 @@ func SetDefaults(p *Project) {
 
 	p.Sauce.Tunnel.SetDefaults()
 	p.Sauce.Metadata.SetDefaultBuild()
-	p.Npm.SetDefaults(p.Kind, p.Playwright.Version)
+	p.Npm.SetDefaults()
 
 	for k := range p.Suites {
 		s := &p.Suites[k]

--- a/internal/testcafe/config.go
+++ b/internal/testcafe/config.go
@@ -180,7 +180,7 @@ func SetDefaults(p *Project) {
 
 	p.Sauce.Tunnel.SetDefaults()
 	p.Sauce.Metadata.SetDefaultBuild()
-	p.Npm.SetDefaults(p.Kind, p.Testcafe.Version)
+	p.Npm.SetDefaults()
 
 	for k := range p.Suites {
 		suite := &p.Suites[k]


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Remove `hasMultiRegistrySupport` and always print the warning msg for `npm.registry`.