### PR TITLE
Ensure 'false' config values are passed through

### DIFF
--- a/internal/cmd/run/espresso.go
+++ b/internal/cmd/run/espresso.go
@@ -76,7 +76,7 @@ func NewEspressoCmd() *cobra.Command {
 	cmd.Flags().Var(&lflags.Device, "device", "Specifies the device to use for testing. Requires --name to be set.")
 
 	// Overwrite devices settings
-	sc.Bool("resigningEnabled", "suite::appSettings::resigningEnabled", false, "Configure app settings for real device to enable app resigning.")
+	sc.Bool("resigningEnabled", "suite::appSettings::resigningEnabled", true, "Configure app settings for real device to enable app resigning.")
 	sc.Bool("audioCapture", "suite::appSettings::audioCapture", false, "Configure app settings for real device to capture audio.")
 	sc.Bool("imageInjection", "suite::appSettings::instrumentation::imageInjection", false, "Configure app settings for real device to inject provided images in the user app.")
 	sc.Bool("bypassScreenshotRestriction", "suite::appSettings::instrumentation::bypassScreenshotRestriction", false, "Configure app settings for real device to enable bypassing of screenshot restriction.")

--- a/internal/cmd/run/xctest.go
+++ b/internal/cmd/run/xctest.go
@@ -70,7 +70,7 @@ func NewXCTestCmd() *cobra.Command {
 	cmd.Flags().Var(&lflags.Device, "device", "Specifies the device to use for testing. Requires --name to be set.")
 
 	// Overwrite devices settings
-	sc.Bool("resigningEnabled", "suite::appSettings::resigningEnabled", false, "Overwrite app settings for real device to enable app resigning.")
+	sc.Bool("resigningEnabled", "suite::appSettings::resigningEnabled", true, "Overwrite app settings for real device to enable app resigning.")
 	sc.Bool("audioCapture", "suite::appSettings::audioCapture", false, "Overwrite app settings for real device to capture audio.")
 	sc.Bool("imageInjection", "suite::appSettings::instrumentation::imageInjection", false, "Overwrite app settings for real device to inject provided images in the user app.")
 	sc.Bool("sysAlertsDelay", "suite::appSettings::instrumentation::sysAlertsDelay", false, "Overwrite app settings for real device to delay system alerts.")

--- a/internal/cmd/run/xcuitest.go
+++ b/internal/cmd/run/xcuitest.go
@@ -73,7 +73,7 @@ func NewXCUITestCmd() *cobra.Command {
 	cmd.Flags().Var(&lflags.Simulator, "simulator", "Specifies the simulator to use for testing. Requires --name to be set.")
 
 	// Configure devices settings
-	sc.Bool("resigningEnabled", "suite::appSettings::resigningEnabled", false, "Configure app settings for real device to enable app resigning.")
+	sc.Bool("resigningEnabled", "suite::appSettings::resigningEnabled", true, "Configure app settings for real device to enable app resigning.")
 	sc.Bool("audioCapture", "suite::appSettings::audioCapture", false, "Configure app settings for real device to capture audio.")
 	sc.Bool("imageInjection", "suite::appSettings::instrumentation::imageInjection", false, "Configure app settings for real device to inject provided images in the user app.")
 	sc.Bool("sysAlertsDelay", "suite::appSettings::instrumentation::sysAlertsDelay", false, "Configure app settings for real device to delay system alerts.")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,20 +206,20 @@ type Defaults struct {
 
 // AppSettings represents override settings.
 type AppSettings struct {
-	ResigningEnabled bool            `yaml:"resigningEnabled,omitempty" json:"resigningEnabled"`
-	AudioCapture     bool            `yaml:"audioCapture,omitempty" json:"audioCapture"`
+	ResigningEnabled *bool           `yaml:"resigningEnabled,omitempty" json:"resigningEnabled"`
+	AudioCapture     *bool           `yaml:"audioCapture,omitempty" json:"audioCapture"`
 	Instrumentation  Instrumentation `yaml:"instrumentation,omitempty" json:"instrumentation"`
 }
 
 // Instrumentation represents Instrumentation settings for real devices.
 type Instrumentation struct {
-	ImageInjection              bool `yaml:"imageInjection,omitempty" json:"imageInjection"`
-	BypassScreenshotRestriction bool `yaml:"bypassScreenshotRestriction,omitempty" json:"bypassScreenshotRestriction"`
-	GroupDirectory              bool `yaml:"groupDirectory,omitempty" json:"groupDirectory"`
-	SysAlertsDelay              bool `yaml:"sysAlertsDelay,omitempty" json:"sysAlertsDelay"`
-	Biometrics                  bool `yaml:"biometrics,omitempty" json:"biometrics"`
-	Vitals                      bool `yaml:"vitals,omitempty" json:"vitals"`
-	NetworkCapture              bool `yaml:"networkCapture,omitempty" json:"networkCapture"`
+	ImageInjection              *bool `yaml:"imageInjection,omitempty" json:"imageInjection"`
+	BypassScreenshotRestriction *bool `yaml:"bypassScreenshotRestriction,omitempty" json:"bypassScreenshotRestriction"`
+	GroupDirectory              *bool `yaml:"groupDirectory,omitempty" json:"groupDirectory"`
+	SysAlertsDelay              *bool `yaml:"sysAlertsDelay,omitempty" json:"sysAlertsDelay"`
+	Biometrics                  *bool `yaml:"biometrics,omitempty" json:"biometrics"`
+	Vitals                      *bool `yaml:"vitals,omitempty" json:"vitals"`
+	NetworkCapture              *bool `yaml:"networkCapture,omitempty" json:"networkCapture"`
 }
 
 // SmartRetry represents the settings for retry strategy.

--- a/internal/espresso/config_test.go
+++ b/internal/espresso/config_test.go
@@ -2,9 +2,10 @@ package espresso
 
 import (
 	"errors"
-	"github.com/google/go-cmp/cmp"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/saucelabs/saucectl/internal/config"
 	"github.com/saucelabs/saucectl/internal/insights"
@@ -297,63 +298,63 @@ func TestEspresso_SortByHistory(t *testing.T) {
 		{
 			name: "sort suites by job history",
 			suites: []Suite{
-				Suite{Name: "suite 1"},
-				Suite{Name: "suite 2"},
-				Suite{Name: "suite 3"},
+				{Name: "suite 1"},
+				{Name: "suite 2"},
+				{Name: "suite 3"},
 			},
 			history: insights.JobHistory{
 				TestCases: []insights.TestCase{
-					insights.TestCase{Name: "suite 2"},
-					insights.TestCase{Name: "suite 1"},
-					insights.TestCase{Name: "suite 3"},
+					{Name: "suite 2"},
+					{Name: "suite 1"},
+					{Name: "suite 3"},
 				},
 			},
 			expRes: []Suite{
-				Suite{Name: "suite 2"},
-				Suite{Name: "suite 1"},
-				Suite{Name: "suite 3"},
+				{Name: "suite 2"},
+				{Name: "suite 1"},
+				{Name: "suite 3"},
 			},
 		},
 		{
 			name: "suites is the subset of job history",
 			suites: []Suite{
-				Suite{Name: "suite 1"},
-				Suite{Name: "suite 2"},
+				{Name: "suite 1"},
+				{Name: "suite 2"},
 			},
 			history: insights.JobHistory{
 				TestCases: []insights.TestCase{
-					insights.TestCase{Name: "suite 2"},
-					insights.TestCase{Name: "suite 1"},
-					insights.TestCase{Name: "suite 3"},
+					{Name: "suite 2"},
+					{Name: "suite 1"},
+					{Name: "suite 3"},
 				},
 			},
 			expRes: []Suite{
-				Suite{Name: "suite 2"},
-				Suite{Name: "suite 1"},
+				{Name: "suite 2"},
+				{Name: "suite 1"},
 			},
 		},
 		{
 			name: "job history is the subset of suites",
 			suites: []Suite{
-				Suite{Name: "suite 1"},
-				Suite{Name: "suite 2"},
-				Suite{Name: "suite 3"},
-				Suite{Name: "suite 4"},
-				Suite{Name: "suite 5"},
+				{Name: "suite 1"},
+				{Name: "suite 2"},
+				{Name: "suite 3"},
+				{Name: "suite 4"},
+				{Name: "suite 5"},
 			},
 			history: insights.JobHistory{
 				TestCases: []insights.TestCase{
-					insights.TestCase{Name: "suite 2"},
-					insights.TestCase{Name: "suite 1"},
-					insights.TestCase{Name: "suite 3"},
+					{Name: "suite 2"},
+					{Name: "suite 1"},
+					{Name: "suite 3"},
 				},
 			},
 			expRes: []Suite{
-				Suite{Name: "suite 2"},
-				Suite{Name: "suite 1"},
-				Suite{Name: "suite 3"},
-				Suite{Name: "suite 4"},
-				Suite{Name: "suite 5"},
+				{Name: "suite 2"},
+				{Name: "suite 1"},
+				{Name: "suite 3"},
+				{Name: "suite 4"},
+				{Name: "suite 5"},
 			},
 		},
 	}

--- a/internal/job/options.go
+++ b/internal/job/options.go
@@ -100,30 +100,30 @@ type StartOptions struct {
 
 // AppSettings represents mobile app settings.
 type AppSettings struct {
-	AudioCapture           bool            `json:"audio_capture,omitempty"`
-	InstrumentationEnabled bool            `json:"instrumentation_enabled,omitempty"`
+	AudioCapture           *bool           `json:"audio_capture,omitempty"`
+	InstrumentationEnabled *bool           `json:"instrumentation_enabled,omitempty"`
 	Instrumentation        Instrumentation `json:"instrumentation,omitempty"`
-	ResigningEnabled       bool            `json:"resigning_enabled,omitempty"`
+	ResigningEnabled       *bool           `json:"resigning_enabled,omitempty"`
 	Resigning              Resigning       `json:"resigning,omitempty"`
 }
 
 // Instrumentation represents mobile app instrumentation settings for Android.
 type Instrumentation struct {
-	ImageInjection              bool `json:"image_injection,omitempty"`
-	BypassScreenshotRestriction bool `json:"bypass_screenshot_restriction,omitempty"`
-	BiometricsInterception      bool `json:"biometrics,omitempty"`
-	Vitals                      bool `json:"vitals,omitempty"`
-	NetworkCapture              bool `json:"network_capture,omitempty"`
+	ImageInjection              *bool `json:"image_injection,omitempty"`
+	BypassScreenshotRestriction *bool `json:"bypass_screenshot_restriction,omitempty"`
+	BiometricsInterception      *bool `json:"biometrics,omitempty"`
+	Vitals                      *bool `json:"vitals,omitempty"`
+	NetworkCapture              *bool `json:"network_capture,omitempty"`
 }
 
 // Resigning represents mobile app instrumentation settings for iOS.
 type Resigning struct {
-	ImageInjection         bool `json:"image_injection,omitempty"`
-	SystemAlertsDelay      bool `json:"sys_alerts_delay,omitempty"`
-	GroupDirectory         bool `json:"group_directory,omitempty"`
-	BiometricsInterception bool `json:"biometrics,omitempty"`
-	Vitals                 bool `json:"vitals,omitempty"`
-	NetworkCapture         bool `json:"network_capture,omitempty"`
+	ImageInjection         *bool `json:"image_injection,omitempty"`
+	SystemAlertsDelay      *bool `json:"sys_alerts_delay,omitempty"`
+	GroupDirectory         *bool `json:"group_directory,omitempty"`
+	BiometricsInterception *bool `json:"biometrics,omitempty"`
+	Vitals                 *bool `json:"vitals,omitempty"`
+	NetworkCapture         *bool `json:"network_capture,omitempty"`
 }
 
 // TunnelOptions represents the options that configure the usage of a tunnel when running tests in the Sauce Labs cloud.


### PR DESCRIPTION
## Issue

Customers reported that there is currently no way to disable Instrumentation using saucectl config (the `resigningEnabled` field) on XCUITest or Espresso. I was able to repro this, and after intercepting the raw JSON sent from saucectl, I found that any config option set to `false` does not get sent through at all (as if it was omitted from config.yml).

This isn't a problem for most fields that default to `false`, but `resigningEnabled` is the odd one out, defaulting to `true`. This means there's currently no way to set this to anything other than the default value (which is a problem).

## Fix

The issue seems to stem from using [omitempty](https://stackoverflow.com/questions/37756236/json-golang-boolean-omitempty) on a boolean field. A primitive boolean can't be nil, so nil values get coerced into `false`, and `false` is considered "empty" (and omitted).

By switching to boolean _pointers_ instead, we can have a nil value (if the config value is not set), which will be considered "empty" and omitted (just like before). But if non-nil (the config value was set), it will always be a pointer to a boolean value, and always included in the JSON output.

## Notes

This was tested extensively in staging to make sure the intended bug was fixed without introducing any other unwanted changes to the JSON output.

Though `resigningEnabled` was the only problematic field, I opted to change all fields to boolean pointers, both for consistency and in case the default back-end value ever changes in the future for other fields (so it won't require a saucectl change as well).