### PR TITLE
feat: cancellable apitest

### DIFF
--- a/internal/apitest/runner_test.go
+++ b/internal/apitest/runner_test.go
@@ -435,7 +435,7 @@ func TestRunner_runLocalTests(t *testing.T) {
 	}
 	c := make(chan TestResult)
 
-	res := r.runLocalTests(s, c)
+	res := r.runLocalTests(context.Background(), s, c)
 	assert.Equal(t, 1, res)
 
 	results := <-c
@@ -608,7 +608,7 @@ func TestRunner_ResolveHookIDs(t *testing.T) {
 				TunnelService: tt.fields.TunnelService,
 			}
 
-			err := r.ResolveHookIDs()
+			err := r.ResolveHookIDs(context.Background())
 			if tt.wantErr != "" {
 				assert.EqualError(t, err, tt.wantErr, "ResolveHookIDs(): got %v, want %v", err, tt.wantErr)
 				return

--- a/internal/cmd/run/apitest.go
+++ b/internal/cmd/run/apitest.go
@@ -53,7 +53,7 @@ func runApitest(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 		TunnelService: &restoClient,
 	}
 
-	if err := r.ResolveHookIDs(); err != nil {
+	if err := r.ResolveHookIDs(cmd.Context()); err != nil {
 		return 1, err
 	}
 


### PR DESCRIPTION
## Description

Propagate the global context to all API calls. This ensures that apitest executions can be cancelled via a soft interrupt (hitting ctrl-c once).