### PR TITLE
fix: Set omitempty when serializing testcase properties

### DIFF
--- a/internal/junit/junit.go
+++ b/internal/junit/junit.go
@@ -29,14 +29,14 @@ type TestCase struct {
 	ClassName string `xml:"classname,attr"`
 	// Status indicates success or failure of the test. May be used instead of
 	// Error, Failure or Skipped or in addition to them.
-	Status     string     `xml:"status,attr,omitempty"`
-	File       string     `xml:"file,attr,omitempty"`
-	SystemErr  string     `xml:"system-err,omitempty"`
-	SystemOut  string     `xml:"system-out,omitempty"`
-	Error      *Error     `xml:"error,omitempty"`
-	Failure    *Failure   `xml:"failure,omitempty"`
-	Skipped    *Skipped   `xml:"skipped,omitempty"`
-	Properties []Property `xml:"properties>property"`
+	Status     string      `xml:"status,attr,omitempty"`
+	File       string      `xml:"file,attr,omitempty"`
+	SystemErr  string      `xml:"system-err,omitempty"`
+	SystemOut  string      `xml:"system-out,omitempty"`
+	Error      *Error      `xml:"error,omitempty"`
+	Failure    *Failure    `xml:"failure,omitempty"`
+	Skipped    *Skipped    `xml:"skipped,omitempty"`
+	Properties *[]Property `xml:"properties>property,omitempty"`
 }
 
 // IsError returns true if the test case errored. Multiple fields are taken


### PR DESCRIPTION


## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

`<properties />` on testcases isn't well defined, some schemas define it, some don't. It is by definition optional so it should not be serialized if empty.