### PR TITLE
fix: nil pointer in saucectl configure command

### DIFF
--- a/internal/cmd/configure/cmd.go
+++ b/internal/cmd/configure/cmd.go
@@ -41,7 +41,6 @@ func Command() *cobra.Command {
 			go func() {
 				tracker.Collect(
 					cmds.FullName(cmd),
-					nil,
 				)
 				_ = tracker.Close()
 			}()

--- a/internal/usage/client.go
+++ b/internal/usage/client.go
@@ -73,7 +73,9 @@ func (c *Client) Collect(subject string, opts ...Option) {
 		Set("ci", ci.GetProvider().Name)
 
 	for _, opt := range opts {
-		opt(p)
+		if opt != nil {
+			opt(p)
+		}
 	}
 
 	userID := credentials.Get().Username


### PR DESCRIPTION
## Description

`for _, opt := range opts {` over a nil slice would yield nothing.

However, `saucectl configure` was passing an explicit `nil` argument, causing `opts` to be an initialized slice that does yield a nil value which then caused a nil pointer access in the loop.