### PR TITLE
[INT-438] testcafe: remove schema from platformName

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -1722,7 +1722,6 @@
                   "type": "boolean"
                 },
                 "platformName": {
-                  "$ref": "#/allOf/3/then/properties/suites/items/properties/platform",
                   "enum": [
                     "macOS 11.00",
                     "macOS 12",
@@ -1730,7 +1729,8 @@
                     "macOS 14",
                     "Windows 10",
                     "Windows 11"
-                  ]
+                  ],
+                  "description": "A specific operating system on which to run the tests. Sauce Labs will try to choose a reasonable default if not explicitly specified."
                 },
                 "assertionTimeout": {
                   "description": "Specifies the time (in milliseconds) TestCafe attempts to successfully execute an assertion if a selector property or a client function was passed as an actual value.",

--- a/api/v1alpha/framework/testcafe.schema.json
+++ b/api/v1alpha/framework/testcafe.schema.json
@@ -117,7 +117,6 @@
             "type": "boolean"
           },
           "platformName": {
-            "$ref": "../subschema/common.schema.json#/definitions/platformName",
             "enum": [
               "macOS 11.00",
               "macOS 12",
@@ -125,7 +124,8 @@
               "macOS 14",
               "Windows 10",
               "Windows 11"
-            ]
+            ],
+            "description": "A specific operating system on which to run the tests. Sauce Labs will try to choose a reasonable default if not explicitly specified."
           },
           "assertionTimeout": {
             "description": "Specifies the time (in milliseconds) TestCafe attempts to successfully execute an assertion if a selector property or a client function was passed as an actual value.",


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
`$ref` to another `platformName` was causing the TestCafe's `platformName` enum values to be ignored.
