### PR TITLE
feat: cancellable storage interactions

### DIFF
--- a/internal/cmd/storage/delete.go
+++ b/internal/cmd/storage/delete.go
@@ -35,8 +35,8 @@ func DeleteCommand() *cobra.Command {
 				_ = tracker.Close()
 			}()
 		},
-		RunE: func(_ *cobra.Command, args []string) error {
-			if err := appsClient.Delete(args[0]); err != nil {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := appsClient.Delete(cmd.Context(), args[0]); err != nil {
 				return fmt.Errorf("failed to delete file: %v", err)
 			}
 

--- a/internal/cmd/storage/list.go
+++ b/internal/cmd/storage/list.go
@@ -82,12 +82,14 @@ func ListCommand() *cobra.Command {
 				_ = tracker.Close()
 			}()
 		},
-		RunE: func(_ *cobra.Command, _ []string) error {
-			list, err := appsClient.List(storage.ListOptions{
-				Q:      query,
-				Name:   name,
-				SHA256: sha256,
-			})
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			list, err := appsClient.List(
+				cmd.Context(),
+				storage.ListOptions{
+					Q:      query,
+					Name:   name,
+					SHA256: sha256,
+				})
 			if err != nil {
 				return fmt.Errorf("failed to retrieve list: %w", err)
 			}

--- a/internal/cmd/storage/list.go
+++ b/internal/cmd/storage/list.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
+	"github.com/saucelabs/saucectl/internal/human"
 	"github.com/saucelabs/saucectl/internal/segment"
 	"github.com/saucelabs/saucectl/internal/storage"
 	"github.com/saucelabs/saucectl/internal/usage"
@@ -143,7 +143,7 @@ func renderTable(list storage.List) {
 			AlignFooter: text.AlignRight,
 			Transformer: func(val interface{}) string {
 				t, _ := val.(int)
-				return humanize.Bytes(uint64(t))
+				return human.Bytes(int64(t))
 			},
 		},
 		{

--- a/internal/cmd/storage/upload.go
+++ b/internal/cmd/storage/upload.go
@@ -45,7 +45,7 @@ func UploadCommand() *cobra.Command {
 				_ = tracker.Close()
 			}()
 		},
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			file, err := os.Open(args[0])
 			if err != nil {
 				return fmt.Errorf("failed to open file: %w", err)
@@ -65,10 +65,12 @@ func UploadCommand() *cobra.Command {
 
 			// Look up the file first.
 			if !force {
-				list, err := appsClient.List(storage.ListOptions{
-					SHA256:     hash,
-					MaxResults: 1,
-				})
+				list, err := appsClient.List(
+					cmd.Context(),
+					storage.ListOptions{
+						SHA256:     hash,
+						MaxResults: 1,
+					})
 				if err != nil {
 					return fmt.Errorf("storage lookup failed: %w", err)
 				}
@@ -83,7 +85,7 @@ func UploadCommand() *cobra.Command {
 				bar := newProgressBar(out, finfo.Size(), "Uploading")
 				reader := progress.NewReadSeeker(file, bar)
 
-				item, err = appsClient.UploadStream(finfo.Name(), description, &reader)
+				item, err = appsClient.UploadStream(cmd.Context(), finfo.Name(), description, &reader)
 				if err != nil {
 					return fmt.Errorf("failed to upload file: %w", err)
 				}

--- a/internal/http/appstore_test.go
+++ b/internal/http/appstore_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -151,7 +152,7 @@ func TestAppStore_UploadStream(t *testing.T) {
 				_ = f.Close()
 			}(f)
 
-			got, err := s.UploadStream(tt.args.filename, "", f)
+			got, err := s.UploadStream(context.Background(), tt.args.filename, "", f)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("UploadStream() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -310,7 +311,7 @@ func TestAppStore_List(t *testing.T) {
 				Username:   tt.fields.Username,
 				AccessKey:  tt.fields.AccessKey,
 			}
-			got, err := s.List(tt.args.opts)
+			got, err := s.List(context.Background(), tt.args.opts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("List() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -414,7 +415,7 @@ func TestAppStore_Delete(t *testing.T) {
 				Username:   tt.fields.Username,
 				AccessKey:  tt.fields.AccessKey,
 			}
-			tt.wantErr(t, s.Delete(tt.args.id), fmt.Sprintf("Delete(%v)", tt.args.id))
+			tt.wantErr(t, s.Delete(context.Background(), tt.args.id), fmt.Sprintf("Delete(%v)", tt.args.id))
 		})
 	}
 }

--- a/internal/ioctx/ioctx.go
+++ b/internal/ioctx/ioctx.go
@@ -1,0 +1,24 @@
+package ioctx
+
+import (
+	"context"
+	"io"
+)
+
+// ContextualReadCloser is a wrapper around an io.ReadCloser that cancels the
+// read operation when the context is canceled.
+type ContextualReadCloser struct {
+	Ctx    context.Context
+	Reader io.ReadCloser
+}
+
+func (crc ContextualReadCloser) Read(p []byte) (n int, err error) {
+	if crc.Ctx.Err() != nil {
+		return 0, crc.Ctx.Err()
+	}
+	return crc.Reader.Read(p)
+}
+
+func (crc ContextualReadCloser) Close() error {
+	return crc.Reader.Close()
+}

--- a/internal/ioctx/ioctx_test.go
+++ b/internal/ioctx/ioctx_test.go
@@ -1,0 +1,66 @@
+package ioctx
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestContextualReadCloser_Read(t *testing.T) {
+	type fields struct {
+		Ctx    context.Context
+		Reader io.ReadCloser
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		wantN     int64
+		wantErr   bool
+		cancelCtx bool
+	}{
+		{
+			name: "read_all",
+			fields: fields{
+				Ctx:    context.Background(),
+				Reader: io.NopCloser(strings.NewReader("hello")),
+			},
+			wantN:     5,
+			wantErr:   false,
+			cancelCtx: false,
+		},
+		{
+			name: "cancel_read",
+			fields: fields{
+				Ctx:    context.Background(),
+				Reader: io.NopCloser(strings.NewReader("hello")),
+			},
+			wantN:     0,
+			wantErr:   true,
+			cancelCtx: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crc := ContextualReadCloser{
+				Ctx:    tt.fields.Ctx,
+				Reader: tt.fields.Reader,
+			}
+
+			if tt.cancelCtx {
+				ctx, cancel := context.WithCancel(crc.Ctx)
+				crc.Ctx = ctx
+				cancel()
+			}
+
+			gotN, err := io.Copy(io.Discard, crc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Read() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotN != tt.wantN {
+				t.Errorf("Read() gotN = %v, want %v", gotN, tt.wantN)
+			}
+		})
+	}
+}

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -613,10 +613,6 @@ func (r *CloudRunner) uploadProject(filename, description string, pType uploadTy
 		if err != nil {
 			return "", fmt.Errorf("unable to download app from %s: %w", filename, err)
 		}
-
-		if err != nil {
-			return "", err
-		}
 		defer os.RemoveAll(dest)
 
 		filename = dest
@@ -640,7 +636,7 @@ func (r *CloudRunner) uploadProject(filename, description string, pType uploadTy
 
 	progress.Show("Uploading %s %s", pType, filename)
 	start := time.Now()
-	resp, err := r.ProjectUploader.UploadStream(filepath.Base(filename), description, file)
+	resp, err := r.ProjectUploader.UploadStream(context.TODO(), filepath.Base(filename), description, file)
 	progress.Stop()
 	if err != nil {
 		return "", err
@@ -660,7 +656,7 @@ func (r *CloudRunner) isFileStored(filename string) (storageID string, err error
 
 	log.Info().Msgf("Checksum: %s", hash)
 
-	l, err := r.ProjectUploader.List(storage.ListOptions{
+	l, err := r.ProjectUploader.List(context.TODO(), storage.ListOptions{
 		SHA256:     hash,
 		MaxResults: 1,
 	})
@@ -989,7 +985,7 @@ func arrayContains(list []string, want string) bool {
 
 // download downloads the resource the URL points to and returns its local path.
 func (r *CloudRunner) download(url string) (string, error) {
-	reader, _, err := r.ProjectUploader.DownloadURL(url)
+	reader, _, err := r.ProjectUploader.DownloadURL(context.TODO(), url)
 	if err != nil {
 		return "", err
 	}

--- a/internal/saucecloud/retry/saucereportretrier.go
+++ b/internal/saucecloud/retry/saucereportretrier.go
@@ -98,7 +98,7 @@ func (r *SauceReportRetrier) uploadConfig(filename string) (string, error) {
 
 	progress.Show("Uploading runner config %s", filename)
 	start := time.Now()
-	resp, err := r.ProjectUploader.UploadStream(filepath.Base(filename), "", file)
+	resp, err := r.ProjectUploader.UploadStream(context.TODO(), filepath.Base(filename), "", file)
 	progress.Stop()
 	if err != nil {
 		return "", err

--- a/internal/saucecloud/retry/saucereportretrier_test.go
+++ b/internal/saucecloud/retry/saucereportretrier_test.go
@@ -17,26 +17,26 @@ import (
 type StubProjectUploader struct {
 }
 
-func (f *StubProjectUploader) UploadStream(_, _ string, _ io.Reader) (storage.Item, error) {
+func (f *StubProjectUploader) UploadStream(context.Context, string, string, io.Reader) (storage.Item, error) {
 	return storage.Item{
 		ID:   "fakeid",
 		Name: "fake name",
 	}, nil
 }
 
-func (f *StubProjectUploader) Download(string) (io.ReadCloser, int64, error) {
+func (f *StubProjectUploader) Download(context.Context, string) (io.ReadCloser, int64, error) {
 	return nil, 0, nil
 }
 
-func (f *StubProjectUploader) DownloadURL(string) (io.ReadCloser, int64, error) {
+func (f *StubProjectUploader) DownloadURL(context.Context, string) (io.ReadCloser, int64, error) {
 	return nil, 0, nil
 }
 
-func (f *StubProjectUploader) List(storage.ListOptions) (storage.List, error) {
+func (f *StubProjectUploader) List(context.Context, storage.ListOptions) (storage.List, error) {
 	return storage.List{}, nil
 }
 
-func (f *StubProjectUploader) Delete(string) error {
+func (f *StubProjectUploader) Delete(context.Context, string) error {
 	return nil
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -58,9 +59,9 @@ func (s *ServerError) Error() string {
 // AppService is the interface for interacting with the Sauce application storage.
 type AppService interface {
 	// UploadStream uploads the contents of reader and stores them under the given filename.
-	UploadStream(filename, description string, reader io.Reader) (Item, error)
-	Download(id string) (io.ReadCloser, int64, error)
-	Delete(id string) error
-	DownloadURL(url string) (io.ReadCloser, int64, error)
-	List(opts ListOptions) (List, error)
+	UploadStream(ctx context.Context, filename, description string, reader io.Reader) (Item, error)
+	Download(ctx context.Context, id string) (io.ReadCloser, int64, error)
+	Delete(ctx context.Context, id string) error
+	DownloadURL(ctx context.Context, url string) (io.ReadCloser, int64, error)
+	List(ctx context.Context, opts ListOptions) (List, error)
 }


### PR DESCRIPTION
## Description

Introduce a global context. As is common in Go, the idea is to propagate this cancellable context wherever it may be needed.
In an effort to keep this PR reviewable, I kept the changes contained to the app storage API. In fact, only the `saucectl storage` subcommands make use of this global context.

However, any other commands will also benefit immediately, as issuing a SIGINT twice will always result in a hard exit at the top level, irrespective of whether the global context is used or not.