### PR TITLE
feat: Add --tags flag for storage upload command

### DIFF
--- a/internal/cmd/storage/upload.go
+++ b/internal/cmd/storage/upload.go
@@ -18,6 +18,7 @@ func UploadCommand() *cobra.Command {
 	var out string
 	var force bool
 	var description string
+	var tags []string
 
 	cmd := &cobra.Command{
 		Use: "upload filename",
@@ -87,6 +88,7 @@ func UploadCommand() *cobra.Command {
 					storage.FileInfo{
 						Name:        finfo.Name(),
 						Description: description,
+						Tags:        tags,
 					},
 					&reader,
 				)
@@ -115,6 +117,7 @@ func UploadCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
+	flags.StringSliceVar(&tags, "tags", []string{}, "A comma separated list of tags to assign to the uploaded app.")
 	flags.StringVarP(&out, "out", "o", "text",
 		"Output format to the console. Options: text, json.",
 	)


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Allow tags to be specified when uploading apps to app storage.

E.g.

`saucectl storage upload path/to/file.app --tags espresso,ci,build`

[DEVX-3160]

[DEVX-3160]: https://saucedev.atlassian.net/browse/DEVX-3160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ