### PR TITLE
[INT-168] playwright: escape test names before passing them to grep

### DIFF
--- a/internal/playwright/config.go
+++ b/internal/playwright/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 	"unicode"
@@ -466,7 +467,14 @@ func (p *Project) FilterFailedTests(suiteName string, report saucereport.SauceRe
 		if s.Name != suiteName {
 			continue
 		}
-		p.Suites[i].Params.Grep = strings.Join(failedTests, "|")
+
+		// Test names have to be escaped, they can contain regexp characters
+		var escapedTestNames []string
+		for _, testName := range failedTests {
+			escapedTestNames = append(escapedTestNames, regexp.QuoteMeta(testName))
+		}
+
+		p.Suites[i].Params.Grep = strings.Join(escapedTestNames, "|")
 		found = true
 		break
 	}


### PR DESCRIPTION
## Description

The test names could contain characters that are used by regular expressions, and were not escaped, such as:
```
[user tests] login test
```

This change makes sure to escape all tests names before passing them to the `grep` parameter.

Ref: https://saucedev.atlassian.net/browse/INT-168