### PR TITLE
[no-ticket] [e2e] use latest playwright version

### DIFF
--- a/tests/e2e/playwright-cucumberjs/.sauce/config.yml
+++ b/tests/e2e/playwright-cucumberjs/.sauce/config.yml
@@ -10,7 +10,7 @@ sauce:
 defaults:
   timeout: 5m
 playwright:
-  version: 1.41.0
+  version: 1.52.0
 rootDir: ./
 suites:
   - name: My Cucumber Test


### PR DESCRIPTION
## Description

`playwright-cucumber-js` used an obsolete version of `playwright`. This changes the version to the latest supported by Sauce.