### PR TITLE
fix: Support test case level properties in junit reporter

### DIFF
--- a/internal/junit/junit.go
+++ b/internal/junit/junit.go
@@ -29,13 +29,14 @@ type TestCase struct {
 	ClassName string `xml:"classname,attr"`
 	// Status indicates success or failure of the test. May be used instead of
 	// Error, Failure or Skipped or in addition to them.
-	Status    string   `xml:"status,attr,omitempty"`
-	File      string   `xml:"file,attr,omitempty"`
-	SystemErr string   `xml:"system-err,omitempty"`
-	SystemOut string   `xml:"system-out,omitempty"`
-	Error     *Error   `xml:"error,omitempty"`
-	Failure   *Failure `xml:"failure,omitempty"`
-	Skipped   *Skipped `xml:"skipped,omitempty"`
+	Status     string     `xml:"status,attr,omitempty"`
+	File       string     `xml:"file,attr,omitempty"`
+	SystemErr  string     `xml:"system-err,omitempty"`
+	SystemOut  string     `xml:"system-out,omitempty"`
+	Error      *Error     `xml:"error,omitempty"`
+	Failure    *Failure   `xml:"failure,omitempty"`
+	Skipped    *Skipped   `xml:"skipped,omitempty"`
+	Properties []Property `xml:"properties>property"`
 }
 
 // IsError returns true if the test case errored. Multiple fields are taken


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

When using playwright's junit reporter, [runtime annotations](https://playwright.dev/docs/test-annotations#runtime-annotations) are serialized as properties on a test case. The junit spec we based the saucectl serializer on did not define test case level properties. So when saucectl's junit reporter is configured, annotations were missing from the merged junit report.

[DEVX-3144]


[DEVX-3144]: https://saucedev.atlassian.net/browse/DEVX-3144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ