### PR TITLE
fix: ensure screenshots are recognized artifacts

### DIFF
--- a/internal/http/resto.go
+++ b/internal/http/resto.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -189,12 +188,24 @@ func (c *Resto) ArtifactNames(ctx context.Context, jobID string, realDevice bool
 
 	var filesList []string
 	for k, v := range filesMap {
-		if k == "video" || k == "screenshots" {
+		if v == nil || k == "video" {
 			continue
 		}
 
-		if v != nil && reflect.TypeOf(v).Name() == "string" {
-			filesList = append(filesList, v.(string))
+		if val, ok := v.(string); ok {
+			filesList = append(filesList, val)
+		}
+
+		if k == "screenshots" {
+			screenshots, ok := v.([]interface{})
+			if !ok {
+				continue
+			}
+			for _, s := range screenshots {
+				if screenshot, ok := s.(string); ok {
+					filesList = append(filesList, screenshot)
+				}
+			}
 		}
 	}
 	return filesList, nil

--- a/internal/http/resto.go
+++ b/internal/http/resto.go
@@ -194,6 +194,7 @@ func (c *Resto) ArtifactNames(ctx context.Context, jobID string, realDevice bool
 
 		if val, ok := v.(string); ok {
 			filesList = append(filesList, val)
+			continue
 		}
 
 		if k == "screenshots" {


### PR DESCRIPTION
## Description

A platform side change (`/assets` endpoint) moved screenshot files to the `screenshots` field. Prior to this change, saucectl was ignoring this field as it expected screenshots to appear on the root level (as do other files).

Before fix:
```
❯ saucectl artifacts list 5648b0fc31c644b78621cf006ad899b3
┌────────────────────────────────────────────────┐
│ Items                                          │
────────────────────────────────────────────────
│ index.html                                     │
│ 583f7f084ebd4ef4b73abc88b09a78e9.last-run.json │
│ log.json                                       │
│ console.log                                    │
│ config.yml                                     │
│ junit.xml                                      │
│ video.mp4                                      │
│ flags.json                                     │
│ sauce-test-report.json                         │
└────────────────────────────────────────────────┘
```

After fix:
```
❯ saucectl artifacts list 5648b0fc31c644b78621cf006ad899b3

┌─────────────────────────────────────────────────────────────────┐
│ Items                                                           │
─────────────────────────────────────────────────────────────────
│ 660938d924107f5889cdb401f0417855fbd326f0.png                    │
│ 6eea30518519a29b942c24b7eec882e2c31a029e.png                    │
│ fc53f633a77f60048da6cffd8cee2b424378cd49.png                    │
│ screen-capture-png-02c5050b38fd8609e580a1db8238ba7cc9c6f8c7.png │
│ screenshot-56cd48708adc9c65ea0a247630c94e6504490b0c.png         │
│ screenshot-96f80502c0a1278713b7ab28522f9d97b0c97a89.png         │
│ screenshot.png                                                  │
│ console.log                                                     │
│ sauce-test-report.json                                          │
│ junit.xml                                                       │
│ log.json                                                        │
│ index.html                                                      │
│ config.yml                                                      │
│ video.mp4                                                       │
│ 583f7f084ebd4ef4b73abc88b09a78e9.last-run.json                  │
│ flags.json                                                      │
└─────────────────────────────────────────────────────────────────┘
```