### PR TITLE
feat: Add xctest support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ 'zip' ]
     files:
       - LICENSE
 checksum:

--- a/api/global.schema.json
+++ b/api/global.schema.json
@@ -14,6 +14,7 @@
         "puppeteer-replay",
         "testcafe",
         "xcuitest",
+        "xctest",
         "playwright-cucumberjs"
       ]
     }
@@ -92,6 +93,18 @@
       },
       "then": {
         "$ref": "v1alpha/framework/xcuitest.schema.json"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "xctest"
+          }
+        }
+      },
+      "then": {
+        "$ref": "v1alpha/framework/xctest.schema.json"
       }
     },
     {

--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -2381,8 +2381,8 @@
           "env": {
             "$ref": "#/allOf/2/then/properties/env"
           },
-          "xcuitest": {
-            "description": "Contains details specific to the XCUITest project.",
+          "xctest": {
+            "description": "Contains details specific to the XCTest project.",
             "type": "object",
             "properties": {
               "app": {

--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -2427,6 +2427,14 @@
                   "description": "Description for the app.",
                   "type": "string"
                 },
+                "xcTestRunFile": {
+                  "description": "Local path or remote url to the .xctestrun file test descriptor. If a remote url is defined, the file will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
+                  "type": "string"
+                },
+                "xcTestRunFileDescription": {
+                  "description": "Description for the xcTestRunFile.",
+                  "type": "string"
+                },
                 "otherApps": {
                   "description": "A list of applications to be installed alongside the main app. Applications can be defined as a local path or a remote url. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values. When targeting simulators, a maximum of 2 otherApps is supported.",
                   "type": "array"

--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -14,6 +14,7 @@
         "puppeteer-replay",
         "testcafe",
         "xcuitest",
+        "xctest",
         "playwright-cucumberjs"
       ]
     }
@@ -845,7 +846,7 @@
             "type": "object",
             "properties": {
               "timeout": {
-                "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
               }
             },
             "additionalProperties": false
@@ -1098,7 +1099,7 @@
                   }
                 },
                 "timeout": {
-                  "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                  "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
                 },
                 "appSettings": {
                   "description": "Overwrite real device settings.",
@@ -1310,7 +1311,7 @@
             "type": "object",
             "properties": {
               "timeout": {
-                "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
               }
             },
             "additionalProperties": false
@@ -1328,7 +1329,7 @@
             "type": "object",
             "properties": {
               "version": {
-                "$ref": "#/allOf/7/then/properties/playwright/properties/version",
+                "$ref": "#/allOf/8/then/properties/playwright/properties/version",
                 "enum": [
                   "package.json",
                   "1.49.0",
@@ -1367,7 +1368,7 @@
                   "type": "string"
                 },
                 "playwrightVersion": {
-                  "$ref": "#/allOf/7/then/properties/playwright/properties/version"
+                  "$ref": "#/allOf/8/then/properties/playwright/properties/version"
                 },
                 "testMatch": {
                   "description": "Paths to the playwright test files. Regex values are supported to indicate all files of a certain type or in a certain directory, etc.",
@@ -1392,7 +1393,7 @@
                   "type": "object",
                   "properties": {
                     "browserName": {
-                      "$ref": "#/allOf/7/then/properties/suites/items/properties/browserName",
+                      "$ref": "#/allOf/8/then/properties/suites/items/properties/browserName",
                       "enum": [
                         "chromium",
                         "firefox",
@@ -1478,7 +1479,7 @@
                   "type": "boolean"
                 },
                 "timeout": {
-                  "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                  "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
                 },
                 "preExec": {
                   "description": "Specifies which commands to execute before starting the tests.",
@@ -1549,7 +1550,7 @@
             "type": "object",
             "properties": {
               "timeout": {
-                "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
               }
             },
             "additionalProperties": false
@@ -1570,7 +1571,7 @@
                   "type": "array"
                 },
                 "browserName": {
-                  "$ref": "#/allOf/7/then/properties/suites/items/properties/browserName",
+                  "$ref": "#/allOf/8/then/properties/suites/items/properties/browserName",
                   "enum": [
                     "chrome"
                   ]
@@ -1590,7 +1591,7 @@
                   "description": "A specific operating system on which to run the tests. Sauce Labs will try to choose a reasonable default if not explicitly specified."
                 },
                 "timeout": {
-                  "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                  "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
                 },
                 "passThreshold": {
                   "$ref": "#/allOf/1/then/properties/suites/items/properties/passThreshold"
@@ -1657,7 +1658,7 @@
             "type": "object",
             "properties": {
               "timeout": {
-                "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
               }
             },
             "additionalProperties": false
@@ -1673,7 +1674,7 @@
             "type": "object",
             "properties": {
               "version": {
-                "$ref": "#/allOf/7/then/properties/playwright/properties/version",
+                "$ref": "#/allOf/8/then/properties/playwright/properties/version",
                 "enum": [
                   "package.json",
                   "3.7.0",
@@ -1711,7 +1712,7 @@
                   "type": "string"
                 },
                 "browserName": {
-                  "$ref": "#/allOf/7/then/properties/suites/items/properties/browserName",
+                  "$ref": "#/allOf/8/then/properties/suites/items/properties/browserName",
                   "enum": [
                     "chrome",
                     "firefox",
@@ -1956,7 +1957,7 @@
                   "type": "boolean"
                 },
                 "timeout": {
-                  "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                  "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
                 },
                 "preExec": {
                   "$ref": "#/allOf/2/then/properties/suites/items/properties/preExec"
@@ -2035,7 +2036,7 @@
             "type": "object",
             "properties": {
               "timeout": {
-                "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
               }
             },
             "additionalProperties": false
@@ -2285,7 +2286,344 @@
                   }
                 },
                 "timeout": {
-                  "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                  "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
+                },
+                "passThreshold": {
+                  "$ref": "#/allOf/1/then/properties/suites/items/properties/passThreshold"
+                },
+                "smartRetry": {
+                  "$ref": "#/allOf/1/then/properties/suites/items/properties/smartRetry"
+                },
+                "shard": {
+                  "description": "When sharding is configured, saucectl automatically splits the tests (e.g. by testList or concurrency) so that they can easily run in parallel.",
+                  "enum": [
+                    "",
+                    "concurrency",
+                    "testList"
+                  ]
+                },
+                "testListFile": {
+                  "description": "This file containing tests will be used in sharding by concurrency.",
+                  "type": "string"
+                }
+              },
+              "anyOf": [
+                {
+                  "required": [
+                    "simulators"
+                  ]
+                },
+                {
+                  "required": [
+                    "devices"
+                  ]
+                }
+              ],
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "apiVersion",
+          "kind",
+          "suites"
+        ],
+        "additionalProperties": true
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "xctest"
+          }
+        }
+      },
+      "then": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "saucectl xctest runner configuration",
+        "description": "Configuration file for xctest using saucectl",
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/allOf/1/then/allOf/0"
+          },
+          {
+            "$ref": "#/allOf/1/then/allOf/1"
+          },
+          {
+            "$ref": "#/allOf/1/then/allOf/2"
+          }
+        ],
+        "properties": {
+          "apiVersion": {
+            "const": "v1alpha"
+          },
+          "kind": {
+            "const": "xctest"
+          },
+          "showConsoleLog": {
+            "$ref": "#/allOf/1/then/properties/showConsoleLog"
+          },
+          "defaults": {
+            "description": "Settings that are applied onto every suite by default, if no value is set on a suite explicitly.",
+            "type": "object",
+            "properties": {
+              "timeout": {
+                "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
+              }
+            },
+            "additionalProperties": false
+          },
+          "env": {
+            "$ref": "#/allOf/2/then/properties/env"
+          },
+          "xcuitest": {
+            "description": "Contains details specific to the XCUITest project.",
+            "type": "object",
+            "properties": {
+              "app": {
+                "description": "Local path or remote url to the application. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
+                "type": "string"
+              },
+              "appDescription": {
+                "description": "Description for the app.",
+                "type": "string"
+              },
+              "xcTestRunFile": {
+                "description": "Local path or remote url to the .xctestrun file test descriptor. If a remote url is defined, the file will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
+                "type": "string"
+              },
+              "xcTestRunFileDescription": {
+                "description": "Description for the xcTestRunFile.",
+                "type": "string"
+              },
+              "otherApps": {
+                "description": "A list of applications to be installed alongside the main app. Applications can be defined as a local path or a remote url. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values. When targeting simulators, a maximum of 2 otherApps is supported.",
+                "type": "array"
+              }
+            },
+            "additionalProperties": false
+          },
+          "suites": {
+            "description": "The set of properties providing details about the test suites to run.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "The name of the test suite, which will be reflected in the test results in Sauce Labs.",
+                  "type": "string"
+                },
+                "app": {
+                  "description": "Local path or remote url to the application. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
+                  "type": "string"
+                },
+                "appDescription": {
+                  "description": "Description for the app.",
+                  "type": "string"
+                },
+                "testApp": {
+                  "description": "Local path or remote url to the test application. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
+                  "type": "string"
+                },
+                "testAppDescription": {
+                  "description": "Description for the testApp.",
+                  "type": "string"
+                },
+                "otherApps": {
+                  "description": "A list of applications to be installed alongside the main app. Applications can be defined as a local path or a remote url. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values. When targeting simulators, a maximum of 2 otherApps is supported.",
+                  "type": "array"
+                },
+                "env": {
+                  "$ref": "#/allOf/2/then/properties/env"
+                },
+                "testOptions": {
+                  "description": "Allows you to control various details on how tests are executed.",
+                  "type": "object",
+                  "properties": {
+                    "class": {
+                      "description": "Only run the specified classes.",
+                      "type": "array"
+                    },
+                    "notClass": {
+                      "description": "Run all classes except those specified here.",
+                      "type": "array"
+                    },
+                    "testLanguage": {
+                      "description": "Specifies ISO 639-1 language during testing. Supported on Simulators only.",
+                      "type": "string"
+                    },
+                    "testRegion": {
+                      "description": "Specifies ISO 3166-1 region during testing.",
+                      "type": "string"
+                    },
+                    "testTimeoutsEnabled": {
+                      "description": "By default there is no timeout, if enabled, then the timeout is 600 seconds. This can be changed by adding the defaultTestExecutionTimeAllowance value. Supported on Simulators only.",
+                      "type": "string",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    },
+                    "maximumTestExecutionTimeAllowance": {
+                      "description": "The maximum execution time, in seconds, an individual test is given to execute, regardless of the test's preferred allowance. Supported on Simulators only.",
+                      "type": "number"
+                    },
+                    "defaultTestExecutionTimeAllowance": {
+                      "description": "The default execution time, in seconds, an individual test is given to execute if test timeouts are enabled. Supported on Simulators only.",
+                      "type": "number"
+                    },
+                    "statusBarOverrideTime": {
+                      "description": "Modify the time displayed on the status bar. Supported on Simulators only.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "appSettings": {
+                  "description": "Overwrite real device settings.",
+                  "type": "object",
+                  "properties": {
+                    "resigningEnabled": {
+                      "description": "Overwrite app settings for real device to enable app resigning.",
+                      "type": "boolean"
+                    },
+                    "audioCapture": {
+                      "description": "Overwrite app settings for real device to capture audio.",
+                      "type": "boolean"
+                    },
+                    "instrumentation": {
+                      "description": "Overwrite app settings for real device instrumentation.",
+                      "type": "object",
+                      "properties": {
+                        "imageInjection": {
+                          "description": "Overwrite app settings for real device to inject provided images in the user app.",
+                          "type": "boolean"
+                        },
+                        "sysAlertsDelay": {
+                          "description": "Overwrite app settings for real device to delay system alerts.",
+                          "type": "boolean"
+                        },
+                        "vitals": {
+                          "description": "Overwrite app settings for real device to enable vitals.",
+                          "type": "boolean"
+                        },
+                        "networkCapture": {
+                          "description": "Overwrite app settings for real device to capture network.",
+                          "type": "boolean"
+                        },
+                        "biometrics": {
+                          "description": "Overwrite app settings for real device to intercept biometric authentication.",
+                          "type": "boolean"
+                        },
+                        "groupDirectory": {
+                          "description": "Overwrite app settings for real device to enable group directory access.",
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                },
+                "simulators": {
+                  "description": "Defines details for running this suite on virtual devices using a simulator.",
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "description": "The name of the simulator. To ensure name accuracy, check the list of supported virtual devices (https://app.saucelabs.com/live/web-testing/virtual).",
+                        "type": "string"
+                      },
+                      "orientation": {
+                        "$ref": "#/allOf/1/then/properties/suites/items/properties/emulators/items/properties/orientation"
+                      },
+                      "platformVersions": {
+                        "description": "The set of one or more versions of the device platform on which to run the test suite.",
+                        "type": "array",
+                        "minItems": 1
+                      },
+                      "armRequired": {
+                        "description": "If set to true, the simulator will run on an ARM-based Mac. If set to false, the simulator will run on an Intel-based Mac.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "platformVersions"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "devices": {
+                  "description": "Define details for running this suite on real devices.",
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "id": {
+                        "description": "Request a specific device for this test suite by its ID. You can look up device IDs in the Sauce Labs app or using our Devices API (https://docs.saucelabs.com/dev/api/rdc#get-devices).",
+                        "type": "string",
+                        "examples": [
+                          "iPhone_12_Pro_14_real",
+                          "iPhone_12_Pro_real_us"
+                        ]
+                      },
+                      "name": {
+                        "description": "Match the device name in full or partially (regex), which may provide a larger pool of available devices of the type you want.",
+                        "type": "string",
+                        "examples": [
+                          "iPad .*",
+                          "iPhone .*"
+                        ]
+                      },
+                      "platformVersion": {
+                        "description": "The version of the iOS operating system.",
+                        "type": "string"
+                      },
+                      "options": {
+                        "description": "Further specify desired device attributes within the pool of devices that match the name and version criteria.",
+                        "type": "object",
+                        "properties": {
+                          "carrierConnectivity": {
+                            "description": "Limit the device selection to those that are connected to a cellular network.",
+                            "type": "boolean"
+                          },
+                          "deviceType": {
+                            "description": "Limit the device selection to a specific type of device.",
+                            "enum": [
+                              "ANY",
+                              "PHONE",
+                              "TABLET"
+                            ]
+                          },
+                          "private": {
+                            "description": "Limit the device selection to only match from your organization's private pool.",
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "oneOf": [
+                      {
+                        "required": [
+                          "id"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "timeout": {
+                  "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
                 },
                 "passThreshold": {
                   "$ref": "#/allOf/1/then/properties/suites/items/properties/passThreshold"
@@ -2451,7 +2789,7 @@
             "type": "object",
             "properties": {
               "timeout": {
-                "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
               }
             },
             "additionalProperties": false
@@ -2574,7 +2912,7 @@
                   "type": "boolean"
                 },
                 "timeout": {
-                  "$ref": "#/allOf/8/then/definitions/suite/properties/timeout"
+                  "$ref": "#/allOf/9/then/definitions/suite/properties/timeout"
                 },
                 "preExec": {
                   "$ref": "#/allOf/2/then/properties/suites/items/properties/preExec"
@@ -2741,7 +3079,7 @@
                 "description": "List of services to run with the suite.",
                 "type": "array",
                 "items": {
-                  "$ref": "#/allOf/8/then/definitions/service"
+                  "$ref": "#/allOf/9/then/definitions/service"
                 }
               }
             },
@@ -2890,22 +3228,22 @@
             "const": "imagerunner"
           },
           "sauce": {
-            "$ref": "#/allOf/8/then/definitions/sauce"
+            "$ref": "#/allOf/9/then/definitions/sauce"
           },
           "defaults": {
             "description": "Settings that are applied onto every suite as a default value.",
-            "$ref": "#/allOf/8/then/definitions/suite"
+            "$ref": "#/allOf/9/then/definitions/suite"
           },
           "suites": {
             "description": "List of suites",
             "type": "array",
             "minItems": 1,
             "items": {
-              "$ref": "#/allOf/8/then/definitions/suite"
+              "$ref": "#/allOf/9/then/definitions/suite"
             }
           },
           "reporters": {
-            "$ref": "#/allOf/8/then/definitions/reporters"
+            "$ref": "#/allOf/9/then/definitions/reporters"
           }
         },
         "required": [

--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -2427,14 +2427,6 @@
                   "description": "Description for the app.",
                   "type": "string"
                 },
-                "testApp": {
-                  "description": "Local path or remote url to the test application. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
-                  "type": "string"
-                },
-                "testAppDescription": {
-                  "description": "Description for the testApp.",
-                  "type": "string"
-                },
                 "otherApps": {
                   "description": "A list of applications to be installed alongside the main app. Applications can be defined as a local path or a remote url. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values. When targeting simulators, a maximum of 2 otherApps is supported.",
                   "type": "array"

--- a/api/v1alpha/framework/xctest.schema.json
+++ b/api/v1alpha/framework/xctest.schema.json
@@ -83,14 +83,6 @@
             "description": "Description for the app.",
             "type": "string"
           },
-          "testApp": {
-            "description": "Local path or remote url to the test application. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
-            "type": "string"
-          },
-          "testAppDescription": {
-            "description": "Description for the testApp.",
-            "type": "string"
-          },
           "otherApps": {
             "description": "A list of applications to be installed alongside the main app. Applications can be defined as a local path or a remote url. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values. When targeting simulators, a maximum of 2 otherApps is supported.",
             "type": "array"

--- a/api/v1alpha/framework/xctest.schema.json
+++ b/api/v1alpha/framework/xctest.schema.json
@@ -1,0 +1,325 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "saucectl xctest runner configuration",
+  "description": "Configuration file for xctest using saucectl",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "../subschema/sauce.schema.json"
+    },
+    {
+      "$ref": "../subschema/artifacts.schema.json"
+    },
+    {
+      "$ref": "../subschema/reporters.schema.json"
+    }
+  ],
+  "properties": {
+    "apiVersion": {
+      "const": "v1alpha"
+    },
+    "kind": {
+      "const": "xctest"
+    },
+    "showConsoleLog": {
+      "$ref": "../subschema/common.schema.json#/definitions/showConsoleLog"
+    },
+    "defaults": {
+      "description": "Settings that are applied onto every suite by default, if no value is set on a suite explicitly.",
+      "type": "object",
+      "properties": {
+        "timeout": {
+          "$ref": "../subschema/common.schema.json#/definitions/timeout"
+        }
+      },
+      "additionalProperties": false
+    },
+    "env": {
+      "$ref": "../subschema/common.schema.json#/definitions/env"
+    },
+    "xcuitest": {
+      "description": "Contains details specific to the XCUITest project.",
+      "type": "object",
+      "properties": {
+        "app": {
+          "description": "Local path or remote url to the application. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
+          "type": "string"
+        },
+        "appDescription": {
+          "description": "Description for the app.",
+          "type": "string"
+        },
+        "xcTestRunFile": {
+          "description": "Local path or remote url to the .xctestrun file test descriptor. If a remote url is defined, the file will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
+          "type": "string"
+        },
+        "xcTestRunFileDescription": {
+          "description": "Description for the xcTestRunFile.",
+          "type": "string"
+        },
+        "otherApps": {
+          "description": "A list of applications to be installed alongside the main app. Applications can be defined as a local path or a remote url. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values. When targeting simulators, a maximum of 2 otherApps is supported.",
+          "type": "array"
+        }
+      },
+      "additionalProperties": false
+    },
+    "suites": {
+      "description": "The set of properties providing details about the test suites to run.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the test suite, which will be reflected in the test results in Sauce Labs.",
+            "type": "string"
+          },
+          "app": {
+            "description": "Local path or remote url to the application. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
+            "type": "string"
+          },
+          "appDescription": {
+            "description": "Description for the app.",
+            "type": "string"
+          },
+          "testApp": {
+            "description": "Local path or remote url to the test application. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
+            "type": "string"
+          },
+          "testAppDescription": {
+            "description": "Description for the testApp.",
+            "type": "string"
+          },
+          "otherApps": {
+            "description": "A list of applications to be installed alongside the main app. Applications can be defined as a local path or a remote url. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values. When targeting simulators, a maximum of 2 otherApps is supported.",
+            "type": "array"
+          },
+          "env": {
+            "$ref": "../subschema/common.schema.json#/definitions/env"
+          },
+          "testOptions": {
+            "description": "Allows you to control various details on how tests are executed.",
+            "type": "object",
+            "properties": {
+              "class": {
+                "description": "Only run the specified classes.",
+                "type": "array"
+              },
+              "notClass": {
+                "description": "Run all classes except those specified here.",
+                "type": "array"
+              },
+              "testLanguage": {
+                "description": "Specifies ISO 639-1 language during testing. Supported on Simulators only.",
+                "type": "string"
+              },
+              "testRegion": {
+                "description": "Specifies ISO 3166-1 region during testing.",
+                "type": "string"
+              },
+              "testTimeoutsEnabled": {
+                "description": "By default there is no timeout, if enabled, then the timeout is 600 seconds. This can be changed by adding the defaultTestExecutionTimeAllowance value. Supported on Simulators only.",
+                "type": "string",
+                "enum": ["Yes", "No"]
+              },
+              "maximumTestExecutionTimeAllowance": {
+                "description": "The maximum execution time, in seconds, an individual test is given to execute, regardless of the test's preferred allowance. Supported on Simulators only.",
+                "type": "number"
+              },
+              "defaultTestExecutionTimeAllowance": {
+                "description": "The default execution time, in seconds, an individual test is given to execute if test timeouts are enabled. Supported on Simulators only.",
+                "type": "number"
+              },
+              "statusBarOverrideTime": {
+                "description": "Modify the time displayed on the status bar. Supported on Simulators only.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "appSettings": {
+            "description": "Overwrite real device settings.",
+            "type": "object",
+            "properties": {
+              "resigningEnabled": {
+                "description": "Overwrite app settings for real device to enable app resigning.",
+                "type": "boolean"
+              },
+              "audioCapture": {
+                "description": "Overwrite app settings for real device to capture audio.",
+                "type": "boolean"
+              },
+              "instrumentation": {
+                "description": "Overwrite app settings for real device instrumentation.",
+                "type": "object",
+                "properties": {
+                  "imageInjection": {
+                    "description": "Overwrite app settings for real device to inject provided images in the user app.",
+                    "type": "boolean"
+                  },
+                  "sysAlertsDelay": {
+                    "description": "Overwrite app settings for real device to delay system alerts.",
+                    "type": "boolean"
+                  },
+                  "vitals": {
+                    "description": "Overwrite app settings for real device to enable vitals.",
+                    "type": "boolean"
+                  },
+                  "networkCapture": {
+                    "description": "Overwrite app settings for real device to capture network.",
+                    "type": "boolean"
+                  },
+                  "biometrics": {
+                    "description": "Overwrite app settings for real device to intercept biometric authentication.",
+                    "type": "boolean"
+                  },
+                  "groupDirectory": {
+                    "description": "Overwrite app settings for real device to enable group directory access.",
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          },
+          "simulators": {
+            "description": "Defines details for running this suite on virtual devices using a simulator.",
+            "type": "array",
+            "items": {
+              "properties": {
+                "name": {
+                  "description": "The name of the simulator. To ensure name accuracy, check the list of supported virtual devices (https://app.saucelabs.com/live/web-testing/virtual).",
+                  "type": "string"
+                },
+                "orientation": {
+                  "$ref": "../subschema/common.schema.json#/definitions/orientation"
+                },
+                "platformVersions": {
+                  "description": "The set of one or more versions of the device platform on which to run the test suite.",
+                  "type": "array",
+                  "minItems": 1
+                },
+                "armRequired": {
+                  "description": "If set to true, the simulator will run on an ARM-based Mac. If set to false, the simulator will run on an Intel-based Mac.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "platformVersions"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "devices": {
+            "description": "Define details for running this suite on real devices.",
+            "type": "array",
+            "items": {
+              "properties": {
+                "id": {
+                  "description": "Request a specific device for this test suite by its ID. You can look up device IDs in the Sauce Labs app or using our Devices API (https://docs.saucelabs.com/dev/api/rdc#get-devices).",
+                  "type": "string",
+                  "examples": [
+                    "iPhone_12_Pro_14_real",
+                    "iPhone_12_Pro_real_us"
+                  ]
+                },
+                "name": {
+                  "description": "Match the device name in full or partially (regex), which may provide a larger pool of available devices of the type you want.",
+                  "type": "string",
+                  "examples": [
+                    "iPad .*",
+                    "iPhone .*"
+                  ]
+                },
+                "platformVersion": {
+                  "description": "The version of the iOS operating system.",
+                  "type": "string"
+                },
+                "options": {
+                  "description": "Further specify desired device attributes within the pool of devices that match the name and version criteria.",
+                  "type": "object",
+                  "properties": {
+                    "carrierConnectivity": {
+                      "description": "Limit the device selection to those that are connected to a cellular network.",
+                      "type": "boolean"
+                    },
+                    "deviceType": {
+                      "description": "Limit the device selection to a specific type of device.",
+                      "enum": [
+                        "ANY",
+                        "PHONE",
+                        "TABLET"
+                      ]
+                    },
+                    "private": {
+                      "description": "Limit the device selection to only match from your organization's private pool.",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "oneOf": [
+                {
+                  "required": [
+                    "id"
+                  ]
+                },
+                {
+                  "required": [
+                    "name"
+                  ]
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "timeout": {
+            "$ref": "../subschema/common.schema.json#/definitions/timeout"
+          },
+          "passThreshold": {
+            "$ref": "../subschema/common.schema.json#/definitions/passThreshold"
+          },
+          "smartRetry": {
+            "$ref": "../subschema/common.schema.json#/definitions/smartRetry"
+          },
+          "shard": {
+            "description": "When sharding is configured, saucectl automatically splits the tests (e.g. by testList or concurrency) so that they can easily run in parallel.",
+            "enum": [
+              "",
+              "concurrency",
+              "testList"
+            ]
+          },
+          "testListFile": {
+            "description": "This file containing tests will be used in sharding by concurrency.",
+            "type": "string"
+          }
+        },
+        "anyOf": [
+          {
+            "required": [
+              "simulators"
+            ]
+          },
+          {
+            "required": [
+              "devices"
+            ]
+          }
+        ],
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "apiVersion",
+    "kind",
+    "suites"
+  ],
+  "additionalProperties": true
+}

--- a/api/v1alpha/framework/xctest.schema.json
+++ b/api/v1alpha/framework/xctest.schema.json
@@ -83,6 +83,14 @@
             "description": "Description for the app.",
             "type": "string"
           },
+          "xcTestRunFile": {
+            "description": "Local path or remote url to the .xctestrun file test descriptor. If a remote url is defined, the file will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values.",
+            "type": "string"
+          },
+          "xcTestRunFileDescription": {
+            "description": "Description for the xcTestRunFile.",
+            "type": "string"
+          },
           "otherApps": {
             "description": "A list of applications to be installed alongside the main app. Applications can be defined as a local path or a remote url. If a remote url is defined, the app will be downloaded to a local temp directory before uploading to the SauceLabs Mobile App Storage service. Supports environment variables as values. When targeting simulators, a maximum of 2 otherApps is supported.",
             "type": "array"

--- a/api/v1alpha/framework/xctest.schema.json
+++ b/api/v1alpha/framework/xctest.schema.json
@@ -37,8 +37,8 @@
     "env": {
       "$ref": "../subschema/common.schema.json#/definitions/env"
     },
-    "xcuitest": {
-      "description": "Contains details specific to the XCUITest project.",
+    "xctest": {
+      "description": "Contains details specific to the XCTest project.",
       "type": "object",
       "properties": {
         "app": {

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -159,6 +159,7 @@ func Command() *cobra.Command {
 		NewReplayCmd(),
 		NewTestcafeCmd(),
 		NewXCUITestCmd(),
+		NewXCTestCmd(),
 		NewCucumberCmd(),
 	)
 

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/report/json"
 	"github.com/saucelabs/saucectl/internal/report/junit"
 	"github.com/saucelabs/saucectl/internal/report/spotlight"
+	"github.com/saucelabs/saucectl/internal/xctest"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -208,6 +209,9 @@ func Run(cmd *cobra.Command) (int, error) {
 	}
 	if typeDef.Kind == espresso.Kind {
 		return runEspresso(cmd, espressoFlags{}, false)
+	}
+	if typeDef.Kind == xctest.Kind {
+		return runXctest(cmd, xcuitestFlags{}, false)
 	}
 	if typeDef.Kind == xcuitest.Kind {
 		return runXcuitest(cmd, xcuitestFlags{}, false)

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -213,7 +213,7 @@ func Run(cmd *cobra.Command) (int, error) {
 		return runEspresso(cmd, espressoFlags{}, false)
 	}
 	if typeDef.Kind == xctest.Kind {
-		return runXctest(cmd, xcuitestFlags{}, false)
+		return runXctest(cmd, xctestFlags{}, false)
 	}
 	if typeDef.Kind == xcuitest.Kind {
 		return runXcuitest(cmd, xcuitestFlags{}, false)

--- a/internal/cmd/run/xctest.go
+++ b/internal/cmd/run/xctest.go
@@ -1,0 +1,215 @@
+package run
+
+import (
+	"context"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/ci"
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
+	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/flags"
+	"github.com/saucelabs/saucectl/internal/framework"
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/saucecloud"
+	"github.com/saucelabs/saucectl/internal/saucecloud/retry"
+	"github.com/saucelabs/saucectl/internal/usage"
+	"github.com/saucelabs/saucectl/internal/xctest"
+	"github.com/saucelabs/saucectl/internal/xcuitest"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type xctestFlags struct {
+	Device flags.Device
+}
+
+// NewXCTestCmd creates the 'run' command for XCTest.
+func NewXCTestCmd() *cobra.Command {
+	sc := flags.SnakeCharmer{Fmap: map[string]*pflag.Flag{}}
+	lflags := xctestFlags{}
+
+	cmd := &cobra.Command{
+		Use:              "xctest",
+		Short:            "Run xctest tests.",
+		Long:             "Unlike 'saucectl run', this command allows you to bypass the config file partially or entirely by configuring an adhoc suite (--name) via flags.",
+		Example:          `saucectl run xctest -c "" --name "My Suite" --app app.ipa --xcTestRunFile xcTestRunFile.xctestrun --otherApps=a.ipa,b.ipa --device name="iPhone.*",platformVersion=14.0,carrierConnectivity=false,deviceType=PHONE,private=false`,
+		SilenceUsage:     true,
+		Hidden:           true, // TODO reveal command once ready
+		TraverseChildren: true,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			sc.BindAll()
+			return preRun()
+		},
+		Run: func(cmd *cobra.Command, _ []string) {
+			exitCode, err := runXctest(cmd, lflags, true)
+			if err != nil {
+				log.Err(err).Msg("failed to execute run command")
+			}
+			os.Exit(exitCode)
+		},
+	}
+
+	sc.Fset = cmd.Flags()
+	sc.String("name", "suite::name", "", "Creates a new adhoc suite with this name. Suites defined in the config will be ignored.")
+	sc.String("app", "xctest::app", "", "Specifies the app under test")
+	sc.String("appDescription", "xctest::appDescription", "", "Specifies description for the app")
+	sc.String("xcTestRunFile", "xctest::xcTestRunFile", "", "Specifies the xctestrun test config")
+	sc.StringSlice("otherApps", "xctest::otherApps", []string{}, "Specifies any additional apps that are installed alongside the main app")
+	sc.Int("passThreshold", "suite::passThreshold", 1, "The minimum number of successful attempts for a suite to be considered as 'passed'.")
+
+	sc.String("shard", "suite::shard", "", "When shard is configured as concurrency, saucectl automatically splits the tests by concurrency so that they can easily run in parallel. Requires --name to be set.")
+	sc.String("testListFile", "suite::testListFile", "", "This file containing tests will be used in sharding by concurrency. Requires --name to be set.")
+
+	// Test Options
+	sc.StringSlice("testOptions.class", "suite::testOptions::class", []string{}, "Only run the specified classes. Requires --name to be set.")
+	sc.StringSlice("testOptions.notClass", "suite::testOptions::notClass", []string{}, "Run all classes except those specified here. Requires --name to be set.")
+
+	// Devices
+	cmd.Flags().Var(&lflags.Device, "device", "Specifies the device to use for testing. Requires --name to be set.")
+
+	// Overwrite devices settings
+	sc.Bool("resigningEnabled", "suite::appSettings::resigningEnabled", false, "Overwrite app settings for real device to enable app resigning.")
+	sc.Bool("audioCapture", "suite::appSettings::audioCapture", false, "Overwrite app settings for real device to capture audio.")
+	sc.Bool("imageInjection", "suite::appSettings::instrumentation::imageInjection", false, "Overwrite app settings for real device to inject provided images in the user app.")
+	sc.Bool("sysAlertsDelay", "suite::appSettings::instrumentation::sysAlertsDelay", false, "Overwrite app settings for real device to delay system alerts.")
+	sc.Bool("vitals", "suite::appSettings::instrumentation::vitals", false, "Overwrite app settings for real device to enable vitals.")
+	sc.Bool("networkCapture", "suite::appSettings::instrumentation::networkCapture", false, "Overwrite app settings for real device to capture network.")
+	sc.Bool("biometrics", "suite::appSettings::instrumentation::biometrics", false, "Overwrite app settings for real device to intercept biometric authentication.")
+	sc.Bool("groupDirectory", "suite::appSettings::instrumentation::groupDirectory", false, "Overwrite app settings for real device to enable group directory access.")
+
+	return cmd
+}
+
+func runXctest(cmd *cobra.Command, xcuiFlags xctestFlags, isCLIDriven bool) (int, error) {
+	if !isCLIDriven {
+		config.ValidateSchema(gFlags.cfgFilePath)
+	}
+
+	p, err := xctest.FromFile(gFlags.cfgFilePath)
+	if err != nil {
+		return 1, err
+	}
+	p.CLIFlags = flags.CaptureCommandLineFlags(cmd.Flags())
+
+	if err := applyXCTestFlags(&p, xcuiFlags); err != nil {
+		return 1, err
+	}
+	xctest.SetDefaults(&p)
+
+	if err := xctest.Validate(p); err != nil {
+		return 1, err
+	}
+	if err := xctest.ShardSuites(&p); err != nil {
+		return 1, err
+	}
+
+	regio := region.FromString(p.Sauce.Region)
+
+	if !gFlags.noAutoTagging {
+		p.Sauce.Metadata.Tags = append(p.Sauce.Metadata.Tags, ci.GetTags()...)
+	}
+
+	tracker := usage.DefaultClient
+	if regio == region.Staging {
+		tracker.Enabled = false
+	}
+
+	go func() {
+		tracker.Collect(
+			cmds.FullName(cmd),
+			usage.Framework("xctest", ""),
+			usage.Flags(cmd.Flags()),
+			usage.SauceConfig(p.Sauce),
+			usage.Artifacts(p.Artifacts),
+			usage.NumSuites(len(p.Suites)),
+			usage.Sharding(xctest.GetShardTypes(p.Suites), nil),
+			usage.SmartRetry(p.IsSmartRetried()),
+			usage.Reporters(p.Reporters),
+		)
+		_ = tracker.Close()
+	}()
+
+	cleanupArtifacts(p.Artifacts)
+
+	return runXctestInCloud(cmd.Context(), p, regio)
+}
+
+func runXctestInCloud(ctx context.Context, p xctest.Project, regio region.Region) (int, error) {
+	log.Info().
+		Str("region", regio.String()).
+		Str("tunnel", p.Sauce.Tunnel.Name).
+		Msg("Running XCTest in Sauce Labs.")
+
+	creds := regio.Credentials()
+
+	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)
+	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)
+	webdriverClient := http.NewWebdriver(regio, creds, webdriverTimeout)
+	appsClient := *http.NewAppStore(regio.APIBaseURL(), creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
+	rdcClient := http.NewRDCService(regio, creds.Username, creds.AccessKey, rdcTimeout)
+	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
+	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
+	jobService := saucecloud.JobService{
+		RDC:                    rdcClient,
+		Resto:                  restoClient,
+		Webdriver:              webdriverClient,
+		TestComposer:           testcompClient,
+		ArtifactDownloadConfig: p.Artifacts.Download,
+	}
+	buildService := http.NewBuildService(
+		regio, creds.Username, creds.AccessKey, buildTimeout,
+	)
+
+	r := saucecloud.XctestRunner{
+		Project: p,
+		CloudRunner: saucecloud.CloudRunner{
+			ProjectUploader: &appsClient,
+			JobService:      jobService,
+			TunnelService:   &restoClient,
+			MetadataService: &testcompClient,
+			InsightsService: &insightsClient,
+			UserService:     &iamClient,
+			BuildService:    &buildService,
+			Region:          regio,
+			ShowConsoleLog:  p.ShowConsoleLog,
+			Reporters:       createReporters(p.Reporters, gFlags.async),
+			Framework:       framework.Framework{Name: xcuitest.Kind},
+			Async:           gFlags.async,
+			FailFast:        gFlags.failFast,
+			Retrier: &retry.JunitRetrier{
+				JobService: jobService,
+			},
+		},
+	}
+	return r.RunProject(ctx)
+}
+
+func applyXCTestFlags(p *xctest.Project, flags xctestFlags) error {
+	if gFlags.selectedSuite != "" {
+		if err := xctest.FilterSuites(p, gFlags.selectedSuite); err != nil {
+			return err
+		}
+	}
+
+	if p.Suite.Name == "" {
+		isErr := len(p.Suite.TestOptions.Class) != 0 ||
+			len(p.Suite.TestOptions.NotClass) != 0 ||
+			flags.Device.Changed
+
+		if isErr {
+			return ErrEmptySuiteName
+		}
+
+		return nil
+	}
+
+	if flags.Device.Changed {
+		p.Suite.Devices = append(p.Suite.Devices, flags.Device.Device)
+	}
+
+	p.Suites = []xctest.Suite{p.Suite}
+
+	return nil
+}

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -16,7 +16,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/saucecloud"
 	"github.com/saucelabs/saucectl/internal/saucecloud/retry"
 	"github.com/saucelabs/saucectl/internal/usage"
-	"github.com/saucelabs/saucectl/internal/xctest"
 	"github.com/saucelabs/saucectl/internal/xcuitest"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -25,62 +24,6 @@ import (
 type xcuitestFlags struct {
 	Device    flags.Device
 	Simulator flags.Simulator
-}
-
-func NewXCTestCmd() *cobra.Command {
-	sc := flags.SnakeCharmer{Fmap: map[string]*pflag.Flag{}}
-	lflags := xcuitestFlags{}
-
-	cmd := &cobra.Command{
-		Use:              "xctest",
-		Short:            "Run xctest tests.",
-		Long:             "Unlike 'saucectl run', this command allows you to bypass the config file partially or entirely by configuring an adhoc suite (--name) via flags.",
-		Example:          `saucectl run xctest -c "" --name "My Suite" --app app.ipa --xcTestRunFile xcTestRunFile.xctestrun --otherApps=a.ipa,b.ipa --device name="iPhone.*",platformVersion=14.0,carrierConnectivity=false,deviceType=PHONE,private=false`,
-		SilenceUsage:     true,
-		Hidden:           true, // TODO reveal command once ready
-		TraverseChildren: true,
-		PreRunE: func(_ *cobra.Command, _ []string) error {
-			sc.BindAll()
-			return preRun()
-		},
-		Run: func(cmd *cobra.Command, _ []string) {
-			exitCode, err := runXctest(cmd, lflags, true)
-			if err != nil {
-				log.Err(err).Msg("failed to execute run command")
-			}
-			os.Exit(exitCode)
-		},
-	}
-
-	sc.Fset = cmd.Flags()
-	sc.String("name", "suite::name", "", "Creates a new adhoc suite with this name. Suites defined in the config will be ignored.")
-	sc.String("app", "xctest::app", "", "Specifies the app under test")
-	sc.String("appDescription", "xctest::appDescription", "", "Specifies description for the app")
-	sc.String("xcTestRunFile", "xctest::xcTestRunFile", "", "Specifies the xctestrun test config")
-	sc.StringSlice("otherApps", "xctest::otherApps", []string{}, "Specifies any additional apps that are installed alongside the main app")
-	sc.Int("passThreshold", "suite::passThreshold", 1, "The minimum number of successful attempts for a suite to be considered as 'passed'.")
-
-	sc.String("shard", "suite::shard", "", "When shard is configured as concurrency, saucectl automatically splits the tests by concurrency so that they can easily run in parallel. Requires --name to be set.")
-	sc.String("testListFile", "suite::testListFile", "", "This file containing tests will be used in sharding by concurrency. Requires --name to be set.")
-
-	// Test Options
-	sc.StringSlice("testOptions.class", "suite::testOptions::class", []string{}, "Only run the specified classes. Requires --name to be set.")
-	sc.StringSlice("testOptions.notClass", "suite::testOptions::notClass", []string{}, "Run all classes except those specified here. Requires --name to be set.")
-
-	// Devices
-	cmd.Flags().Var(&lflags.Device, "device", "Specifies the device to use for testing. Requires --name to be set.")
-
-	// Overwrite devices settings
-	sc.Bool("resigningEnabled", "suite::appSettings::resigningEnabled", false, "Overwrite app settings for real device to enable app resigning.")
-	sc.Bool("audioCapture", "suite::appSettings::audioCapture", false, "Overwrite app settings for real device to capture audio.")
-	sc.Bool("imageInjection", "suite::appSettings::instrumentation::imageInjection", false, "Overwrite app settings for real device to inject provided images in the user app.")
-	sc.Bool("sysAlertsDelay", "suite::appSettings::instrumentation::sysAlertsDelay", false, "Overwrite app settings for real device to delay system alerts.")
-	sc.Bool("vitals", "suite::appSettings::instrumentation::vitals", false, "Overwrite app settings for real device to enable vitals.")
-	sc.Bool("networkCapture", "suite::appSettings::instrumentation::networkCapture", false, "Overwrite app settings for real device to capture network.")
-	sc.Bool("biometrics", "suite::appSettings::instrumentation::biometrics", false, "Overwrite app settings for real device to intercept biometric authentication.")
-	sc.Bool("groupDirectory", "suite::appSettings::instrumentation::groupDirectory", false, "Overwrite app settings for real device to enable group directory access.")
-
-	return cmd
 }
 
 // NewXCUITestCmd creates the 'run' command for XCUITest.
@@ -142,60 +85,6 @@ func NewXCUITestCmd() *cobra.Command {
 	return cmd
 }
 
-func runXctest(cmd *cobra.Command, xcuiFlags xcuitestFlags, isCLIDriven bool) (int, error) {
-	if !isCLIDriven {
-		config.ValidateSchema(gFlags.cfgFilePath)
-	}
-
-	p, err := xctest.FromFile(gFlags.cfgFilePath)
-	if err != nil {
-		return 1, err
-	}
-	p.CLIFlags = flags.CaptureCommandLineFlags(cmd.Flags())
-
-	if err := applyXCTestFlags(&p, xcuiFlags); err != nil {
-		return 1, err
-	}
-	xctest.SetDefaults(&p)
-
-	if err := xctest.Validate(p); err != nil {
-		return 1, err
-	}
-	if err := xctest.ShardSuites(&p); err != nil {
-		return 1, err
-	}
-
-	regio := region.FromString(p.Sauce.Region)
-
-	if !gFlags.noAutoTagging {
-		p.Sauce.Metadata.Tags = append(p.Sauce.Metadata.Tags, ci.GetTags()...)
-	}
-
-	tracker := usage.DefaultClient
-	if regio == region.Staging {
-		tracker.Enabled = false
-	}
-
-	go func() {
-		tracker.Collect(
-			cmds.FullName(cmd),
-			usage.Framework("xctest", ""),
-			usage.Flags(cmd.Flags()),
-			usage.SauceConfig(p.Sauce),
-			usage.Artifacts(p.Artifacts),
-			usage.NumSuites(len(p.Suites)),
-			usage.Sharding(xctest.GetShardTypes(p.Suites), nil),
-			usage.SmartRetry(p.IsSmartRetried()),
-			usage.Reporters(p.Reporters),
-		)
-		_ = tracker.Close()
-	}()
-
-	cleanupArtifacts(p.Artifacts)
-
-	return runXctestInCloud(cmd.Context(), p, regio)
-}
-
 func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, isCLIDriven bool) (int, error) {
 	if !isCLIDriven {
 		config.ValidateSchema(gFlags.cfgFilePath)
@@ -249,56 +138,6 @@ func runXcuitest(cmd *cobra.Command, xcuiFlags xcuitestFlags, isCLIDriven bool) 
 	cleanupArtifacts(p.Artifacts)
 
 	return runXcuitestInCloud(cmd.Context(), p, regio)
-}
-
-func runXctestInCloud(ctx context.Context, p xctest.Project, regio region.Region) (int, error) {
-	log.Info().
-		Str("region", regio.String()).
-		Str("tunnel", p.Sauce.Tunnel.Name).
-		Msg("Running XCTest in Sauce Labs.")
-
-	creds := regio.Credentials()
-
-	restoClient := http.NewResto(regio, creds.Username, creds.AccessKey, 0)
-	testcompClient := http.NewTestComposer(regio.APIBaseURL(), creds, testComposerTimeout)
-	webdriverClient := http.NewWebdriver(regio, creds, webdriverTimeout)
-	appsClient := *http.NewAppStore(regio.APIBaseURL(), creds.Username, creds.AccessKey, gFlags.appStoreTimeout)
-	rdcClient := http.NewRDCService(regio, creds.Username, creds.AccessKey, rdcTimeout)
-	insightsClient := http.NewInsightsService(regio.APIBaseURL(), creds, insightsTimeout)
-	iamClient := http.NewUserService(regio.APIBaseURL(), creds, iamTimeout)
-	jobService := saucecloud.JobService{
-		RDC:                    rdcClient,
-		Resto:                  restoClient,
-		Webdriver:              webdriverClient,
-		TestComposer:           testcompClient,
-		ArtifactDownloadConfig: p.Artifacts.Download,
-	}
-	buildService := http.NewBuildService(
-		regio, creds.Username, creds.AccessKey, buildTimeout,
-	)
-
-	r := saucecloud.XctestRunner{
-		Project: p,
-		CloudRunner: saucecloud.CloudRunner{
-			ProjectUploader: &appsClient,
-			JobService:      jobService,
-			TunnelService:   &restoClient,
-			MetadataService: &testcompClient,
-			InsightsService: &insightsClient,
-			UserService:     &iamClient,
-			BuildService:    &buildService,
-			Region:          regio,
-			ShowConsoleLog:  p.ShowConsoleLog,
-			Reporters:       createReporters(p.Reporters, gFlags.async),
-			Framework:       framework.Framework{Name: xcuitest.Kind},
-			Async:           gFlags.async,
-			FailFast:        gFlags.failFast,
-			Retrier: &retry.JunitRetrier{
-				JobService: jobService,
-			},
-		},
-	}
-	return r.RunProject(ctx)
 }
 
 func runXcuitestInCloud(ctx context.Context, p xcuitest.Project, regio region.Region) (int, error) {
@@ -380,39 +219,6 @@ func applyXCUITestFlags(p *xcuitest.Project, flags xcuitestFlags) error {
 	}
 
 	p.Suites = []xcuitest.Suite{p.Suite}
-
-	return nil
-}
-
-func applyXCTestFlags(p *xctest.Project, flags xcuitestFlags) error {
-	if gFlags.selectedSuite != "" {
-		if err := xctest.FilterSuites(p, gFlags.selectedSuite); err != nil {
-			return err
-		}
-	}
-
-	if p.Suite.Name == "" {
-		isErr := len(p.Suite.TestOptions.Class) != 0 ||
-			len(p.Suite.TestOptions.NotClass) != 0 ||
-			flags.Device.Changed ||
-			flags.Simulator.Changed
-
-		if isErr {
-			return ErrEmptySuiteName
-		}
-
-		return nil
-	}
-
-	if flags.Device.Changed {
-		p.Suite.Devices = append(p.Suite.Devices, flags.Device.Device)
-	}
-
-	if flags.Simulator.Changed {
-		p.Suite.Simulators = append(p.Suite.Simulators, flags.Simulator.Simulator)
-	}
-
-	p.Suites = []xctest.Suite{p.Suite}
 
 	return nil
 }

--- a/internal/http/rdcservice.go
+++ b/internal/http/rdcservice.go
@@ -58,6 +58,7 @@ type RDCSessionRequest struct {
 	TestFramework       string            `json:"test_framework,omitempty"`
 	AppID               string            `json:"app_id,omitempty"`
 	TestAppID           string            `json:"test_app_id,omitempty"`
+	XCTestRunFileID     string            `json:"xc_test_run_file,omitempty"`
 	OtherApps           []string          `json:"other_apps,omitempty"`
 	DeviceQuery         DeviceQuery       `json:"device_query,omitempty"`
 	TestOptions         map[string]string `json:"test_options,omitempty"`
@@ -105,6 +106,8 @@ func (c *RDCService) StartJob(ctx context.Context, opts job.StartOptions) (job.J
 		frameworkName = "ANDROID_INSTRUMENTATION"
 	case "xcuitest":
 		frameworkName = "XCUITEST"
+	case "xctest":
+		frameworkName = "XCTEST"
 	}
 
 	useTestOrchestrator := false
@@ -115,7 +118,8 @@ func (c *RDCService) StartJob(ctx context.Context, opts job.StartOptions) (job.J
 	jobReq := RDCSessionRequest{
 		TestName:            opts.Name,
 		AppID:               opts.App,
-		TestAppID:           opts.Suite,
+		TestAppID:           opts.TestApp,
+		XCTestRunFileID:     opts.XCTestRunFile,
 		OtherApps:           opts.OtherApps,
 		TestOptions:         c.formatEspressoArgs(opts.TestOptions),
 		TestsToRun:          opts.TestsToRun,

--- a/internal/job/options.go
+++ b/internal/job/options.go
@@ -85,6 +85,7 @@ type StartOptions struct {
 	TestsToRun        []string    `json:"testsToRun,omitempty"`
 	TestsToSkip       []string    `json:"testsToSkip,omitempty"`
 	RealDeviceKind    string      `json:"realDeviceKind,omitempty"`
+	XCTestRunFile     string      `json:"xcTestRunFile,omitempty"`
 
 	// VMD specific settings.
 

--- a/internal/msg/errormsg.go
+++ b/internal/msg/errormsg.go
@@ -182,6 +182,8 @@ const (
 	MissingXcuitestAppPath = "missing path to app .ipa"
 	// MissingXcuitestTestAppPath indicates empty testApp path for xcuitest
 	MissingXcuitestTestAppPath = "missing path to test app .ipa"
+	// MissingXCTestFileAppPath indicates empty path for xctest descriptor file
+	MissingXCTestFileAppPath = "missing path to xctest descriptor file .xctestrun"
 	// MissingXcuitestDeviceConfig indicates empty device setting for xcuitest
 	MissingXcuitestDeviceConfig = "missing devices configuration for suite: %s"
 )

--- a/internal/saucecloud/archive.go
+++ b/internal/saucecloud/archive.go
@@ -1,0 +1,93 @@
+package saucecloud
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/archive/zip"
+	"github.com/saucelabs/saucectl/internal/sauceignore"
+)
+
+// cache represents a store that can be used to cache return values of functions.
+type cache struct {
+	store map[string]string
+}
+
+func newCache() cache {
+	return cache{
+		store: make(map[string]string),
+	}
+}
+
+// lookup attempts to find the value for a key in the cache and returns if there's a hit, otherwise it executes the closure fn and returns its results.
+func (c cache) lookup(key string, fn func() (string, error)) (string, error) {
+	var err error
+	val, ok := c.store[key]
+	if !ok {
+		val, err = fn()
+		if err == nil {
+			c.store[key] = val
+		}
+	}
+	return val, err
+}
+
+func archive(src string, targetDir string, archiveType archiveType) (string, error) {
+	switch archiveType {
+	case ipaArchive:
+		return archiveAppToIpa(src, targetDir)
+	case zipArchive:
+		return archiveAppToZip(src, targetDir)
+	case xctestArchive:
+		return src, nil
+	}
+	return "", fmt.Errorf("unknown archive type: %s", archiveType)
+}
+
+func archiveAppToZip(appPath string, targetDir string) (string, error) {
+	if strings.HasSuffix(appPath, ".zip") {
+		return appPath, nil
+	}
+
+	log.Info().Msgf("Archiving %s to .zip", path.Base(appPath))
+
+	fileName := fmt.Sprintf("%s.zip", strings.TrimSuffix(path.Base(appPath), ".app"))
+	zipName := filepath.Join(targetDir, fileName)
+	arch, err := zip.NewFileWriter(zipName, sauceignore.NewMatcher([]sauceignore.Pattern{}))
+	if err != nil {
+		return "", err
+	}
+	defer arch.Close()
+
+	_, _, err = arch.Add(appPath, "")
+	if err != nil {
+		return "", err
+	}
+	return zipName, nil
+}
+
+// archiveAppToIpa generates a valid IPA file from a .app folder.
+func archiveAppToIpa(appPath string, targetDir string) (string, error) {
+	if strings.HasSuffix(appPath, ".ipa") {
+		return appPath, nil
+	}
+
+	log.Info().Msgf("Archiving %s to .ipa", path.Base(appPath))
+
+	fileName := fmt.Sprintf("%s.ipa", strings.TrimSuffix(path.Base(appPath), ".app"))
+	zipName := filepath.Join(targetDir, fileName)
+	arch, err := zip.NewFileWriter(zipName, sauceignore.NewMatcher([]sauceignore.Pattern{}))
+	if err != nil {
+		return "", err
+	}
+	defer arch.Close()
+
+	_, _, err = arch.Add(appPath, "Payload/")
+	if err != nil {
+		return "", err
+	}
+	return zipName, nil
+}

--- a/internal/saucecloud/archive_test.go
+++ b/internal/saucecloud/archive_test.go
@@ -1,0 +1,71 @@
+package saucecloud
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path"
+	"reflect"
+	"testing"
+
+	"gotest.tools/v3/fs"
+)
+
+func TestEnsureAppsAreIpa(t *testing.T) {
+	dir := fs.NewDir(t, "my-app",
+		fs.WithDir("my-app.app",
+			fs.WithFile("check-me.txt", "check-me",
+				fs.WithMode(0644))),
+		fs.WithDir("my-test-app.app",
+			fs.WithFile("test-check-me.txt", "test-check-me",
+				fs.WithMode(0644))))
+	defer dir.Remove()
+
+	tempDir := fs.NewDir(t, "tmp")
+	defer tempDir.Remove()
+
+	originalAppPath := path.Join(dir.Path(), "my-app.app")
+	originalTestAppPath := path.Join(dir.Path(), "my-test-app.app")
+
+	appPath, err := archive(originalAppPath, tempDir.Path(), ipaArchive)
+	if err != nil {
+		t.Errorf("got error: %v", err)
+	}
+	defer os.Remove(appPath)
+
+	testAppPath, err := archive(originalTestAppPath, tempDir.Path(), ipaArchive)
+	if err != nil {
+		t.Errorf("got error: %v", err)
+	}
+	defer os.Remove(testAppPath)
+
+	if path.Ext(appPath) != ".ipa" {
+		t.Errorf("%v: should be an .ipa file", appPath)
+	}
+	if path.Ext(testAppPath) != ".ipa" {
+		t.Errorf("%v: should be an .ipa file", testAppPath)
+	}
+	checkFileFound(t, appPath, "Payload/my-app.app/check-me.txt", "check-me")
+	checkFileFound(t, testAppPath, "Payload/my-test-app.app/test-check-me.txt", "test-check-me")
+}
+
+func checkFileFound(t *testing.T, archiveName, fileName, fileContent string) {
+	rd, _ := zip.OpenReader(archiveName)
+	defer rd.Close()
+
+	found := false
+	for _, file := range rd.File {
+		if file.Name == fileName {
+			found = true
+			frd, _ := file.Open()
+			body, _ := io.ReadAll(frd)
+			frd.Close()
+			if !reflect.DeepEqual(body, []byte(fileContent)) {
+				t.Errorf("want: %v, got: %v", fileContent, body)
+			}
+		}
+	}
+	if found == false {
+		t.Errorf("%s was not found in archive", fileName)
+	}
+}

--- a/internal/saucecloud/xctest.go
+++ b/internal/saucecloud/xctest.go
@@ -209,7 +209,7 @@ func (r *XctestRunner) startJob(jobOpts chan<- job.StartOptions, appFileID, xcTe
 		ARMRequired: d.armRequired,
 
 		// Overwrite device settings
-		RealDeviceKind: strings.ToLower(xcuitest.IOS),
+		RealDeviceKind: strings.ToLower(xctest.IOS),
 		AppSettings: job.AppSettings{
 			AudioCapture: s.AppSettings.AudioCapture,
 			Instrumentation: job.Instrumentation{

--- a/internal/saucecloud/xctest.go
+++ b/internal/saucecloud/xctest.go
@@ -12,24 +12,22 @@ import (
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/storage"
+	"github.com/saucelabs/saucectl/internal/xctest"
 	"github.com/saucelabs/saucectl/internal/xcuitest"
 )
 
 // XcuitestRunner represents the Sauce Labs cloud implementation for xcuitest.
-type XcuitestRunner struct {
+type XctestRunner struct {
 	CloudRunner
-	Project xcuitest.Project
+	Project xctest.Project
 }
 
-type archiveType string
-
 var (
-	ipaArchive archiveType = "ipa"
-	zipArchive archiveType = "zip"
+	xctestArchive archiveType = "xctestrun"
 )
 
 // RunProject runs the tests defined in xcuitest.Project.
-func (r *XcuitestRunner) RunProject(ctx context.Context) (int, error) {
+func (r *XctestRunner) RunProject(ctx context.Context) (int, error) {
 	exitCode := 1
 
 	if err := r.validateTunnel(
@@ -86,15 +84,15 @@ func (r *XcuitestRunner) RunProject(ctx context.Context) (int, error) {
 		}
 		r.Project.Suites[i].App = storageURL
 
-		archivePath, err = cachedArchive(s.TestApp, tempDir, archiveType)
+		archivePath, err = cachedArchive(s.XCTestRunFile, tempDir, xctestArchive)
 		if err != nil {
 			return exitCode, err
 		}
-		storageURL, err = cachedUpload(archivePath, s.TestAppDescription, testAppUpload, r.Project.DryRun)
+		storageURL, err = cachedUpload(archivePath, s.XCTestRunFileDescription, testAppUpload, r.Project.DryRun)
 		if err != nil {
 			return exitCode, err
 		}
-		r.Project.Suites[i].TestApp = storageURL
+		r.Project.Suites[i].XCTestRunFile = storageURL
 
 		var otherApps []string
 		for _, o := range s.OtherApps {
@@ -124,7 +122,7 @@ func (r *XcuitestRunner) RunProject(ctx context.Context) (int, error) {
 	return exitCode, nil
 }
 
-func (r *XcuitestRunner) dryRun() {
+func (r *XctestRunner) dryRun() {
 	fmt.Println("\nThe following test suites would have run:")
 	for _, s := range r.Project.Suites {
 		fmt.Printf("  - %s\n", s.Name)
@@ -135,7 +133,7 @@ func (r *XcuitestRunner) dryRun() {
 	fmt.Println()
 }
 
-func (r *XcuitestRunner) runSuites(ctx context.Context) bool {
+func (r *XctestRunner) runSuites(ctx context.Context) bool {
 	jobOpts, results := r.createWorkerPool(ctx, r.Project.Sauce.Concurrency, r.Project.Sauce.Retries)
 	defer close(results)
 
@@ -145,7 +143,7 @@ func (r *XcuitestRunner) runSuites(ctx context.Context) bool {
 		if err != nil {
 			log.Warn().Err(err).Msg(msg.RetrieveJobHistoryError)
 		} else {
-			suites = xcuitest.SortByHistory(suites, history)
+			suites = xctest.SortByHistory(suites, history)
 		}
 	}
 
@@ -158,7 +156,7 @@ func (r *XcuitestRunner) runSuites(ctx context.Context) bool {
 					Str("deviceName", d.name).Str("deviceID", d.ID).
 					Str("platformVersion", d.platformVersion).
 					Msg("Starting job")
-				r.startJob(jobOpts, s.App, s.TestApp, s.OtherApps, s, d)
+				r.startJob(jobOpts, s.App, s.XCTestRunFile, s.OtherApps, s, d)
 			}
 		}
 	}()
@@ -166,17 +164,17 @@ func (r *XcuitestRunner) runSuites(ctx context.Context) bool {
 	return r.collectResults(ctx, results, jobsCount)
 }
 
-func (r *XcuitestRunner) startJob(jobOpts chan<- job.StartOptions, appFileID, testAppFileID string, otherAppsIDs []string, s xcuitest.Suite, d deviceConfig) {
+func (r *XctestRunner) startJob(jobOpts chan<- job.StartOptions, appFileID, xcTestRunFileID string, otherAppsIDs []string, s xctest.Suite, d deviceConfig) {
 	jobOpts <- job.StartOptions{
 		ConfigFilePath:   r.Project.ConfigFilePath,
 		CLIFlags:         r.Project.CLIFlags,
 		DisplayName:      s.Name,
 		Timeout:          s.Timeout,
 		App:              appFileID,
-		TestApp:          testAppFileID,
-		Suite:            testAppFileID,
+		XCTestRunFile:    xcTestRunFileID,
+		Suite:            xcTestRunFileID,
 		OtherApps:        otherAppsIDs,
-		Framework:        "xcuitest",
+		Framework:        "xctest",
 		FrameworkVersion: "1.0.0-stable",
 		PlatformName:     d.platformName,
 		PlatformVersion:  d.platformVersion,
@@ -213,21 +211,15 @@ func (r *XcuitestRunner) startJob(jobOpts chan<- job.StartOptions, appFileID, te
 		// Overwrite device settings
 		RealDeviceKind: strings.ToLower(xcuitest.IOS),
 		AppSettings: job.AppSettings{
-			ResigningEnabled: s.AppSettings.ResigningEnabled,
-			AudioCapture:     s.AppSettings.AudioCapture,
-			Resigning: job.Resigning{
-				ImageInjection:         s.AppSettings.Instrumentation.ImageInjection,
-				GroupDirectory:         s.AppSettings.Instrumentation.GroupDirectory,
-				SystemAlertsDelay:      s.AppSettings.Instrumentation.SysAlertsDelay,
-				BiometricsInterception: s.AppSettings.Instrumentation.Biometrics,
-				Vitals:                 s.AppSettings.Instrumentation.Vitals,
-				NetworkCapture:         s.AppSettings.Instrumentation.NetworkCapture,
+			AudioCapture: s.AppSettings.AudioCapture,
+			Instrumentation: job.Instrumentation{
+				NetworkCapture: s.AppSettings.Instrumentation.NetworkCapture,
 			},
 		},
 	}
 }
 
-func (r *XcuitestRunner) calculateJobsCount(suites []xcuitest.Suite) int {
+func (r *XctestRunner) calculateJobsCount(suites []xctest.Suite) int {
 	jobsCount := 0
 	for _, s := range suites {
 		jobsCount += len(enumerateDevices(s.Devices, s.Simulators))

--- a/internal/saucecloud/xctest.go
+++ b/internal/saucecloud/xctest.go
@@ -13,7 +13,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/msg"
 	"github.com/saucelabs/saucectl/internal/storage"
 	"github.com/saucelabs/saucectl/internal/xctest"
-	"github.com/saucelabs/saucectl/internal/xcuitest"
 )
 
 // XcuitestRunner represents the Sauce Labs cloud implementation for xcuitest.

--- a/internal/saucecloud/xcuitest_test.go
+++ b/internal/saucecloud/xcuitest_test.go
@@ -1,14 +1,7 @@
 package saucecloud
 
 import (
-	"archive/zip"
-	"io"
-	"os"
-	"path"
-	"reflect"
 	"testing"
-
-	"gotest.tools/v3/fs"
 
 	"github.com/stretchr/testify/assert"
 
@@ -43,63 +36,4 @@ func TestCalculateJobsCount(t *testing.T) {
 		},
 	}
 	assert.Equal(t, runner.calculateJobsCount(runner.Project.Suites), 2)
-}
-
-func TestXcuitestRunner_ensureAppsAreIpa(t *testing.T) {
-	dir := fs.NewDir(t, "my-app",
-		fs.WithDir("my-app.app",
-			fs.WithFile("check-me.txt", "check-me",
-				fs.WithMode(0644))),
-		fs.WithDir("my-test-app.app",
-			fs.WithFile("test-check-me.txt", "test-check-me",
-				fs.WithMode(0644))))
-	defer dir.Remove()
-
-	tempDir := fs.NewDir(t, "tmp")
-	defer tempDir.Remove()
-
-	originalAppPath := path.Join(dir.Path(), "my-app.app")
-	originalTestAppPath := path.Join(dir.Path(), "my-test-app.app")
-
-	appPath, err := archive(originalAppPath, tempDir.Path(), ipaArchive)
-	if err != nil {
-		t.Errorf("got error: %v", err)
-	}
-	defer os.Remove(appPath)
-
-	testAppPath, err := archive(originalTestAppPath, tempDir.Path(), ipaArchive)
-	if err != nil {
-		t.Errorf("got error: %v", err)
-	}
-	defer os.Remove(testAppPath)
-
-	if path.Ext(appPath) != ".ipa" {
-		t.Errorf("%v: should be an .ipa file", appPath)
-	}
-	if path.Ext(testAppPath) != ".ipa" {
-		t.Errorf("%v: should be an .ipa file", testAppPath)
-	}
-	checkFileFound(t, appPath, "Payload/my-app.app/check-me.txt", "check-me")
-	checkFileFound(t, testAppPath, "Payload/my-test-app.app/test-check-me.txt", "test-check-me")
-}
-
-func checkFileFound(t *testing.T, archiveName, fileName, fileContent string) {
-	rd, _ := zip.OpenReader(archiveName)
-	defer rd.Close()
-
-	found := false
-	for _, file := range rd.File {
-		if file.Name == fileName {
-			found = true
-			frd, _ := file.Open()
-			body, _ := io.ReadAll(frd)
-			frd.Close()
-			if !reflect.DeepEqual(body, []byte(fileContent)) {
-				t.Errorf("want: %v, got: %v", fileContent, body)
-			}
-		}
-	}
-	if found == false {
-		t.Errorf("%s was not found in archive", fileName)
-	}
 }

--- a/internal/xctest/config.go
+++ b/internal/xctest/config.go
@@ -1,0 +1,417 @@
+package xctest
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/apps"
+	"github.com/saucelabs/saucectl/internal/concurrency"
+	"github.com/saucelabs/saucectl/internal/config"
+	"github.com/saucelabs/saucectl/internal/insights"
+	"github.com/saucelabs/saucectl/internal/msg"
+	"github.com/saucelabs/saucectl/internal/region"
+)
+
+// Config descriptors.
+var (
+	// Kind represents the type definition of this config.
+	Kind = "xctest"
+
+	// APIVersion represents the supported config version.
+	APIVersion = "v1alpha"
+)
+
+// Project represents the xcuitest project configuration.
+type Project struct {
+	config.TypeDef `yaml:",inline" mapstructure:",squash"`
+	Defaults       config.Defaults        `yaml:"defaults,omitempty" json:"defaults"`
+	ConfigFilePath string                 `yaml:"-" json:"-"`
+	ShowConsoleLog bool                   `yaml:"showConsoleLog" json:"-"`
+	DryRun         bool                   `yaml:"-" json:"-"`
+	CLIFlags       map[string]interface{} `yaml:"-" json:"-"`
+	Sauce          config.SauceConfig     `yaml:"sauce,omitempty" json:"sauce"`
+	Xctest         Xctest                 `yaml:"xctest,omitempty" json:"xctest"`
+	// Suite is only used as a workaround to parse adhoc suites that are created via CLI args.
+	Suite     Suite             `yaml:"suite,omitempty" json:"-"`
+	Suites    []Suite           `yaml:"suites,omitempty" json:"suites"`
+	Artifacts config.Artifacts  `yaml:"artifacts,omitempty" json:"artifacts"`
+	Reporters config.Reporters  `yaml:"reporters,omitempty" json:"-"`
+	Env       map[string]string `yaml:"env,omitempty" json:"-"`
+	EnvFlag   map[string]string `yaml:"-" json:"-"`
+}
+
+// Xcuitest represents xcuitest apps configuration.
+type Xctest struct {
+	App                      string   `yaml:"app,omitempty" json:"app"`
+	AppDescription           string   `yaml:"appDescription,omitempty" json:"appDescription"`
+	XCTestRunFile            string   `yaml:"xcTestRunFile,omitempty" json:"xcTestRunFile"`
+	XCTestRunFileDescription string   `yaml:"xcTestRunFileDescription,omitempty" json:"xcTestRunFileDescription"`
+	OtherApps                []string `yaml:"otherApps,omitempty" json:"otherApps"`
+}
+
+// TestOptions represents the xcuitest test filter options configuration.
+type TestOptions struct {
+	NotClass                          []string `yaml:"notClass,omitempty" json:"notClass"`
+	Class                             []string `yaml:"class,omitempty" json:"class"`
+	TestLanguage                      string   `yaml:"testLanguage,omitempty" json:"testLanguage"`
+	TestRegion                        string   `yaml:"testRegion,omitempty" json:"testRegion"`
+	TestTimeoutsEnabled               string   `yaml:"testTimeoutsEnabled,omitempty" json:"testTimeoutsEnabled"`
+	MaximumTestExecutionTimeAllowance int      `yaml:"maximumTestExecutionTimeAllowance,omitempty" json:"maximumTestExecutionTimeAllowance"`
+	DefaultTestExecutionTimeAllowance int      `yaml:"defaultTestExecutionTimeAllowance,omitempty" json:"defaultTestExecutionTimeAllowance"`
+	StatusBarOverrideTime             string   `yaml:"statusBarOverrideTime,omitempty" json:"statusBarOverrideTime"`
+}
+
+// ToMap converts the TestOptions to a map where the keys are derived from json struct tags.
+func (t TestOptions) ToMap() map[string]interface{} {
+	m := make(map[string]interface{})
+	v := reflect.ValueOf(t)
+	tt := v.Type()
+
+	count := v.NumField()
+	for i := 0; i < count; i++ {
+		if v.Field(i).CanInterface() {
+			tag := tt.Field(i).Tag
+			tname, ok := tag.Lookup("json")
+			if ok && tname != "-" {
+				fv := v.Field(i).Interface()
+				ft := v.Field(i).Type()
+				switch ft.Kind() {
+				// Convert int to string to match chef expectation that all test option values are strings
+				case reflect.Int:
+					// Conventionally, test options with value "" will be ignored.
+					if fv.(int) == 0 {
+						m[tname] = ""
+					} else {
+						m[tname] = fmt.Sprintf("%v", fv)
+					}
+				default:
+					m[tname] = fv
+				}
+			}
+		}
+	}
+	return m
+}
+
+// Suite represents the xcuitest test suite configuration.
+type Suite struct {
+	Name                     string             `yaml:"name,omitempty" json:"name"`
+	App                      string             `yaml:"app,omitempty" json:"app"`
+	AppDescription           string             `yaml:"appDescription,omitempty" json:"appDescription"`
+	XCTestRunFile            string             `yaml:"xcTestRunFile,omitempty" json:"xcTestRunFile"`
+	XCTestRunFileDescription string             `yaml:"xcTestRunFileDescription,omitempty" json:"xcTestRunFileDescription"`
+	OtherApps                []string           `yaml:"otherApps,omitempty" json:"otherApps"`
+	Timeout                  time.Duration      `yaml:"timeout,omitempty" json:"timeout"`
+	Devices                  []config.Device    `yaml:"devices,omitempty" json:"devices"`
+	Simulators               []config.Simulator `yaml:"simulators,omitempty" json:"simulators"`
+	TestOptions              TestOptions        `yaml:"testOptions,omitempty" json:"testOptions"`
+	AppSettings              config.AppSettings `yaml:"appSettings,omitempty" json:"appSettings"`
+	PassThreshold            int                `yaml:"passThreshold,omitempty" json:"-"`
+	SmartRetry               config.SmartRetry  `yaml:"smartRetry,omitempty" json:"-"`
+	Shard                    string             `yaml:"shard,omitempty" json:"-"`
+	TestListFile             string             `yaml:"testListFile,omitempty" json:"-"`
+	Env                      map[string]string  `yaml:"env,omitempty" json:"-"`
+}
+
+// IOS constant
+const IOS = "iOS"
+
+// FromFile creates a new xcuitest Project based on the filepath cfgPath.
+func FromFile(cfgPath string) (Project, error) {
+	var p Project
+
+	if err := config.Unmarshal(cfgPath, &p); err != nil {
+		return p, err
+	}
+
+	p.ConfigFilePath = cfgPath
+
+	return p, nil
+}
+
+// SetDefaults applies config defaults in case the user has left them blank.
+func SetDefaults(p *Project) {
+	if p.Kind == "" {
+		p.Kind = Kind
+	}
+
+	if p.APIVersion == "" {
+		p.APIVersion = APIVersion
+	}
+
+	if p.Sauce.Concurrency < 1 {
+		p.Sauce.Concurrency = 2
+	}
+
+	if p.Defaults.Timeout < 0 {
+		p.Defaults.Timeout = 0
+	}
+
+	p.Sauce.Tunnel.SetDefaults()
+	p.Sauce.Metadata.SetDefaultBuild()
+
+	for i := range p.Suites {
+		suite := &p.Suites[i]
+
+		for id := range suite.Devices {
+			suite.Devices[id].PlatformName = "iOS"
+
+			// device type only supports uppercase values
+			suite.Devices[id].Options.DeviceType = strings.ToUpper(suite.Devices[id].Options.DeviceType)
+		}
+		for id := range suite.Simulators {
+			suite.Simulators[id].PlatformName = "iOS"
+		}
+
+		if suite.Timeout <= 0 {
+			suite.Timeout = p.Defaults.Timeout
+		}
+
+		if suite.XCTestRunFile == "" {
+			suite.XCTestRunFile = p.Xctest.XCTestRunFile
+			suite.XCTestRunFileDescription = p.Xctest.XCTestRunFileDescription
+		}
+		if suite.App == "" {
+			suite.App = p.Xctest.App
+			suite.AppDescription = p.Xctest.AppDescription
+		}
+		if len(suite.OtherApps) == 0 {
+			suite.OtherApps = append(suite.OtherApps, p.Xctest.OtherApps...)
+		}
+		if suite.PassThreshold < 1 {
+			suite.PassThreshold = 1
+		}
+
+		// Precedence: --env flag > root-level env vars > suite-level env vars.
+		for _, env := range []map[string]string{p.Env, p.EnvFlag} {
+			for k, v := range env {
+				if suite.Env == nil {
+					suite.Env = map[string]string{}
+				}
+				suite.Env[k] = v
+			}
+		}
+	}
+}
+
+// Validate validates basic configuration of the project and returns an error if any of the settings contain illegal
+// values. This is not an exhaustive operation and further validation should be performed both in the client and/or
+// server side depending on the workflow that is executed.
+func Validate(p Project) error {
+	regio := region.FromString(p.Sauce.Region)
+	if regio == region.None {
+		return errors.New(msg.MissingRegion)
+	}
+
+	if p.Sauce.LaunchOrder != "" && p.Sauce.LaunchOrder != config.LaunchOrderFailRate {
+		return fmt.Errorf(msg.InvalidLaunchingOption, p.Sauce.LaunchOrder, string(config.LaunchOrderFailRate))
+	}
+
+	if len(p.Suites) == 0 {
+		return errors.New(msg.EmptySuite)
+	}
+
+	for _, suite := range p.Suites {
+		if len(suite.Devices) == 0 && len(suite.Simulators) == 0 {
+			return fmt.Errorf(msg.MissingXcuitestDeviceConfig, suite.Name)
+		}
+		if len(suite.Devices) > 0 && len(suite.Simulators) > 0 {
+			return fmt.Errorf("suite cannot have both simulators and devices")
+		}
+
+		validAppExt := []string{".app"}
+		if len(suite.Devices) > 0 {
+			validAppExt = append(validAppExt, ".ipa")
+		} else if len(suite.Simulators) > 0 {
+			validAppExt = append(validAppExt, ".zip")
+		}
+		if suite.App == "" {
+			return errors.New(msg.MissingXcuitestAppPath)
+		}
+		if err := apps.Validate("application", suite.App, validAppExt); err != nil {
+			return err
+		}
+
+		if suite.XCTestRunFile == "" {
+			return errors.New(msg.MissingXCTestFileAppPath)
+		}
+		if err := apps.Validate("test configuration", suite.XCTestRunFile, []string{".xctestrun"}); err != nil {
+			return err
+		}
+
+		for _, app := range suite.OtherApps {
+			if err := apps.Validate("other application", app, validAppExt); err != nil {
+				return err
+			}
+		}
+
+		for didx, device := range suite.Devices {
+			if device.ID == "" && device.Name == "" {
+				return fmt.Errorf(msg.MissingDeviceConfig, suite.Name, didx)
+			}
+
+			if device.Options.DeviceType != "" && !config.IsSupportedDeviceType(device.Options.DeviceType) {
+				return fmt.Errorf(msg.InvalidDeviceType,
+					device.Options.DeviceType, suite.Name, didx, strings.Join(config.SupportedDeviceTypes, ","))
+			}
+		}
+		if p.Sauce.Retries < suite.PassThreshold-1 {
+			return fmt.Errorf(msg.InvalidPassThreshold)
+		}
+		config.ValidateSmartRetry(suite.SmartRetry)
+	}
+	if p.Sauce.Retries < 0 {
+		log.Warn().Int("retries", p.Sauce.Retries).Msg(msg.InvalidReries)
+	}
+
+	return nil
+}
+
+// FilterSuites filters out suites in the project that don't match the given suite name.
+func FilterSuites(p *Project, suiteName string) error {
+	for _, s := range p.Suites {
+		if s.Name == suiteName {
+			p.Suites = []Suite{s}
+			return nil
+		}
+	}
+	return fmt.Errorf(msg.SuiteNameNotFound, suiteName)
+}
+
+// SortByHistory sorts the suites in the order of job history
+func SortByHistory(suites []Suite, history insights.JobHistory) []Suite {
+	hash := map[string]Suite{}
+	for _, s := range suites {
+		hash[s.Name] = s
+	}
+	var res []Suite
+	for _, s := range history.TestCases {
+		if v, ok := hash[s.Name]; ok {
+			res = append(res, v)
+			delete(hash, s.Name)
+		}
+	}
+	for _, v := range suites {
+		if _, ok := hash[v.Name]; ok {
+			res = append(res, v)
+		}
+	}
+	return res
+}
+
+// ShardSuites applies sharding by provided testListFile.
+func ShardSuites(p *Project) error {
+	var suites []Suite
+	for _, s := range p.Suites {
+		if s.Shard == "concurrency" {
+			shardedSuites, err := shardByConcurrency(s, p.Sauce.Concurrency)
+			if err != nil {
+				return fmt.Errorf("failed to get tests from testListFile(%q): %v", s.TestListFile, err)
+			}
+			suites = append(suites, shardedSuites...)
+		} else if s.Shard == "testList" {
+			shardedSuites, err := shardByTestList(s)
+			if err != nil {
+				return fmt.Errorf("failed to get tests from testListFile(%q): %v", s.TestListFile, err)
+			}
+			suites = append(suites, shardedSuites...)
+		} else {
+			suites = append(suites, s)
+		}
+	}
+	p.Suites = suites
+
+	return nil
+}
+
+func shardByConcurrency(suite Suite, ccy int) ([]Suite, error) {
+	readFile, err := os.Open(suite.TestListFile)
+	if err != nil {
+		return nil, err
+	}
+	defer readFile.Close()
+
+	fileScanner := bufio.NewScanner(readFile)
+	fileScanner.Split(bufio.ScanLines)
+	var tests []string
+	for fileScanner.Scan() {
+		text := strings.TrimSpace(fileScanner.Text())
+		if text == "" {
+			continue
+		}
+		tests = append(tests, text)
+	}
+	if len(tests) == 0 {
+		return nil, errors.New("empty file")
+	}
+
+	buckets := concurrency.BinPack(tests, ccy)
+	var suites []Suite
+	for i, b := range buckets {
+		currSuite := suite
+		currSuite.Name = fmt.Sprintf("%s - %d/%d", suite.Name, i+1, len(buckets))
+		currSuite.TestOptions.Class = b
+		suites = append(suites, currSuite)
+	}
+	return suites, nil
+}
+
+func shardByTestList(suite Suite) ([]Suite, error) {
+	readFile, err := os.Open(suite.TestListFile)
+	if err != nil {
+		return nil, err
+	}
+	defer readFile.Close()
+
+	fileScanner := bufio.NewScanner(readFile)
+	fileScanner.Split(bufio.ScanLines)
+	var tests []string
+	for fileScanner.Scan() {
+		text := strings.TrimSpace(fileScanner.Text())
+		if text == "" {
+			continue
+		}
+		tests = append(tests, text)
+	}
+	if len(tests) == 0 {
+		return nil, errors.New("empty file")
+	}
+	var suites []Suite
+	for _, t := range tests {
+		currSuite := suite
+		currSuite.Name = fmt.Sprintf("%s - %s", suite.Name, t)
+		currSuite.TestOptions.Class = []string{t}
+		suites = append(suites, currSuite)
+	}
+	return suites, nil
+}
+
+func GetShardTypes(suites []Suite) []string {
+	var set = map[string]bool{}
+	for _, s := range suites {
+		if s.Shard != "" {
+			set[s.Shard] = true
+		}
+	}
+	var values []string
+	for k := range set {
+		values = append(values, k)
+	}
+	return values
+}
+
+// IsSmartRetried checks if the suites contain a smartRetried suite
+func (p *Project) IsSmartRetried() bool {
+	for _, s := range p.Suites {
+		if s.SmartRetry.IsRetryFailedOnly() {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/xctest/config.go
+++ b/internal/xctest/config.go
@@ -46,7 +46,7 @@ type Project struct {
 	EnvFlag   map[string]string `yaml:"-" json:"-"`
 }
 
-// Xcuitest represents xcuitest apps configuration.
+// Xctest represents xctest apps configuration.
 type Xctest struct {
 	App                      string   `yaml:"app,omitempty" json:"app"`
 	AppDescription           string   `yaml:"appDescription,omitempty" json:"appDescription"`


### PR DESCRIPTION
## Description
Adds `xctest` test type support. Unlike `xcuitest` it doesn't require a "test" `.ipa` but a `xctestrun` file which is an Apple plist format as a descriptor. Here is what the configuration looks like:

```
apiVersion: v1alpha
kind: xctest
sauce:
  metadata:
    build: XCUITest Basic
  concurrency: 1
xctest:
  app: /Users/ricardoillgen/projects/saucelabs/rdc-xcuitest-test/apps/FlutterTestApp.ipa
  xcTestRunFile: /Users/ricardoillgen/projects/saucelabs/rdc-xcuitest-test/FlutterTest.xctestrun
suites:
  - name: "Basic XCTest"
    devices:
      - name: $DEVICE_NAME
        platformVersion: $PLATFORM_VERSION
artifacts:
  download:
    when: always
    match:
      - junit.xml
    directory: ./
```