### PR TITLE
refactor: no err on worker pool creation

### DIFF
--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -90,7 +90,7 @@ type result struct {
 // ConsoleLogAsset represents job asset log file name.
 const ConsoleLogAsset = "console.log"
 
-func (r *CloudRunner) createWorkerPool(ccy int, maxRetries int) (chan job.StartOptions, chan result, error) {
+func (r *CloudRunner) createWorkerPool(ccy int, maxRetries int) (chan job.StartOptions, chan result) {
 	jobOpts := make(chan job.StartOptions, maxRetries+1)
 	results := make(chan result, ccy)
 
@@ -99,7 +99,7 @@ func (r *CloudRunner) createWorkerPool(ccy int, maxRetries int) (chan job.StartO
 		go r.runJobs(jobOpts, results)
 	}
 
-	return jobOpts, results, nil
+	return jobOpts, results
 }
 
 func (r *CloudRunner) collectResults(results chan result, expected int) bool {

--- a/internal/saucecloud/cucumber.go
+++ b/internal/saucecloud/cucumber.go
@@ -137,10 +137,7 @@ func (r *CucumberRunner) runSuites(app string, otherApps []string) bool {
 	sigChan := r.registerSkipSuitesOnSignal()
 	defer unregisterSignalCapture(sigChan)
 
-	jobOpts, results, err := r.createWorkerPool(r.Project.Sauce.Concurrency, r.Project.Sauce.Retries)
-	if err != nil {
-		return false
-	}
+	jobOpts, results := r.createWorkerPool(r.Project.Sauce.Concurrency, r.Project.Sauce.Retries)
 	defer close(results)
 
 	suites := r.Project.Suites

--- a/internal/saucecloud/cypress.go
+++ b/internal/saucecloud/cypress.go
@@ -128,10 +128,7 @@ func (r *CypressRunner) validateFramework(m framework.Metadata) error {
 func (r *CypressRunner) runSuites(app string, otherApps []string) bool {
 	sigChan := r.registerSkipSuitesOnSignal()
 	defer unregisterSignalCapture(sigChan)
-	jobOpts, results, err := r.createWorkerPool(r.Project.GetSauceCfg().Concurrency, r.Project.GetSauceCfg().Retries)
-	if err != nil {
-		return false
-	}
+	jobOpts, results := r.createWorkerPool(r.Project.GetSauceCfg().Concurrency, r.Project.GetSauceCfg().Retries)
 	defer close(results)
 
 	suites := r.Project.GetSuites()

--- a/internal/saucecloud/espresso.go
+++ b/internal/saucecloud/espresso.go
@@ -87,12 +87,9 @@ func (r *EspressoRunner) runSuites() bool {
 	sigChan := r.registerSkipSuitesOnSignal()
 	defer unregisterSignalCapture(sigChan)
 
-	jobOpts, results, err := r.createWorkerPool(
+	jobOpts, results := r.createWorkerPool(
 		r.Project.Sauce.Concurrency, r.Project.Sauce.Retries,
 	)
-	if err != nil {
-		return false
-	}
 	defer close(results)
 
 	suites := r.Project.Suites

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -142,10 +142,7 @@ func (r *PlaywrightRunner) runSuites(app string, otherApps []string) bool {
 	sigChan := r.registerSkipSuitesOnSignal()
 	defer unregisterSignalCapture(sigChan)
 
-	jobOpts, results, err := r.createWorkerPool(r.Project.Sauce.Concurrency, r.Project.Sauce.Retries)
-	if err != nil {
-		return false
-	}
+	jobOpts, results := r.createWorkerPool(r.Project.Sauce.Concurrency, r.Project.Sauce.Retries)
 	defer close(results)
 
 	suites := r.Project.Suites

--- a/internal/saucecloud/replay.go
+++ b/internal/saucecloud/replay.go
@@ -75,10 +75,7 @@ func (r *ReplayRunner) runSuites(fileURI string) bool {
 	sigChan := r.registerSkipSuitesOnSignal()
 	defer unregisterSignalCapture(sigChan)
 
-	jobOpts, results, err := r.createWorkerPool(r.Project.Sauce.Concurrency, r.Project.Sauce.Retries)
-	if err != nil {
-		return false
-	}
+	jobOpts, results := r.createWorkerPool(r.Project.Sauce.Concurrency, r.Project.Sauce.Retries)
 	defer close(results)
 
 	suites := r.Project.Suites

--- a/internal/saucecloud/testcafe.go
+++ b/internal/saucecloud/testcafe.go
@@ -137,10 +137,7 @@ func (r *TestcafeRunner) runSuites(app string, otherApps []string) bool {
 	sigChan := r.registerSkipSuitesOnSignal()
 	defer unregisterSignalCapture(sigChan)
 
-	jobOpts, results, err := r.createWorkerPool(r.Project.Sauce.Concurrency, r.Project.Sauce.Retries)
-	if err != nil {
-		return false
-	}
+	jobOpts, results := r.createWorkerPool(r.Project.Sauce.Concurrency, r.Project.Sauce.Retries)
 	defer close(results)
 
 	suites := r.Project.Suites

--- a/internal/saucecloud/xcuitest.go
+++ b/internal/saucecloud/xcuitest.go
@@ -164,10 +164,7 @@ func (r *XcuitestRunner) runSuites() bool {
 	sigChan := r.registerSkipSuitesOnSignal()
 	defer unregisterSignalCapture(sigChan)
 
-	jobOpts, results, err := r.createWorkerPool(r.Project.Sauce.Concurrency, r.Project.Sauce.Retries)
-	if err != nil {
-		return false
-	}
+	jobOpts, results := r.createWorkerPool(r.Project.Sauce.Concurrency, r.Project.Sauce.Retries)
 	defer close(results)
 
 	suites := r.Project.Suites


### PR DESCRIPTION
## Description

Worker pool creation can't fail. `error` was always `nil`. Remove return param and unnecessary error handling.