### PR TITLE
[INT-83] add devices list command

### DIFF
--- a/cmd/saucectl/saucectl.go
+++ b/cmd/saucectl/saucectl.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/saucelabs/saucectl/internal/cmd/devices"
 	"os"
 	"os/signal"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/saucelabs/saucectl/internal/cmd/builds"
 	"github.com/saucelabs/saucectl/internal/cmd/completion"
 	"github.com/saucelabs/saucectl/internal/cmd/configure"
+	"github.com/saucelabs/saucectl/internal/cmd/devices"
 	"github.com/saucelabs/saucectl/internal/cmd/docker"
 	"github.com/saucelabs/saucectl/internal/cmd/imagerunner"
 	"github.com/saucelabs/saucectl/internal/cmd/ini"

--- a/cmd/saucectl/saucectl.go
+++ b/cmd/saucectl/saucectl.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/saucelabs/saucectl/internal/cmd/devices"
 	"os"
 	"os/signal"
 	"time"
@@ -75,6 +76,7 @@ func main() {
 		apit.Command(cmd.PersistentPreRun),
 		docker.Command(cmd.PersistentPreRun),
 		builds.Command(cmd.PersistentPreRun),
+		devices.Command(cmd.PersistentPreRun),
 	)
 
 	if err := cmd.ExecuteContext(newContext()); err != nil {

--- a/internal/cmd/devices/cmd.go
+++ b/internal/cmd/devices/cmd.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	devicesReader  devices.Reader
-	devicesTimeout = 1 * time.Minute
+	devicesReader         devices.Reader
+	devicesStatusesReader devices.StatusReader
+	devicesTimeout        = 1 * time.Minute
 )
 
 func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
@@ -41,6 +42,7 @@ func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
 			rdcService := http.NewRDCService(reg, creds.Username, creds.AccessKey, devicesTimeout)
 
 			devicesReader = &rdcService
+			devicesStatusesReader = &rdcService
 
 			return nil
 		},

--- a/internal/cmd/devices/cmd.go
+++ b/internal/cmd/devices/cmd.go
@@ -1,0 +1,55 @@
+package devices
+
+import (
+	"errors"
+	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/devices"
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/usage"
+	"github.com/spf13/cobra"
+	"time"
+)
+
+var (
+	devicesReader  devices.Reader
+	devicesTimeout = 1 * time.Minute
+)
+
+func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
+	var regio string
+
+	cmd := &cobra.Command{
+		Use:              "devices",
+		Short:            "Interact with devices",
+		SilenceUsage:     true,
+		TraverseChildren: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if preRun != nil {
+				preRun(cmd, args)
+			}
+
+			reg := region.FromString(regio)
+			if reg == region.None {
+				return errors.New("invalid region")
+			}
+			if reg == region.Staging {
+				usage.DefaultClient.Enabled = false
+			}
+
+			creds := credentials.Get()
+			rdcService := http.NewRDCService(reg, creds.Username, creds.AccessKey, devicesTimeout)
+
+			devicesReader = &rdcService
+
+			return nil
+		},
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.StringVarP(&regio, "region", "r", "us-west-1", "The Sauce Labs region. Options: us-west-1, eu-central-1.")
+
+	cmd.AddCommand(ListCommand())
+
+	return cmd
+}

--- a/internal/cmd/devices/cmd.go
+++ b/internal/cmd/devices/cmd.go
@@ -2,13 +2,14 @@ package devices
 
 import (
 	"errors"
+	"time"
+
 	"github.com/saucelabs/saucectl/internal/credentials"
 	"github.com/saucelabs/saucectl/internal/devices"
 	"github.com/saucelabs/saucectl/internal/http"
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/saucelabs/saucectl/internal/usage"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 var (

--- a/internal/cmd/devices/list.go
+++ b/internal/cmd/devices/list.go
@@ -56,7 +56,7 @@ func ListCommand() *cobra.Command {
 		},
 		Short:        "Returns the list of devices",
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if page < 0 {
 				return errors.New("invalid page")
 			}

--- a/internal/cmd/devices/list.go
+++ b/internal/cmd/devices/list.go
@@ -22,25 +22,25 @@ const (
 	TextOutput = "text"
 )
 
-type DeviceWithStatus struct {
+type deviceWithStatus struct {
 	ID     string `json:"id"`
 	Name   string `json:"name"`
 	OS     string `json:"os"`
 	Status string `json:"status"`
 }
 
-type Filter struct {
+type filter struct {
 	Name   string
 	Os     string
 	Status string
 }
 
-type ListOptions struct {
+type listOptions struct {
 	Page         int
 	Size         int
 	Status       bool
 	OutputFormat string
-	Filter       Filter
+	Filter       filter
 }
 
 func ListCommand() *cobra.Command {
@@ -90,12 +90,12 @@ func ListCommand() *cobra.Command {
 				addStatus = true
 			}
 
-			options := ListOptions{
+			options := listOptions{
 				Page:         page,
 				Size:         size,
 				Status:       addStatus,
 				OutputFormat: out,
-				Filter: Filter{
+				Filter: filter{
 					Name:   nameFilter,
 					Os:     osFilter,
 					Status: statusFilter,
@@ -118,13 +118,13 @@ func ListCommand() *cobra.Command {
 	return cmd
 }
 
-func list(ctx context.Context, options ListOptions) error {
+func list(ctx context.Context, options listOptions) error {
 	devs, err := devicesReader.GetDevices(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get devices: %w", err)
 	}
 
-	var devsWithStatuses []DeviceWithStatus
+	var devsWithStatuses []deviceWithStatus
 	if options.Status {
 		res, err := getDevicesWithStatuses(ctx, devs)
 		if err != nil {
@@ -137,7 +137,7 @@ func list(ctx context.Context, options ListOptions) error {
 
 	var filtered = filterDevices(devsWithStatuses, options.Filter)
 
-	var paginated []DeviceWithStatus
+	var paginated []deviceWithStatus
 	var from, to int
 	if options.Size > 0 {
 		from = min(options.Size*options.Page, len(filtered))
@@ -161,8 +161,8 @@ func list(ctx context.Context, options ListOptions) error {
 	return nil
 }
 
-func filterDevices(devs []DeviceWithStatus, filter Filter) []DeviceWithStatus {
-	var filtered []DeviceWithStatus
+func filterDevices(devs []deviceWithStatus, filter filter) []deviceWithStatus {
+	var filtered []deviceWithStatus
 	for _, dev := range devs {
 		if filter.Name != "" && !strings.Contains(strings.ToLower(dev.Name), strings.ToLower(filter.Name)) {
 			continue
@@ -181,13 +181,13 @@ func filterDevices(devs []DeviceWithStatus, filter Filter) []DeviceWithStatus {
 	return filtered
 }
 
-func getDevicesWithStatuses(ctx context.Context, devs []devices.Device) ([]DeviceWithStatus, error) {
+func getDevicesWithStatuses(ctx context.Context, devs []devices.Device) ([]deviceWithStatus, error) {
 	statuses, err := devicesStatusesReader.GetDevicesStatuses(ctx)
 	if err != nil {
-		return []DeviceWithStatus{}, fmt.Errorf("failed to get devices statuses: %w", err)
+		return []deviceWithStatus{}, fmt.Errorf("failed to get devices statuses: %w", err)
 	}
 
-	var result []DeviceWithStatus
+	var result []deviceWithStatus
 	for _, dev := range devs {
 		var searchedStatus devices.DeviceStatus
 		for _, status := range statuses {
@@ -196,7 +196,7 @@ func getDevicesWithStatuses(ctx context.Context, devs []devices.Device) ([]Devic
 			}
 		}
 
-		result = append(result, DeviceWithStatus{
+		result = append(result, deviceWithStatus{
 			ID:     dev.ID,
 			Name:   dev.Name,
 			OS:     dev.OS,
@@ -207,10 +207,10 @@ func getDevicesWithStatuses(ctx context.Context, devs []devices.Device) ([]Devic
 	return result, nil
 }
 
-func getDevicesWithEmptyStatuses(devs []devices.Device) []DeviceWithStatus {
-	var result []DeviceWithStatus
+func getDevicesWithEmptyStatuses(devs []devices.Device) []deviceWithStatus {
+	var result []deviceWithStatus
 	for _, dev := range devs {
-		result = append(result, DeviceWithStatus{
+		result = append(result, deviceWithStatus{
 			ID:   dev.ID,
 			Name: dev.Name,
 			OS:   dev.OS,
@@ -223,7 +223,7 @@ func renderJSON(val any) error {
 	return json.NewEncoder(os.Stdout).Encode(val)
 }
 
-func renderListTable(devices []DeviceWithStatus, from int, to int, total int, status bool) {
+func renderListTable(devices []deviceWithStatus, from int, to int, total int, status bool) {
 	if len(devices) == 0 {
 		println("No devices found")
 		return
@@ -247,7 +247,7 @@ func renderListTable(devices []DeviceWithStatus, from int, to int, total int, st
 	fmt.Println(t.Render())
 }
 
-func writeDevices(t table.Writer, devices []DeviceWithStatus) {
+func writeDevices(t table.Writer, devices []deviceWithStatus) {
 	t.AppendHeader(table.Row{
 		"Name", "OS",
 	})
@@ -261,7 +261,7 @@ func writeDevices(t table.Writer, devices []DeviceWithStatus) {
 	}
 }
 
-func writeDevicesWithStatus(t table.Writer, devices []DeviceWithStatus) {
+func writeDevicesWithStatus(t table.Writer, devices []deviceWithStatus) {
 	t.AppendHeader(table.Row{
 		"Name", "OS", "Status",
 	})

--- a/internal/cmd/devices/list.go
+++ b/internal/cmd/devices/list.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Masterminds/semver/v3"
 	"os"
 	"strings"
+
+	"github.com/Masterminds/semver/v3"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	cmds "github.com/saucelabs/saucectl/internal/cmd"

--- a/internal/cmd/devices/list.go
+++ b/internal/cmd/devices/list.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"github.com/saucelabs/saucectl/internal/devices"
 	"github.com/saucelabs/saucectl/internal/devices/devicestatus"
 	"github.com/saucelabs/saucectl/internal/tables"
+	"github.com/saucelabs/saucectl/internal/usage"
 	"github.com/spf13/cobra"
 	"os"
 	"strings"
@@ -56,6 +58,17 @@ func ListCommand() *cobra.Command {
 		},
 		Short:        "Returns the list of devices",
 		SilenceUsage: true,
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			tracker := usage.DefaultClient
+
+			go func() {
+				tracker.Collect(
+					cmds.FullName(cmd),
+					usage.Flags(cmd.Flags()),
+				)
+				_ = tracker.Close()
+			}()
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if page < 0 {
 				return errors.New("invalid page")

--- a/internal/cmd/devices/list.go
+++ b/internal/cmd/devices/list.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/saucelabs/saucectl/internal/devices"
+	"github.com/saucelabs/saucectl/internal/devices/devicestatus"
 	"github.com/saucelabs/saucectl/internal/tables"
 	"github.com/spf13/cobra"
 	"os"
@@ -18,12 +19,20 @@ const (
 	TextOutput = "text"
 )
 
+type DeviceWithStatus struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	OS     string `json:"os"`
+	Status string `json:"status"`
+}
+
 func ListCommand() *cobra.Command {
 	var out string
 	var page int
 	var size int
 	var nameFilter string
 	var osFilter string
+	var addStatus bool
 
 	cmd := &cobra.Command{
 		Use: "list",
@@ -43,7 +52,7 @@ func ListCommand() *cobra.Command {
 				return errors.New("unknown output format")
 			}
 
-			return list(cmd.Context(), out, page, size, nameFilter, osFilter)
+			return list(cmd.Context(), out, page, size, nameFilter, osFilter, addStatus)
 		},
 	}
 
@@ -53,14 +62,15 @@ func ListCommand() *cobra.Command {
 	flags.IntVarP(&size, "size", "s", 20, "Per page for pagination. Default is 20.")
 	flags.StringVarP(&nameFilter, "name", "n", "", "Filter devices by name.")
 	flags.StringVar(&osFilter, "os", "", "Filter devices by OS.")
+	flags.BoolVar(&addStatus, "statuses", false, "Fetch status for devices.")
 
 	return cmd
 }
 
-func list(ctx context.Context, format string, page int, size int, nameFilter string, osFilter string) error {
+func list(ctx context.Context, format string, page int, size int, nameFilter string, osFilter string, addStatus bool) error {
 	devs, err := devicesReader.GetDevices(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get devs: %w", err)
+		return fmt.Errorf("failed to get devices: %w", err)
 	}
 
 	var filtered = filterDevices(devs, nameFilter, osFilter)
@@ -71,11 +81,32 @@ func list(ctx context.Context, format string, page int, size int, nameFilter str
 
 	switch format {
 	case "json":
-		if err := renderJSON(paginated); err != nil {
+		var toRender any
+		if addStatus {
+			res, err := getDevicesWithStatuses(ctx, paginated)
+			if err != nil {
+				return err
+			}
+			toRender = res
+		} else {
+			toRender = paginated
+		}
+
+		if err := renderJSON(toRender); err != nil {
 			return fmt.Errorf("failed to render output: %w", err)
 		}
 	case "text":
-		renderListTable(paginated, from+1, to, len(filtered))
+		var toDisplay []DeviceWithStatus
+		if addStatus {
+			devsWithStatuses, err := getDevicesWithStatuses(ctx, paginated)
+			if err != nil {
+				return err
+			}
+			toDisplay = devsWithStatuses
+		} else {
+			toDisplay = getDevicesWithEmptyStatuses(devs)
+		}
+		renderListTable(toDisplay, from+1, to, len(filtered), addStatus)
 	}
 
 	return nil
@@ -97,11 +128,49 @@ func filterDevices(devs []devices.Device, nameFilter string, osFilter string) []
 	return filtered
 }
 
+func getDevicesWithStatuses(ctx context.Context, devs []devices.Device) ([]DeviceWithStatus, error) {
+	statuses, err := devicesStatusesReader.GetDevicesStatuses(ctx)
+	if err != nil {
+		return []DeviceWithStatus{}, fmt.Errorf("failed to get devices statuses: %w", err)
+	}
+
+	var result []DeviceWithStatus
+	for _, dev := range devs {
+		var searchedStatus devices.DeviceStatus
+		for _, status := range statuses {
+			if status.ID == dev.ID {
+				searchedStatus = status
+			}
+		}
+
+		result = append(result, DeviceWithStatus{
+			ID:     dev.ID,
+			Name:   dev.Name,
+			OS:     dev.OS,
+			Status: devicestatus.StatusToStr(searchedStatus.Status),
+		})
+	}
+
+	return result, nil
+}
+
+func getDevicesWithEmptyStatuses(devs []devices.Device) []DeviceWithStatus {
+	var result []DeviceWithStatus
+	for _, dev := range devs {
+		result = append(result, DeviceWithStatus{
+			ID:   dev.ID,
+			Name: dev.Name,
+			OS:   dev.OS,
+		})
+	}
+	return result
+}
+
 func renderJSON(val any) error {
 	return json.NewEncoder(os.Stdout).Encode(val)
 }
 
-func renderListTable(devices []devices.Device, from int, to int, total int) {
+func renderListTable(devices []DeviceWithStatus, from int, to int, total int, status bool) {
 	if len(devices) == 0 {
 		println("No devices found")
 		return
@@ -111,6 +180,21 @@ func renderListTable(devices []devices.Device, from int, to int, total int) {
 	t.SetStyle(tables.DefaultTableStyle)
 	t.SuppressEmptyColumns()
 
+	if status {
+		writeDevicesWithStatus(t, devices)
+	} else {
+		writeDevices(t, devices)
+	}
+
+	t.SuppressEmptyColumns()
+	t.AppendFooter(table.Row{
+		fmt.Sprintf("showing %d-%d devices out of %d", from, to, total),
+	})
+
+	fmt.Println(t.Render())
+}
+
+func writeDevices(t table.Writer, devices []DeviceWithStatus) {
 	t.AppendHeader(table.Row{
 		"Name", "OS",
 	})
@@ -122,10 +206,19 @@ func renderListTable(devices []devices.Device, from int, to int, total int) {
 			item.OS,
 		})
 	}
-	t.SuppressEmptyColumns()
-	t.AppendFooter(table.Row{
-		fmt.Sprintf("showing %d-%d devices out of %d", from, to, total),
+}
+
+func writeDevicesWithStatus(t table.Writer, devices []DeviceWithStatus) {
+	t.AppendHeader(table.Row{
+		"Name", "OS", "Status",
 	})
 
-	fmt.Println(t.Render())
+	for _, item := range devices {
+		// the order of values must match the order of the header
+		t.AppendRow(table.Row{
+			item.Name,
+			item.OS,
+			item.Status,
+		})
+	}
 }

--- a/internal/cmd/devices/list.go
+++ b/internal/cmd/devices/list.go
@@ -82,6 +82,11 @@ func ListCommand() *cobra.Command {
 			}
 
 			if statusFilter != "" {
+				_, err := devicestatus.StrToStatus(statusFilter)
+				if err != nil {
+					return err
+				}
+
 				addStatus = true
 			}
 

--- a/internal/cmd/devices/list.go
+++ b/internal/cmd/devices/list.go
@@ -1,0 +1,131 @@
+package devices
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/saucelabs/saucectl/internal/devices"
+	"github.com/saucelabs/saucectl/internal/tables"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+)
+
+const (
+	JSONOutput = "json"
+	TextOutput = "text"
+)
+
+func ListCommand() *cobra.Command {
+	var out string
+	var page int
+	var size int
+	var nameFilter string
+	var osFilter string
+
+	cmd := &cobra.Command{
+		Use: "list",
+		Aliases: []string{
+			"ls",
+		},
+		Short:        "Returns the list of devices",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if page < 0 {
+				return errors.New("invalid page")
+			}
+			if size < 0 {
+				return errors.New("invalid size")
+			}
+			if out != JSONOutput && out != TextOutput {
+				return errors.New("unknown output format")
+			}
+
+			return list(cmd.Context(), out, page, size, nameFilter, osFilter)
+		},
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.StringVarP(&out, "out", "o", "text", "Output format to the console. Options: text, json.")
+	flags.IntVarP(&page, "page", "p", 0, "Page for pagination. Default is 0.")
+	flags.IntVarP(&size, "size", "s", 20, "Per page for pagination. Default is 20.")
+	flags.StringVarP(&nameFilter, "name", "n", "", "Filter devices by name.")
+	flags.StringVar(&osFilter, "os", "", "Filter devices by OS.")
+
+	return cmd
+}
+
+func list(ctx context.Context, format string, page int, size int, nameFilter string, osFilter string) error {
+	devs, err := devicesReader.GetDevices(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get devs: %w", err)
+	}
+
+	var filtered = filterDevices(devs, nameFilter, osFilter)
+
+	from := min(size*page, len(filtered))
+	to := min(size*(page+1), len(filtered))
+	paginated := filtered[from:to]
+
+	switch format {
+	case "json":
+		if err := renderJSON(paginated); err != nil {
+			return fmt.Errorf("failed to render output: %w", err)
+		}
+	case "text":
+		renderListTable(paginated, from+1, to, len(filtered))
+	}
+
+	return nil
+}
+
+func filterDevices(devs []devices.Device, nameFilter string, osFilter string) []devices.Device {
+	var filtered []devices.Device
+	for _, dev := range devs {
+		if nameFilter != "" && !strings.Contains(strings.ToLower(dev.Name), strings.ToLower(nameFilter)) {
+			continue
+		}
+
+		if osFilter != "" && !strings.Contains(strings.ToLower(dev.OS), strings.ToLower(osFilter)) {
+			continue
+		}
+
+		filtered = append(filtered, dev)
+	}
+	return filtered
+}
+
+func renderJSON(val any) error {
+	return json.NewEncoder(os.Stdout).Encode(val)
+}
+
+func renderListTable(devices []devices.Device, from int, to int, total int) {
+	if len(devices) == 0 {
+		println("No devices found")
+		return
+	}
+
+	t := table.NewWriter()
+	t.SetStyle(tables.DefaultTableStyle)
+	t.SuppressEmptyColumns()
+
+	t.AppendHeader(table.Row{
+		"Name", "OS",
+	})
+
+	for _, item := range devices {
+		// the order of values must match the order of the header
+		t.AppendRow(table.Row{
+			item.Name,
+			item.OS,
+		})
+	}
+	t.SuppressEmptyColumns()
+	t.AppendFooter(table.Row{
+		fmt.Sprintf("showing %d-%d devices out of %d", from, to, total),
+	})
+
+	fmt.Println(t.Render())
+}

--- a/internal/cmd/devices/list.go
+++ b/internal/cmd/devices/list.go
@@ -90,7 +90,7 @@ func ListCommand() *cobra.Command {
 	flags := cmd.PersistentFlags()
 	flags.StringVarP(&out, "out", "o", "text", "OutputFormat format to the console. Options: text, json.")
 	flags.IntVarP(&page, "page", "p", 0, "Page for pagination. Default is 0.")
-	flags.IntVarP(&size, "size", "s", 20, "Per page for pagination. Default is 20.")
+	flags.IntVarP(&size, "size", "s", 0, "Per page for pagination. Default is all.")
 	flags.StringVarP(&nameFilter, "name", "n", "", "Filter devices by name.")
 	flags.StringVar(&osFilter, "os", "", "Filter devices by OS.")
 	flags.BoolVar(&addStatus, "statuses", false, "Fetch status for devices.")
@@ -118,9 +118,17 @@ func list(ctx context.Context, options ListOptions) error {
 
 	var filtered = filterDevices(devsWithStatuses, options.Filter)
 
-	from := min(options.Size*options.Page, len(filtered))
-	to := min(options.Size*(options.Page+1), len(filtered))
-	paginated := filtered[from:to]
+	var paginated []DeviceWithStatus
+	var from, to int
+	if options.Size > 0 {
+		from = min(options.Size*options.Page, len(filtered))
+		to = min(options.Size*(options.Page+1), len(filtered))
+		paginated = filtered[from:to]
+	} else {
+		from = 0
+		to = len(filtered)
+		paginated = filtered
+	}
 
 	switch options.OutputFormat {
 	case "json":

--- a/internal/cmd/devices/list.go
+++ b/internal/cmd/devices/list.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/jedib0t/go-pretty/v6/table"
 	cmds "github.com/saucelabs/saucectl/internal/cmd"
 	"github.com/saucelabs/saucectl/internal/devices"
@@ -12,8 +15,6 @@ import (
 	"github.com/saucelabs/saucectl/internal/tables"
 	"github.com/saucelabs/saucectl/internal/usage"
 	"github.com/spf13/cobra"
-	"os"
-	"strings"
 )
 
 const (

--- a/internal/cmd/ini/initializer.go
+++ b/internal/cmd/ini/initializer.go
@@ -50,7 +50,7 @@ var fallbackIOSVirtualDevices = []vmd.VirtualDevice{
 type initializer struct {
 	stdio        terminal.Stdio
 	infoReader   framework.MetadataService
-	deviceReader devices.Reader
+	deviceReader devices.ByOSReader
 	vmdReader    vmd.Reader
 	userService  iam.UserService
 	cfg          *initConfig

--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -2,7 +2,7 @@ package devices
 
 import (
 	"context"
-	
+
 	"github.com/saucelabs/saucectl/internal/devices/devicestatus"
 )
 

--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -8,9 +8,10 @@ import (
 
 // Device describes a real device that can be used to run tests.
 type Device struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	OS   string `json:"os"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	OS        string `json:"os"`
+	OSVersion string `json:"osVersion"`
 }
 
 type DeviceStatus struct {
@@ -21,10 +22,11 @@ type DeviceStatus struct {
 }
 
 type DeviceWithStatus struct {
-	ID     string              `json:"id"`
-	Name   string              `json:"name"`
-	OS     string              `json:"os"`
-	Status devicestatus.Status `json:"status"`
+	ID        string              `json:"id"`
+	Name      string              `json:"name"`
+	OS        string              `json:"os"`
+	OSVersion string              `json:"osVersion"`
+	Status    devicestatus.Status `json:"status"`
 }
 
 // Reader is the interface for retrieving available devices.

--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -1,16 +1,32 @@
 package devices
 
-import "context"
+import (
+	"context"
+	"github.com/saucelabs/saucectl/internal/devices/devicestatus"
+)
 
 // Device describes a real device that can be used to run tests.
 type Device struct {
-	Name string
-	OS   string
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	OS   string `json:"os"`
+}
+
+type DeviceStatus struct {
+	ID              string
+	Status          devicestatus.Status
+	InUseBy         []string
+	IsPrivateDevice bool
 }
 
 // Reader is the interface for retrieving available devices.
 type Reader interface {
 	GetDevices(ctx context.Context) ([]Device, error)
+}
+
+// StatusReader is the interface for retrieving available devices' statuses.
+type StatusReader interface {
+	GetDevicesStatuses(ctx context.Context) ([]DeviceStatus, error)
 }
 
 // ByOSReader is the interface for retrieving available devices by OS.

--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -2,6 +2,7 @@ package devices
 
 import (
 	"context"
+	
 	"github.com/saucelabs/saucectl/internal/devices/devicestatus"
 )
 

--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -20,6 +20,13 @@ type DeviceStatus struct {
 	IsPrivateDevice bool
 }
 
+type DeviceWithStatus struct {
+	ID     string              `json:"id"`
+	Name   string              `json:"name"`
+	OS     string              `json:"os"`
+	Status devicestatus.Status `json:"status"`
+}
+
 // Reader is the interface for retrieving available devices.
 type Reader interface {
 	GetDevices(ctx context.Context) ([]Device, error)
@@ -28,6 +35,7 @@ type Reader interface {
 // StatusReader is the interface for retrieving available devices' statuses.
 type StatusReader interface {
 	GetDevicesStatuses(ctx context.Context) ([]DeviceStatus, error)
+	GetDevicesWithStatuses(ctx context.Context) ([]DeviceWithStatus, error)
 }
 
 // ByOSReader is the interface for retrieving available devices by OS.

--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -10,5 +10,10 @@ type Device struct {
 
 // Reader is the interface for retrieving available devices.
 type Reader interface {
-	GetDevices(ctx context.Context, OS string) ([]Device, error)
+	GetDevices(ctx context.Context) ([]Device, error)
+}
+
+// ByOSReader is the interface for retrieving available devices by OS.
+type ByOSReader interface {
+	GetDevicesByOS(ctx context.Context, OS string) ([]Device, error)
 }

--- a/internal/devices/devicestatus/devicestatus.go
+++ b/internal/devices/devicestatus/devicestatus.go
@@ -9,22 +9,22 @@ type Status string
 
 const (
 	Unknown     Status = "UNKNOWN"
-	Available          = "AVAILABLE"
-	InUse              = "IN_USE"
-	Cleaning           = "CLEANING"
-	Maintenance        = "MAINTENANCE"
-	Rebooting          = "REBOOTING"
-	Offline            = "OFFLINE"
+	Available   Status = "AVAILABLE"
+	InUse       Status = "IN_USE"
+	Cleaning    Status = "CLEANING"
+	Maintenance Status = "MAINTENANCE"
+	Rebooting   Status = "REBOOTING"
+	Offline     Status = "OFFLINE"
 )
 
 var stringToStatusMap = map[string]Status{
-	string(Unknown): Unknown,
-	Available:       Available,
-	InUse:           InUse,
-	Cleaning:        Cleaning,
-	Maintenance:     Maintenance,
-	Rebooting:       Rebooting,
-	Offline:         Offline,
+	string(Unknown):     Unknown,
+	string(Available):   Available,
+	string(InUse):       InUse,
+	string(Cleaning):    Cleaning,
+	string(Maintenance): Maintenance,
+	string(Rebooting):   Rebooting,
+	string(Offline):     Offline,
 }
 
 func Make(str string) (Status, error) {

--- a/internal/devices/devicestatus/devicestatus.go
+++ b/internal/devices/devicestatus/devicestatus.go
@@ -1,49 +1,41 @@
 package devicestatus
 
-import "fmt"
-
-type Status int
-
-const (
-	Available Status = iota
-	InUse
-	Cleaning
-	Maintenance
-	Rebooting
-	Offline
+import (
+	"fmt"
+	"strings"
 )
 
-var statusToStringMap = map[Status]string{
-	Available:   "AVAILABLE",
-	InUse:       "IN_USE",
-	Cleaning:    "CLEANING",
-	Maintenance: "MAINTENANCE",
-	Rebooting:   "REBOOTING",
-	Offline:     "OFFLINE",
-}
+type Status string
+
+const (
+	Unknown     Status = "UNKNOWN"
+	Available          = "AVAILABLE"
+	InUse              = "IN_USE"
+	Cleaning           = "CLEANING"
+	Maintenance        = "MAINTENANCE"
+	Rebooting          = "REBOOTING"
+	Offline            = "OFFLINE"
+)
 
 var stringToStatusMap = map[string]Status{
-	"AVAILABLE":   Available,
-	"IN_USE":      InUse,
-	"CLEANING":    Cleaning,
-	"MAINTENANCE": Maintenance,
-	"REBOOTING":   Rebooting,
-	"OFFLINE":     Offline,
+	string(Unknown): Unknown,
+	Available:       Available,
+	InUse:           InUse,
+	Cleaning:        Cleaning,
+	Maintenance:     Maintenance,
+	Rebooting:       Rebooting,
+	Offline:         Offline,
 }
 
-func StrToStatus(status string) (Status, error) {
-	c, ok := stringToStatusMap[status]
+func Make(str string) (Status, error) {
+	c, ok := stringToStatusMap[strings.ToUpper(str)]
 	if !ok {
-		return c, fmt.Errorf("unknown status %s", status)
+		return c, fmt.Errorf("unknown status %s", str)
 	}
 
 	return c, nil
 }
 
-func StatusToStr(ds Status) string {
-	return statusToStringMap[ds]
-}
-
 func (ds Status) String() string {
-	return StatusToStr(ds)
+	return string(ds)
 }

--- a/internal/devices/devicestatus/devicestatus.go
+++ b/internal/devices/devicestatus/devicestatus.go
@@ -1,0 +1,49 @@
+package devicestatus
+
+import "fmt"
+
+type Status int
+
+const (
+	Available Status = iota
+	InUse
+	Cleaning
+	Maintenance
+	Rebooting
+	Offline
+)
+
+var statusToStringMap = map[Status]string{
+	Available:   "AVAILABLE",
+	InUse:       "IN_USE",
+	Cleaning:    "CLEANING",
+	Maintenance: "MAINTENANCE",
+	Rebooting:   "REBOOTING",
+	Offline:     "OFFLINE",
+}
+
+var stringToStatusMap = map[string]Status{
+	"AVAILABLE":   Available,
+	"IN_USE":      InUse,
+	"CLEANING":    Cleaning,
+	"MAINTENANCE": Maintenance,
+	"REBOOTING":   Rebooting,
+	"OFFLINE":     Offline,
+}
+
+func StrToStatus(status string) (Status, error) {
+	c, ok := stringToStatusMap[status]
+	if !ok {
+		return c, fmt.Errorf("unknown status %s", status)
+	}
+
+	return c, nil
+}
+
+func StatusToStr(ds Status) string {
+	return statusToStringMap[ds]
+}
+
+func (ds Status) String() string {
+	return StatusToStr(ds)
+}

--- a/internal/http/rdcservice.go
+++ b/internal/http/rdcservice.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/saucelabs/saucectl/internal/devices/devicestatus"
 	"io"
 	"net/http"
 	"strings"
@@ -18,6 +17,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 
 	"github.com/saucelabs/saucectl/internal/devices"
+	"github.com/saucelabs/saucectl/internal/devices/devicestatus"
 	"github.com/saucelabs/saucectl/internal/espresso"
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/xcuitest"

--- a/internal/http/rdcservice.go
+++ b/internal/http/rdcservice.go
@@ -405,8 +405,29 @@ func (c *RDCService) Artifact(ctx context.Context, jobID, fileName string, realD
 	return io.ReadAll(resp.Body)
 }
 
-// GetDevices returns the list of available devices using a specific operating system.
-func (c *RDCService) GetDevices(ctx context.Context, OS string) ([]devices.Device, error) {
+func (c *RDCService) GetDevices(ctx context.Context) ([]devices.Device, error) {
+	req, err := NewRetryableRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/rdc/devices", c.URL), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(c.Username, c.AccessKey)
+
+	res, err := c.Client.Do(req)
+	if err != nil {
+		return []devices.Device{}, err
+	}
+
+	var resp []devices.Device
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return []devices.Device{}, err
+	}
+
+	return resp, nil
+}
+
+// GetDevicesByOS returns the list of available devices using a specific operating system.
+func (c *RDCService) GetDevicesByOS(ctx context.Context, OS string) ([]devices.Device, error) {
 	req, err := NewRetryableRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/rdc/devices/filtered", c.URL), nil)
 	if err != nil {
 		return nil, err

--- a/internal/http/rdcservice.go
+++ b/internal/http/rdcservice.go
@@ -504,10 +504,11 @@ func (c *RDCService) GetDevicesWithStatuses(ctx context.Context) ([]devices.Devi
 		}
 
 		result = append(result, devices.DeviceWithStatus{
-			ID:     dev.ID,
-			Name:   dev.Name,
-			OS:     dev.OS,
-			Status: status,
+			ID:        dev.ID,
+			Name:      dev.Name,
+			OS:        dev.OS,
+			OSVersion: dev.OSVersion,
+			Status:    status,
 		})
 	}
 
@@ -533,8 +534,9 @@ func (c *RDCService) GetDevicesByOS(ctx context.Context, OS string) ([]devices.D
 
 	var resp struct {
 		Entities []struct {
-			Name string
-			OS   string
+			Name      string
+			OS        string
+			OSVersion string
 		}
 	}
 	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
@@ -544,8 +546,9 @@ func (c *RDCService) GetDevicesByOS(ctx context.Context, OS string) ([]devices.D
 	var dev []devices.Device
 	for _, d := range resp.Entities {
 		dev = append(dev, devices.Device{
-			Name: d.Name,
-			OS:   d.OS,
+			Name:      d.Name,
+			OS:        d.OS,
+			OSVersion: d.OSVersion,
 		})
 	}
 	return dev, nil

--- a/internal/http/rdcservice_test.go
+++ b/internal/http/rdcservice_test.go
@@ -402,9 +402,17 @@ func TestRDCService_GetDevicesByOS(t *testing.T) {
 		completeQuery := fmt.Sprintf("%s?%s", r.URL.Path, r.URL.RawQuery)
 		switch completeQuery {
 		case "/v1/rdc/devices/filtered?os=ANDROID":
-			_, err = w.Write([]byte(`{"entities":[{"name": "OnePlus 5T"},{"name": "OnePlus 6"},{"name": "OnePlus 6T"}]}`))
+			_, err = w.Write([]byte(`{"entities":[
+				{"name": "OnePlus 5T", "os": "ANDROID", "osVersion": "10.0"},
+				{"name": "OnePlus 6", "os": "ANDROID", "osVersion": "10.0"},
+				{"name": "OnePlus 6T", "os": "ANDROID", "osVersion": "10.0"}
+			]}`))
 		case "/v1/rdc/devices/filtered?os=IOS":
-			_, err = w.Write([]byte(`{"entities":[{"name": "iPhone XR"},{"name": "iPhone XS"},{"name": "iPhone X"}]}`))
+			_, err = w.Write([]byte(`{"entities":[
+				{"name": "iPhone XR", "os": "IOS", "osVersion": "10.0"},
+				{"name": "iPhone XS", "os": "IOS", "osVersion": "10.0"},
+				{"name": "iPhone X", "os": "IOS", "osVersion": "10.0"}
+			]}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -440,9 +448,9 @@ func TestRDCService_GetDevicesByOS(t *testing.T) {
 				OS:  "ANDROID",
 			},
 			want: []devices.Device{
-				{Name: "OnePlus 5T"},
-				{Name: "OnePlus 6"},
-				{Name: "OnePlus 6T"},
+				{Name: "OnePlus 5T", OS: "ANDROID", OSVersion: "10.0"},
+				{Name: "OnePlus 6", OS: "ANDROID", OSVersion: "10.0"},
+				{Name: "OnePlus 6T", OS: "ANDROID", OSVersion: "10.0"},
 			},
 			wantErr: false,
 		},
@@ -453,9 +461,9 @@ func TestRDCService_GetDevicesByOS(t *testing.T) {
 				OS:  "IOS",
 			},
 			want: []devices.Device{
-				{Name: "iPhone XR"},
-				{Name: "iPhone XS"},
-				{Name: "iPhone X"},
+				{Name: "iPhone XR", OS: "IOS", OSVersion: "10.0"},
+				{Name: "iPhone XS", OS: "IOS", OSVersion: "10.0"},
+				{Name: "iPhone X", OS: "IOS", OSVersion: "10.0"},
 			},
 			wantErr: false,
 		},
@@ -477,7 +485,14 @@ func TestRDCService_GetDevicesByOS(t *testing.T) {
 func TestRDCService_GetDevices(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		var err error
-		_, err = w.Write([]byte(`[{"name": "OnePlus 5T"},{"name": "OnePlus 6"},{"name": "OnePlus 6T"},{"name": "iPhone XR"},{"name": "iPhone XS"},{"name": "iPhone X"}]`))
+		_, err = w.Write([]byte(`[
+			{"name": "OnePlus 5T", "os": "ANDROID", "osVersion": "10.0"},
+			{"name": "OnePlus 6", "os": "ANDROID", "osVersion": "10.0"},
+			{"name": "OnePlus 6T", "os": "ANDROID", "osVersion": "10.0"},
+			{"name": "iPhone XR", "os": "IOS", "osVersion": "10.0"},
+			{"name": "iPhone XS", "os": "IOS", "osVersion": "10.0"},
+			{"name": "iPhone X", "os": "IOS", "osVersion": "10.0"}
+		]`))
 		if err != nil {
 			t.Errorf("failed to respond: %v", err)
 		}
@@ -495,12 +510,12 @@ func TestRDCService_GetDevices(t *testing.T) {
 
 	ctx := context.Background()
 	want := []devices.Device{
-		{Name: "OnePlus 5T"},
-		{Name: "OnePlus 6"},
-		{Name: "OnePlus 6T"},
-		{Name: "iPhone XR"},
-		{Name: "iPhone XS"},
-		{Name: "iPhone X"},
+		{Name: "OnePlus 5T", OS: "ANDROID", OSVersion: "10.0"},
+		{Name: "OnePlus 6", OS: "ANDROID", OSVersion: "10.0"},
+		{Name: "OnePlus 6T", OS: "ANDROID", OSVersion: "10.0"},
+		{Name: "iPhone XR", OS: "IOS", OSVersion: "10.0"},
+		{Name: "iPhone XS", OS: "IOS", OSVersion: "10.0"},
+		{Name: "iPhone X", OS: "IOS", OSVersion: "10.0"},
 	}
 
 	got, err := cl.GetDevices(ctx)

--- a/internal/http/rdcservice_test.go
+++ b/internal/http/rdcservice_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/saucelabs/saucectl/internal/devices/devicestatus"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/saucelabs/saucectl/internal/devices"
+	"github.com/saucelabs/saucectl/internal/devices/devicestatus"
 	"github.com/saucelabs/saucectl/internal/job"
 	"github.com/saucelabs/saucectl/internal/region"
 	"github.com/stretchr/testify/assert"
@@ -475,7 +475,7 @@ func TestRDCService_GetDevicesByOS(t *testing.T) {
 }
 
 func TestRDCService_GetDevices(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		var err error
 		_, err = w.Write([]byte(`[{"name": "OnePlus 5T"},{"name": "OnePlus 6"},{"name": "OnePlus 6T"},{"name": "iPhone XR"},{"name": "iPhone XS"},{"name": "iPhone X"}]`))
 		if err != nil {
@@ -491,10 +491,6 @@ func TestRDCService_GetDevices(t *testing.T) {
 		URL:       ts.URL,
 		Username:  "dummy-user",
 		AccessKey: "dummy-key",
-	}
-	type args struct {
-		ctx context.Context
-		OS  string
 	}
 
 	ctx := context.Background()
@@ -518,7 +514,7 @@ func TestRDCService_GetDevices(t *testing.T) {
 }
 
 func TestRDCService_GetDevicesStatuses(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		var err error
 		_, err = w.Write([]byte(`{"devices":[
 			{"descriptor": "OnePlus 5T","state":"AVAILABLE"},
@@ -541,10 +537,6 @@ func TestRDCService_GetDevicesStatuses(t *testing.T) {
 		URL:       ts.URL,
 		Username:  "dummy-user",
 		AccessKey: "dummy-key",
-	}
-	type args struct {
-		ctx context.Context
-		OS  string
 	}
 
 	ctx := context.Background()

--- a/internal/mocks/devices.go
+++ b/internal/mocks/devices.go
@@ -6,12 +6,12 @@ import (
 	"github.com/saucelabs/saucectl/internal/devices"
 )
 
-// FakeDevicesReader is a mock for the devices.Reader interface.
+// FakeDevicesReader is a mock for the devices.ByOSReader interface.
 type FakeDevicesReader struct {
 	GetDevicesFn func(context.Context, string) ([]devices.Device, error)
 }
 
-// GetDevices is a wrapper around GetDevicesFn.
-func (fdr *FakeDevicesReader) GetDevices(ctx context.Context, OS string) ([]devices.Device, error) {
+// GetDevicesByOS is a wrapper around GetDevicesFn.
+func (fdr *FakeDevicesReader) GetDevicesByOS(ctx context.Context, OS string) ([]devices.Device, error) {
 	return fdr.GetDevicesFn(ctx, OS)
 }


### PR DESCRIPTION
## Description

Adds `devices list` command:

```sh
$ saucectl devices list  --help
Returns the list of devices

Usage:
  saucectl devices list [flags]

Aliases:
  list, ls

Flags:
  -h, --help                help for list
  -n, --name string         Filter devices by name.
      --os string           Filter devices by OS.
      --os-version string   Filter devices by OS version. Accepts semver ranges.
  -o, --out string          OutputFormat format to the console. Options: text, json. (default "text")
      --status string       Filter devices by status. Implies --statuses if not set.
      --statuses            Fetch status for devices.

Global Flags:
      --disable-usage-metrics   Disable usage metrics collection.
      --no-color                disable colorized output
  -r, --region string           The Sauce Labs region. Options: us-west-1, eu-central-1. (default "us-west-1")
      --verbose                 turn on verbose logging
```

Sample output:

```sh
$ saucectl devices list                                              
 Name                             OS       OS Version 
──────────────────────────────────────────────────────
 iPhone 12 mini                   IOS      17.7       
 Google Pixel 9 Pro XL            ANDROID  15         
 iPad Pro 11 2024                 IOS      17.6.1     
──────────────────────────────────────────────────────
 showing 298 devices  
```

```sh
$ saucectl devices list --status available --os-version ">=15" --os ios
 Name                            OS   OS Version  Status    
────────────────────────────────────────────────────────────
 iPhone 12 mini                  IOS  17.7        AVAILABLE 
 iPad Pro 11 2024                IOS  17.6.1      AVAILABLE 
 iPhone 13                       IOS  17.7        AVAILABLE 
────────────────────────────────────────────────────────────
 showing 101 devices                                        
```