### PR TITLE
fix: preserve XCUITest class filter on VDC smart retry when JUnit has no failures

### DIFF
--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -78,9 +78,13 @@ func setClassesToRetry(opt *job.StartOptions, testcases []junit.TestCase) []stri
 		tests := getFailedXCUITests(testcases, opt.RealDevice)
 
 		// RDC and VDC API filter use different fields for test filtering.
+		// Only overwrite the existing class filter when there are actual failures to retry.
+		// If tests is empty (e.g. the previous attempt produced a JUnit with no <failure>
+		// elements), preserving the original filter avoids sending a session with no test
+		// filter at all, which would run the entire test bundle.
 		if opt.RealDevice {
 			opt.TestsToRun = tests
-		} else {
+		} else if len(tests) > 0 {
 			opt.TestOptions["class"] = tests
 		}
 

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -92,7 +92,9 @@ func setClassesToRetry(opt *job.StartOptions, testcases []junit.TestCase) []stri
 	}
 
 	tests := getFailedEspressoTests(testcases)
-	opt.TestOptions["class"] = tests
+	if len(tests) > 0 {
+		opt.TestOptions["class"] = tests
+	}
 
 	return tests
 }

--- a/internal/saucecloud/retry/junitretrier_test.go
+++ b/internal/saucecloud/retry/junitretrier_test.go
@@ -245,6 +245,94 @@ func TestAppsRetrier_Retry(t *testing.T) {
 			},
 		},
 		{
+			name: "XCUITest: VDC retries only failed tests when JUnit has failures + SmartRetry",
+			init: init{
+				JobService: &mocks.FakeJobService{
+					GetJobAssetFileContentFn: func(_ context.Context, jobID, fileName string) ([]byte, error) {
+						if jobID == "fake-job-id" && fileName == junit.FileName {
+							return []byte("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<testsuite>\n    <testcase name=\"testLogin\" classname=\"SampleApp.AuthTests\">\n        <failure>Test failed</failure>\n    </testcase>\n    <testcase name=\"testLogout\" classname=\"SampleApp.AuthTests\"/>\n</testsuite>\n"), nil
+						}
+						return []byte{}, errors.New("unknown file")
+					},
+				},
+				RetryVDC: true,
+			},
+			args: args{
+				jobOpts: make(chan job.StartOptions),
+				opt: job.StartOptions{
+					Framework:   xcuitest.Kind,
+					DisplayName: "Dummy Test",
+					SmartRetry: job.SmartRetry{
+						FailedOnly: true,
+					},
+					TestOptions: map[string]interface{}{
+						"class": []string{"SampleApp/AuthTests/testLogin"},
+					},
+				},
+				previous: job.Job{
+					ID:    "fake-job-id",
+					IsRDC: false,
+				},
+			},
+			expected: job.StartOptions{
+				Framework:   xcuitest.Kind,
+				DisplayName: "Dummy Test",
+				TestOptions: map[string]interface{}{
+					"class": []string{"SampleApp/AuthTests/testLogin"},
+				},
+				SmartRetry: job.SmartRetry{
+					FailedOnly: true,
+				},
+			},
+		},
+		{
+			// Regression test: when a VDC XCUITest job fails but the JUnit has no <failure>
+			// elements (e.g. silent crash), the original class filter must be preserved.
+			// Previously, setClassesToRetry unconditionally overwrote opt.TestOptions["class"]
+			// with an empty slice, causing the VDC to run the entire test bundle without filters.
+			name: "XCUITest: VDC preserves original class filter when JUnit has no failures + SmartRetry",
+			init: init{
+				JobService: &mocks.FakeJobService{
+					GetJobAssetFileContentFn: func(_ context.Context, jobID, fileName string) ([]byte, error) {
+						if jobID == "fake-job-id" && fileName == junit.FileName {
+							// Valid JUnit with test cases but no <failure> or <error> elements.
+							return []byte("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<testsuite>\n    <testcase name=\"testCheckout\" classname=\"SampleApp.CartTests\"/>\n</testsuite>\n"), nil
+						}
+						return []byte{}, errors.New("unknown file")
+					},
+				},
+				RetryVDC: true,
+			},
+			args: args{
+				jobOpts: make(chan job.StartOptions),
+				opt: job.StartOptions{
+					Framework:   xcuitest.Kind,
+					DisplayName: "Dummy Test",
+					SmartRetry: job.SmartRetry{
+						FailedOnly: true,
+					},
+					TestOptions: map[string]interface{}{
+						"class": []string{"SampleApp/CartTests/testCheckout"},
+					},
+				},
+				previous: job.Job{
+					ID:    "fake-job-id",
+					IsRDC: false,
+				},
+			},
+			expected: job.StartOptions{
+				Framework:   xcuitest.Kind,
+				DisplayName: "Dummy Test",
+				// The original single-test filter must survive the retry unchanged.
+				TestOptions: map[string]interface{}{
+					"class": []string{"SampleApp/CartTests/testCheckout"},
+				},
+				SmartRetry: job.SmartRetry{
+					FailedOnly: true,
+				},
+			},
+		},
+		{
 			name: "Base Retry if junit is malformed",
 			init: init{
 				JobService: &mocks.FakeJobService{

--- a/internal/saucecloud/retry/junitretrier_test.go
+++ b/internal/saucecloud/retry/junitretrier_test.go
@@ -245,6 +245,49 @@ func TestAppsRetrier_Retry(t *testing.T) {
 			},
 		},
 		{
+			// Regression test: when a VDC Espresso job fails but the JUnit has no <failure>
+			// elements (e.g. silent crash), the original class filter must be preserved.
+			name: "Espresso: VDC preserves original class filter when JUnit has no failures + SmartRetry",
+			init: init{
+				JobService: &mocks.FakeJobService{
+					GetJobAssetFileContentFn: func(_ context.Context, jobID, fileName string) ([]byte, error) {
+						if jobID == "fake-job-id" && fileName == junit.FileName {
+							return []byte("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<testsuite>\n    <testcase classname=\"Demo.Class1\"/>\n    <testcase classname=\"Demo.Class2\"/>\n</testsuite>\n"), nil
+						}
+						return []byte{}, errors.New("unknown file")
+					},
+				},
+				RetryVDC: true,
+			},
+			args: args{
+				jobOpts: make(chan job.StartOptions),
+				opt: job.StartOptions{
+					Framework:   espresso.Kind,
+					DisplayName: "Dummy Test",
+					SmartRetry: job.SmartRetry{
+						FailedOnly: true,
+					},
+					TestOptions: map[string]interface{}{
+						"class": []string{"Demo.Class1", "Demo.Class2"},
+					},
+				},
+				previous: job.Job{
+					ID:    "fake-job-id",
+					IsRDC: false,
+				},
+			},
+			expected: job.StartOptions{
+				Framework:   espresso.Kind,
+				DisplayName: "Dummy Test",
+				TestOptions: map[string]interface{}{
+					"class": []string{"Demo.Class1", "Demo.Class2"},
+				},
+				SmartRetry: job.SmartRetry{
+					FailedOnly: true,
+				},
+			},
+		},
+		{
 			name: "XCUITest: VDC retries only failed tests when JUnit has failures + SmartRetry",
 			init: init{
 				JobService: &mocks.FakeJobService{


### PR DESCRIPTION
## Description

When smartRetry.failedOnly is enabled, and a previous attempt's JUnit contains no <failure> or <error> elements (e.g., a silent crash or an infrastructure error), setClassesToRetry unconditionally overwrites opt.TestOptions["class"] with an empty slice. This caused the class arg to be dropped from the API request, so xcodebuild ran the entire test bundle without any -only-testing filters.

The fix adds a len(tests) > 0 guard so the original single-test class filter set at sharding time is preserved when no failures are found.


