### PR TITLE
updating logic for platform and browser version compatibility

### DIFF
--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -45,8 +45,9 @@ func (m *Metadata) IsFlaggedForRemoval() bool {
 
 // Platform represent a supported platform.
 type Platform struct {
-	PlatformName string
-	BrowserNames []string
+	PlatformName    string
+	BrowserNames    []string
+	BrowserDefaults map[string]string
 }
 
 // HasPlatform returns true if the provided Metadata has a matching platform.

--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -47,7 +47,7 @@ func (m *Metadata) IsFlaggedForRemoval() bool {
 type Platform struct {
 	PlatformName    string
 	BrowserNames    []string
-	BrowserDefaults map[string]string
+	BrowserDefaults map[string]string //TODO: Checking if this works out for maintaining multiple browser versions for the same playwright version
 }
 
 // HasPlatform returns true if the provided Metadata has a matching platform.

--- a/internal/http/testcomposer.go
+++ b/internal/http/testcomposer.go
@@ -35,7 +35,7 @@ type FrameworkResponse struct {
 	Platforms   []struct {
 		Name            string            `json:"name"`
 		Browsers        []string          `json:"browsers"`
-		BrowserDefaults map[string]string `json:"browserDefaults,omitempty"`
+		BrowserDefaults map[string]string `json:"browserDefaults,omitempty"` //TODO: Checking if this works out for maintaining multiple browser versions for the same playwright version
 	} `json:"platforms"`
 	BrowserDefaults map[string]string `json:"browserDefaults"`
 	Runtimes        []string          `json:"runtimes"`
@@ -183,7 +183,7 @@ func (c *TestComposer) Versions(ctx context.Context, frameworkName string) ([]fr
 			platforms = append(platforms, framework.Platform{
 				PlatformName:    p.Name,
 				BrowserNames:    p.Browsers,
-				BrowserDefaults: p.BrowserDefaults,
+				BrowserDefaults: p.BrowserDefaults, //TODO: Checking if this works out for maintaining multiple browser versions for the same playwright version
 			})
 		}
 		frameworks = append(frameworks, framework.Metadata{

--- a/internal/http/testcomposer.go
+++ b/internal/http/testcomposer.go
@@ -32,7 +32,7 @@ type FrameworkResponse struct {
 	EOLDate     time.Time `json:"eolDate"`
 	RemovalDate time.Time `json:"removalDate"`
 	Runner      runner    `json:"runner"`
-	Platforms []struct {
+	Platforms   []struct {
 		Name            string            `json:"name"`
 		Browsers        []string          `json:"browsers"`
 		BrowserDefaults map[string]string `json:"browserDefaults,omitempty"`

--- a/internal/http/testcomposer.go
+++ b/internal/http/testcomposer.go
@@ -32,9 +32,10 @@ type FrameworkResponse struct {
 	EOLDate     time.Time `json:"eolDate"`
 	RemovalDate time.Time `json:"removalDate"`
 	Runner      runner    `json:"runner"`
-	Platforms   []struct {
-		Name     string
-		Browsers []string
+	Platforms []struct {
+		Name            string            `json:"name"`
+		Browsers        []string          `json:"browsers"`
+		BrowserDefaults map[string]string `json:"browserDefaults,omitempty"`
 	} `json:"platforms"`
 	BrowserDefaults map[string]string `json:"browserDefaults"`
 	Runtimes        []string          `json:"runtimes"`
@@ -180,8 +181,9 @@ func (c *TestComposer) Versions(ctx context.Context, frameworkName string) ([]fr
 		var platforms []framework.Platform
 		for _, p := range f.Platforms {
 			platforms = append(platforms, framework.Platform{
-				PlatformName: p.Name,
-				BrowserNames: p.Browsers,
+				PlatformName:    p.Name,
+				BrowserNames:    p.Browsers,
+				BrowserDefaults: p.BrowserDefaults,
 			})
 		}
 		frameworks = append(frameworks, framework.Metadata{

--- a/internal/saucecloud/playwright.go
+++ b/internal/saucecloud/playwright.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/saucelabs/saucectl/internal/framework"
@@ -126,9 +127,26 @@ func (r *PlaywrightRunner) validateFramework(ctx context.Context, m framework.Me
 			msg.LogUnsupportedPlatform(s.PlatformName, framework.PlatformNames(m.Platforms))
 			return errors.New("unsupported platform")
 		}
-		r.Project.Suites[i].Params.BrowserVersion = m.BrowserDefaults[PlaywrightBrowserMap[s.Params.BrowserName]]
+		browserKey := PlaywrightBrowserMap[s.Params.BrowserName]
+		r.Project.Suites[i].Params.BrowserVersion = r.resolveBrowserVersion(m, s.PlatformName, browserKey)
 	}
 	return nil
+}
+
+// resolveBrowserVersion returns the browser version for a given platform and browser key.
+// It checks per-platform browserDefaults first, then falls back to the top-level defaults.
+func (r *PlaywrightRunner) resolveBrowserVersion(m framework.Metadata, platformName, browserKey string) string {
+	if platformName != "" {
+		for _, p := range m.Platforms {
+			if strings.EqualFold(p.PlatformName, platformName) && p.BrowserDefaults != nil {
+				if v, ok := p.BrowserDefaults[browserKey]; ok {
+					return v
+				}
+				break
+			}
+		}
+	}
+	return m.BrowserDefaults[browserKey]
 }
 
 func (r *PlaywrightRunner) getSuiteNames() []string {

--- a/internal/saucecloud/playwright_test.go
+++ b/internal/saucecloud/playwright_test.go
@@ -3,9 +3,80 @@ package saucecloud
 import (
 	"testing"
 
+	"github.com/saucelabs/saucectl/internal/framework"
 	"github.com/saucelabs/saucectl/internal/playwright"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestResolveBrowserVersion(t *testing.T) {
+	meta := framework.Metadata{
+		Platforms: []framework.Platform{
+			{
+				PlatformName: "macos 13",
+				BrowserNames: []string{"playwright-chromium", "playwright-firefox", "playwright-webkit"},
+				BrowserDefaults: map[string]string{
+					"playwright-webkit": "18.4",
+				},
+			},
+			{
+				PlatformName: "macos 15",
+				BrowserNames: []string{"playwright-chromium", "playwright-firefox", "playwright-webkit"},
+			},
+		},
+		BrowserDefaults: map[string]string{
+			"playwright-chromium": "145.0.7632.6.",
+			"playwright-firefox":  "146.0.1",
+			"playwright-webkit":   "26.0.",
+		},
+	}
+
+	r := &PlaywrightRunner{Project: &playwright.Project{}}
+
+	tests := []struct {
+		name       string
+		platform   string
+		browserKey string
+		expected   string
+	}{
+		{
+			name:       "per-platform override for webkit on macos 13",
+			platform:   "macos 13",
+			browserKey: "playwright-webkit",
+			expected:   "18.4",
+		},
+		{
+			name:       "fallback to top-level for webkit on macos 15 (no per-platform default)",
+			platform:   "macos 15",
+			browserKey: "playwright-webkit",
+			expected:   "26.0.",
+		},
+		{
+			name:       "fallback to top-level for chromium on macos 13 (not overridden)",
+			platform:   "macos 13",
+			browserKey: "playwright-chromium",
+			expected:   "145.0.7632.6.",
+		},
+		{
+			name:       "case-insensitive platform match",
+			platform:   "Macos 13",
+			browserKey: "playwright-webkit",
+			expected:   "18.4",
+		},
+		{
+			name:       "empty platform falls back to top-level",
+			platform:   "",
+			browserKey: "playwright-webkit",
+			expected:   "26.0.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := r.resolveBrowserVersion(meta, tt.platform, tt.browserKey)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
 
 func TestPlaywright_GetSuiteNames(t *testing.T) {
 	runner := &PlaywrightRunner{


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
⏺ Summary                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                            
  - Support per-platform browserDefaults from the framework info API, enabling different browser versions per OS (e.g., webkit 18.4 on macOS 13 vs 26.0. on macOS 15)                                                                                                                                                       
  - When resolving browser version for a Playwright suite, check the suite's target platform for an override first, then fall back to the top-level browserDefaults
  - This allows test-composer to pin older browser versions on platforms where newer builds aren't compatible, without affecting other platforms 
