### PR TITLE
fix: Log tunnel and region once

### DIFF
--- a/internal/apitest/runner.go
+++ b/internal/apitest/runner.go
@@ -433,7 +433,6 @@ func (r *Runner) runSuites() bool {
 			Str("projectName", suite.ProjectName).
 			Str("suite", suite.Name).
 			Bool("parallel", true).
-			Str("tunnel", r.Project.Sauce.Tunnel.Name).
 			Msg("Starting suite")
 
 		if s.UseRemoteTests {

--- a/internal/cmd/run/apitest.go
+++ b/internal/cmd/run/apitest.go
@@ -3,6 +3,7 @@ package run
 import (
 	"os"
 
+	"github.com/rs/zerolog/log"
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/usage"
@@ -69,6 +70,10 @@ func runApitest(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 		_ = tracker.Close()
 	}()
 
+	log.Info().
+		Str("region", regio.String()).
+		Str("tunnel", r.Project.Sauce.Tunnel.Name).
+		Msg("Running API Test in Sauce Labs.")
 	return r.RunProject()
 }
 

--- a/internal/cmd/run/cucumber.go
+++ b/internal/cmd/run/cucumber.go
@@ -137,7 +137,10 @@ func runCucumber(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 		regio, creds.Username, creds.AccessKey, buildTimeout,
 	)
 
-	log.Info().Msg("Running Playwright-Cucumberjs in Sauce Labs")
+	log.Info().
+		Str("region", regio.String()).
+		Str("tunnel", p.Sauce.Tunnel.Name).
+		Msg("Running Playwright-Cucumberjs in Sauce Labs.")
 	r := saucecloud.CucumberRunner{
 		Project: p,
 		CloudRunner: saucecloud.CloudRunner{

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -170,7 +170,10 @@ func runCypress(cmd *cobra.Command, cflags cypressFlags, isCLIDriven bool) (int,
 		regio, creds.Username, creds.AccessKey, buildTimeout,
 	)
 
-	log.Info().Msg("Running Cypress in Sauce Labs")
+	log.Info().
+		Str("region", regio.String()).
+		Str("tunnel", p.GetSauceCfg().Tunnel.Name).
+		Msg("Running Cypress in Sauce Labs.")
 	r := saucecloud.CypressRunner{
 		Project: p,
 		CloudRunner: saucecloud.CloudRunner{

--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -134,7 +134,10 @@ func runEspresso(cmd *cobra.Command, espressoFlags espressoFlags, isCLIDriven bo
 }
 
 func runEspressoInCloud(p espresso.Project, regio region.Region) (int, error) {
-	log.Info().Msg("Running Espresso in Sauce Labs")
+	log.Info().
+		Str("region", regio.String()).
+		Str("tunnel", p.Sauce.Tunnel.Name).
+		Msg("Running Espresso in Sauce Labs.")
 
 	creds := regio.Credentials()
 	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)

--- a/internal/cmd/run/imagerunner.go
+++ b/internal/cmd/run/imagerunner.go
@@ -3,6 +3,7 @@ package run
 import (
 	"os"
 
+	"github.com/rs/zerolog/log"
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/http"
@@ -79,6 +80,10 @@ func runImageRunner(cmd *cobra.Command) (int, error) {
 	r := saucecloud.NewImgRunner(p, &imageRunnerClient, &restoClient, asyncEventManager,
 		reporters, gFlags.async)
 
+	log.Info().
+		Str("region", regio.String()).
+		Str("tunnel", r.Project.Sauce.Tunnel.Name).
+		Msg("Running in Sauce Labs.")
 	return r.RunProject()
 }
 

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -182,7 +182,10 @@ func runPlaywright(cmd *cobra.Command, pf playwrightFlags, isCLIDriven bool) (in
 		regio, creds.Username, creds.AccessKey, buildTimeout,
 	)
 
-	log.Info().Msg("Running Playwright in Sauce Labs")
+	log.Info().
+		Str("region", regio.String()).
+		Str("tunnel", p.Sauce.Tunnel.Name).
+		Msg("Running Playwright in Sauce Labs.")
 	r := saucecloud.PlaywrightRunner{
 		Project: p,
 		CloudRunner: saucecloud.CloudRunner{

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -120,7 +120,10 @@ func runReplay(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 }
 
 func runPuppeteerReplayInSauce(p replay.Project, regio region.Region) (int, error) {
-	log.Info().Msg("Replaying chrome devtools recordings")
+	log.Info().
+		Str("region", regio.String()).
+		Str("tunnel", p.Sauce.Tunnel.Name).
+		Msg("Replaying chrome devtools recordings.")
 
 	creds := regio.Credentials()
 	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -205,7 +205,10 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 		regio, creds.Username, creds.AccessKey, buildTimeout,
 	)
 
-	log.Info().Msg("Running Testcafe in Sauce Labs")
+	log.Info().
+		Str("region", regio.String()).
+		Str("tunnel", p.Sauce.Tunnel.Name).
+		Msg("Running Testcafe in Sauce Labs.")
 	r := saucecloud.TestcafeRunner{
 		Project: p,
 		CloudRunner: saucecloud.CloudRunner{

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -134,7 +134,10 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, isCLIDriven bool) 
 }
 
 func runXcuitestInCloud(p xcuitest.Project, regio region.Region) (int, error) {
-	log.Info().Msg("Running XCUITest in Sauce Labs")
+	log.Info().
+		Str("region", regio.String()).
+		Str("tunnel", p.Sauce.Tunnel.Name).
+		Msg("Running XCUITest in Sauce Labs.")
 
 	creds := regio.Credentials()
 

--- a/internal/saucecloud/cloud.go
+++ b/internal/saucecloud/cloud.go
@@ -214,8 +214,6 @@ func (r *CloudRunner) findBuild(jobID string, isRDC bool) build.Build {
 func (r *CloudRunner) runJob(opts job.StartOptions) (j job.Job, skipped bool, err error) {
 	log.Info().
 		Str("suite", opts.DisplayName).
-		Str("region", r.Region.String()).
-		Str("tunnel", opts.Tunnel.Name).
 		Msg("Starting suite.")
 
 	j, err = r.JobService.StartJob(context.Background(), opts)

--- a/internal/saucecloud/imagerunner.go
+++ b/internal/saucecloud/imagerunner.go
@@ -235,7 +235,6 @@ func (r *ImgRunner) runSuite(suite imagerunner.Suite) (imagerunner.Runner, error
 	log.Info().
 		Str("image", suite.Image).
 		Str("suite", suite.Name).
-		Str("tunnel", r.Project.Sauce.Tunnel.Name).
 		Msg("Starting suite.")
 
 	if suite.Timeout <= 0 {


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Reduce logging noise by logging tunnel and region when the run starts, not with each suite.

[DEVX-3092]

[DEVX-3092]: https://saucedev.atlassian.net/browse/DEVX-3092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ