### PR TITLE
[no-ticket] fix .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-brews:
+homebrew_casks:
   - repository:
       owner: saucelabs
       name: homebrew-saucectl


### PR DESCRIPTION
## Description
CICD seems to be failing because of a deprecated key in `.goreleaser.yml`: https://goreleaser.com/deprecations/#brews
