### PR TITLE
adding macos 26 support for playwright tests

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -1366,6 +1366,7 @@
                     "macOS 13",
                     "macOS 14",
                     "macOS 15",
+                    "macOS 26",
                     "Windows 10",
                     "Windows 11"
                   ]
@@ -1732,6 +1733,7 @@
                     "macOS 13",
                     "macOS 14",
                     "macOS 15",
+                    "macOS 26",
                     "Windows 10",
                     "Windows 11"
                   ],
@@ -2796,6 +2798,7 @@
                     "macOS 13",
                     "macOS 14",
                     "macOS 15",
+                    "macOS 26",
                     "Windows 10",
                     "Windows 11"
                   ]

--- a/api/v1alpha/framework/playwright-cucumberjs.schema.json
+++ b/api/v1alpha/framework/playwright-cucumberjs.schema.json
@@ -82,6 +82,7 @@
               "macOS 13",
               "macOS 14",
               "macOS 15",
+              "macOS 26",
               "Windows 10",
               "Windows 11"
             ]

--- a/api/v1alpha/framework/playwright.schema.json
+++ b/api/v1alpha/framework/playwright.schema.json
@@ -104,6 +104,7 @@
               "macOS 13",
               "macOS 14",
               "macOS 15",
+              "macOS 26",
               "Windows 10",
               "Windows 11"
             ]

--- a/api/v1alpha/framework/testcafe.schema.json
+++ b/api/v1alpha/framework/testcafe.schema.json
@@ -123,6 +123,7 @@
               "macOS 13",
               "macOS 14",
               "macOS 15",
+              "macOS 26",
               "Windows 10",
               "Windows 11"
             ],


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
Adding macos 26 support for playwright testing.
