### PR TITLE
[INT-367] testcafe: fix invalid armRequired type

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -1755,7 +1755,7 @@
                 },
                 "armRequired": {
                   "description": "Specifies if ARM architecture is required to run this test.",
-                  "type": "string"
+                  "type": "boolean"
                 },
                 "compilerOptions": {
                   "description": "Specifies the typescript compiler options to be used when running the tests.",

--- a/api/v1alpha/framework/testcafe.schema.json
+++ b/api/v1alpha/framework/testcafe.schema.json
@@ -150,7 +150,7 @@
           },
           "armRequired": {
             "description": "Specifies if ARM architecture is required to run this test.",
-            "type": "string"
+            "type": "boolean"
           },
           "compilerOptions": {
             "description": "Specifies the typescript compiler options to be used when running the tests.",


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Changes `armRequired` type to `bool` instead of `string`.