### PR TITLE
chore: Remove deprecated feature

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -417,28 +417,6 @@
                   "13.6.6"
                 ],
                 "description": "Which framework version to use."
-              },
-              "reporters": {
-                "description": "Set of reporter to use.",
-                "type": "array",
-                "minimum": 0,
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "description": "Name of the reporter. You may have to install the associated npm dependency through npm.packages field.",
-                      "type": "string",
-                      "examples": [
-                        "dot",
-                        "nyan"
-                      ]
-                    },
-                    "options": {
-                      "description": "Options to pass to the reporter."
-                    }
-                  },
-                  "additionalProperties": false
-                }
               }
             },
             "required": [

--- a/api/v1/framework/cypress.schema.json
+++ b/api/v1/framework/cypress.schema.json
@@ -79,28 +79,6 @@
             "13.7.3",
             "13.6.6"
           ]
-        },
-        "reporters": {
-          "description": "Set of reporter to use.",
-          "type": "array",
-          "minimum": 0,
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "description": "Name of the reporter. You may have to install the associated npm dependency through npm.packages field.",
-                "type": "string",
-                "examples": [
-                  "dot",
-                  "nyan"
-                ]
-              },
-              "options": {
-                "description": "Options to pass to the reporter."
-              }
-            },
-            "additionalProperties": false
-          }
         }
       },
       "required": [

--- a/internal/cypress/v1/config.go
+++ b/internal/cypress/v1/config.go
@@ -80,12 +80,6 @@ type SuiteConfig struct {
 	Env                map[string]string `yaml:"env,omitempty" json:"env"`
 }
 
-// Reporter represents a cypress report configuration.
-type Reporter struct {
-	Name    string                 `yaml:"name" json:"name"`
-	Options map[string]interface{} `yaml:"options" json:"options"`
-}
-
 // Cypress represents crucial cypress configuration that is required for setting up a project.
 type Cypress struct {
 	// ConfigFile is the path to "cypress.json".
@@ -99,9 +93,6 @@ type Cypress struct {
 
 	// Key represents the cypress framework key flag.
 	Key string `yaml:"key" json:"key"`
-
-	// Reporters represents the customer reporters.
-	Reporters []Reporter `yaml:"reporters" json:"reporters"`
 }
 
 // FromFile creates a new cypress Project based on the filepath cfgPath.
@@ -234,10 +225,6 @@ func (p *Project) Validate() error {
 
 	if p.Sauce.LaunchOrder != "" && p.Sauce.LaunchOrder != config.LaunchOrderFailRate {
 		return fmt.Errorf(msg.InvalidLaunchingOption, p.Sauce.LaunchOrder, string(config.LaunchOrderFailRate))
-	}
-
-	if len(p.Cypress.Reporters) > 0 {
-		log.Warn().Msg("cypress.reporters has been deprecated. Migrate your reporting configuration to your cypress config file.")
 	}
 
 	// Validate suites.


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
cypress reporters should be setup with the user's cypress config. Supporting cypress reporters in saucectl config has been deprecated for a while, removing support here.

[INT-171]

[INT-171]: https://saucedev.atlassian.net/browse/INT-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ