### PR TITLE
fix: skip Espresso smart retry for non-Java classnames (Cucumber-on-E…

### DIFF
--- a/internal/msg/errormsg.go
+++ b/internal/msg/errormsg.go
@@ -177,7 +177,7 @@ const (
 	// SkippingSmartRetries implies that all tests will be retried.
 	SkippingSmartRetries = "Skipping SmartRetry. Retrying all tests from the previous job."
 	// SmartRetryUnsupportedClassnames indicates that JUnit classnames are not valid Java identifiers.
-	SmartRetryUnsupportedClassnames = "SmartRetry failedOnly is not supported for this test framework (e.g. Cucumber-on-Espresso). The retry will run the full suite."
+	SmartRetryUnsupportedClassnames = "SmartRetry failedOnly is not supported for Cucumber-on-Espresso. Failed tests with non-Java classnames cannot be retried individually and will be excluded from the retry filter."
 	// RetryWithTests indicates which tests will be run
 	RetryWithTests = "Retrying with failed tests: %q"
 	// UnableToCreateRunnerConfig indicates a failure to create runner config file

--- a/internal/msg/errormsg.go
+++ b/internal/msg/errormsg.go
@@ -176,6 +176,8 @@ const (
 	UnableToUnmarshallFile = "Unable to unmarshall file '%s'"
 	// SkippingSmartRetries implies that all tests will be retried.
 	SkippingSmartRetries = "Skipping SmartRetry. Retrying all tests from the previous job."
+	// SmartRetryUnsupportedClassnames indicates that JUnit classnames are not valid Java identifiers.
+	SmartRetryUnsupportedClassnames = "SmartRetry failedOnly is not supported for Cucumber-on-Espresso. Falling back to a full retry."
 	// RetryWithTests indicates which tests will be run
 	RetryWithTests = "Retrying with failed tests: %q"
 	// UnableToCreateRunnerConfig indicates a failure to create runner config file

--- a/internal/msg/errormsg.go
+++ b/internal/msg/errormsg.go
@@ -177,7 +177,7 @@ const (
 	// SkippingSmartRetries implies that all tests will be retried.
 	SkippingSmartRetries = "Skipping SmartRetry. Retrying all tests from the previous job."
 	// SmartRetryUnsupportedClassnames indicates that JUnit classnames are not valid Java identifiers.
-	SmartRetryUnsupportedClassnames = "SmartRetry failedOnly is not supported for Cucumber-on-Espresso. Falling back to a full retry."
+	SmartRetryUnsupportedClassnames = "SmartRetry failedOnly is not supported for this test framework (e.g. Cucumber-on-Espresso). The retry will run the full suite."
 	// RetryWithTests indicates which tests will be run
 	RetryWithTests = "Retrying with failed tests: %q"
 	// UnableToCreateRunnerConfig indicates a failure to create runner config file

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -145,11 +145,11 @@ func conformXCUITestClassName(name string, rdc bool) string {
 // "am instrument -e class" filter only accepts real class identifiers.
 func getFailedEspressoTests(testCases []junit.TestCase) []string {
 	classes := map[string]bool{}
-	var skippedClassnames []string
+	skipped := map[string]struct{}{}
 	for _, tc := range testCases {
 		if tc.Error != nil || tc.Failure != nil {
 			if !isJavaClassName(tc.ClassName) {
-				skippedClassnames = append(skippedClassnames, tc.ClassName)
+				skipped[tc.ClassName] = struct{}{}
 				continue
 			}
 			if tc.Name != "" {
@@ -159,10 +159,10 @@ func getFailedEspressoTests(testCases []junit.TestCase) []string {
 			}
 		}
 	}
-	if len(skippedClassnames) > 0 {
+	if len(skipped) > 0 {
 		log.Warn().
-			Int("skipped", len(skippedClassnames)).
-			Strs("classnames", skippedClassnames).
+			Int("skipped", len(skipped)).
+			Strs("classnames", maps.Keys(skipped)).
 			Msg(msg.SmartRetryUnsupportedClassnames)
 	}
 	return maps.Keys(classes)
@@ -188,6 +188,11 @@ func isJavaClassName(name string) bool {
 
 // isJavaIdentifier returns true if s is a valid Java identifier segment
 // (e.g. "com", "example", "MyTest", "MyTest$Inner").
+//
+// Intentionally ASCII-only. The JLS permits Unicode letters in identifiers,
+// but real-world Android test classes are ASCII; restricting to ASCII keeps
+// the check simple and avoids accepting names that the instrumentation class
+// filter would still fail to match.
 func isJavaIdentifier(s string) bool {
 	if len(s) == 0 {
 		return false

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -145,11 +145,11 @@ func conformXCUITestClassName(name string, rdc bool) string {
 // "am instrument -e class" filter only accepts real class identifiers.
 func getFailedEspressoTests(testCases []junit.TestCase) []string {
 	classes := map[string]bool{}
-	skipped := false
+	var skippedClassnames []string
 	for _, tc := range testCases {
 		if tc.Error != nil || tc.Failure != nil {
 			if !isJavaClassName(tc.ClassName) {
-				skipped = true
+				skippedClassnames = append(skippedClassnames, tc.ClassName)
 				continue
 			}
 			if tc.Name != "" {
@@ -159,8 +159,11 @@ func getFailedEspressoTests(testCases []junit.TestCase) []string {
 			}
 		}
 	}
-	if skipped && len(classes) == 0 {
-		log.Warn().Msg(msg.SmartRetryUnsupportedClassnames)
+	if len(skippedClassnames) > 0 {
+		log.Warn().
+			Int("skipped", len(skippedClassnames)).
+			Strs("classnames", skippedClassnames).
+			Msg(msg.SmartRetryUnsupportedClassnames)
 	}
 	return maps.Keys(classes)
 }

--- a/internal/saucecloud/retry/junitretrier.go
+++ b/internal/saucecloud/retry/junitretrier.go
@@ -139,10 +139,19 @@ func conformXCUITestClassName(name string, rdc bool) string {
 // getFailedEspressoTests returns a list of failed Espresso tests from the given
 // test cases. The format is "<className>#<testMethodName>", with the test
 // method name being optional.
+//
+// Test cases whose classname is not a valid Java class (e.g. Cucumber scenario
+// display names like "Collect Elements") are skipped because Android's
+// "am instrument -e class" filter only accepts real class identifiers.
 func getFailedEspressoTests(testCases []junit.TestCase) []string {
 	classes := map[string]bool{}
+	skipped := false
 	for _, tc := range testCases {
 		if tc.Error != nil || tc.Failure != nil {
+			if !isJavaClassName(tc.ClassName) {
+				skipped = true
+				continue
+			}
 			if tc.Name != "" {
 				classes[fmt.Sprintf("%s#%s", tc.ClassName, tc.Name)] = true
 			} else {
@@ -150,5 +159,46 @@ func getFailedEspressoTests(testCases []junit.TestCase) []string {
 			}
 		}
 	}
+	if skipped && len(classes) == 0 {
+		log.Warn().Msg(msg.SmartRetryUnsupportedClassnames)
+	}
 	return maps.Keys(classes)
+}
+
+// isJavaClassName returns true if the given name looks like a valid fully
+// qualified Java class name (e.g. "com.example.MyTest"). Each segment between
+// dots must start with a letter, underscore, or dollar sign and contain only
+// valid Java identifier characters. Cucumber scenario display names such as
+// "Collect Elements" or "Login.v2.0" are rejected as unsuitable for use with
+// Android's instrumentation class filter.
+func isJavaClassName(name string) bool {
+	if name == "" || !strings.Contains(name, ".") {
+		return false
+	}
+	for _, seg := range strings.Split(name, ".") {
+		if !isJavaIdentifier(seg) {
+			return false
+		}
+	}
+	return true
+}
+
+// isJavaIdentifier returns true if s is a valid Java identifier segment
+// (e.g. "com", "example", "MyTest", "MyTest$Inner").
+func isJavaIdentifier(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 {
+			if !(r >= 'a' && r <= 'z') && !(r >= 'A' && r <= 'Z') && r != '_' && r != '$' {
+				return false
+			}
+		} else {
+			if !(r >= 'a' && r <= 'z') && !(r >= 'A' && r <= 'Z') && !(r >= '0' && r <= '9') && r != '_' && r != '$' {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/internal/saucecloud/retry/junitretrier_test.go
+++ b/internal/saucecloud/retry/junitretrier_test.go
@@ -521,3 +521,41 @@ func Test_normalizeXCUITestClassName(t *testing.T) {
 		})
 	}
 }
+
+func Test_isJavaClassName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		// Valid Java classnames
+		{name: "fully qualified class", input: "com.example.MyTest", want: true},
+		{name: "nested class with dollar", input: "com.example.MyTest$Inner", want: true},
+		{name: "two segments", input: "Demo.Class1", want: true},
+		{name: "underscore in package", input: "com.my_app.Test", want: true},
+		{name: "dollar in class", input: "com.example.$Generated", want: true},
+
+		// Cucumber display names
+		{name: "cucumber feature name with spaces", input: "Collect Elements", want: false},
+		{name: "cucumber long scenario name", input: "Testing Collect Elements in different scenarios", want: false},
+
+		// Edge cases - no dot
+		{name: "single word no package", input: "MyTest", want: false},
+		{name: "empty string", input: "", want: false},
+
+		// Edge cases - dot present but not valid Java
+		{name: "cucumber name with dot", input: "Collect.Elements v2", want: false},
+		{name: "version string", input: "Login.v2.0", want: false},
+		{name: "numeric segment", input: "123.456", want: false},
+		{name: "leading dot", input: ".com.example", want: false},
+		{name: "trailing dot", input: "com.example.", want: false},
+		{name: "consecutive dots", input: "com..example", want: false},
+		{name: "special characters", input: "com.example/MyTest", want: false},
+		{name: "hyphen in segment", input: "com.my-app.Test", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isJavaClassName(tt.input))
+		})
+	}
+}

--- a/internal/saucecloud/retry/junitretrier_test.go
+++ b/internal/saucecloud/retry/junitretrier_test.go
@@ -288,6 +288,94 @@ func TestAppsRetrier_Retry(t *testing.T) {
 			},
 		},
 		{
+			// Integration test: Cucumber-on-Espresso produces JUnit classnames like
+			// "Collect Elements" (display names, not Java classes). These are invalid
+			// for Android's "am instrument -e class" filter and must be skipped.
+			// The original TestOptions["class"] must be preserved.
+			name: "Espresso: VDC skips Cucumber display names and preserves original class filter + SmartRetry",
+			init: init{
+				JobService: &mocks.FakeJobService{
+					GetJobAssetFileContentFn: func(_ context.Context, jobID, fileName string) ([]byte, error) {
+						if jobID == "fake-job-id" && fileName == junit.FileName {
+							return []byte("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<testsuite>\n    <testcase classname=\"Collect Elements\" name=\"Testing scenario 1\" status=\"success\"/>\n    <testcase classname=\"Collect Elements\" name=\"Testing scenario 2\" status=\"error\">\n        <error>assertion failed</error>\n    </testcase>\n</testsuite>\n"), nil
+						}
+						return []byte{}, errors.New("unknown file")
+					},
+				},
+				RetryVDC: true,
+			},
+			args: args{
+				jobOpts: make(chan job.StartOptions),
+				opt: job.StartOptions{
+					Framework:   espresso.Kind,
+					DisplayName: "Dummy Test",
+					SmartRetry: job.SmartRetry{
+						FailedOnly: true,
+					},
+					TestOptions: map[string]interface{}{
+						"class": []string{"com.example.MyTest"},
+					},
+				},
+				previous: job.Job{
+					ID:    "fake-job-id",
+					IsRDC: false,
+				},
+			},
+			expected: job.StartOptions{
+				Framework:   espresso.Kind,
+				DisplayName: "Dummy Test",
+				// Original class filter must be preserved when all classnames are non-Java.
+				TestOptions: map[string]interface{}{
+					"class": []string{"com.example.MyTest"},
+				},
+				SmartRetry: job.SmartRetry{
+					FailedOnly: true,
+				},
+			},
+		},
+		{
+			// Integration test: mixed JUnit with both valid Java classnames and
+			// Cucumber display names. Only valid Java classes should be retried.
+			name: "Espresso: VDC retries only valid Java classes when mixed with Cucumber display names + SmartRetry",
+			init: init{
+				JobService: &mocks.FakeJobService{
+					GetJobAssetFileContentFn: func(_ context.Context, jobID, fileName string) ([]byte, error) {
+						if jobID == "fake-job-id" && fileName == junit.FileName {
+							return []byte("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<testsuite>\n    <testcase classname=\"Collect Elements\" name=\"Testing scenario 1\" status=\"error\">\n        <error>assertion failed</error>\n    </testcase>\n    <testcase classname=\"com.example.RealTest\" name=\"testLogin\" status=\"error\">\n        <error>login failed</error>\n    </testcase>\n</testsuite>\n"), nil
+						}
+						return []byte{}, errors.New("unknown file")
+					},
+				},
+				RetryVDC: true,
+			},
+			args: args{
+				jobOpts: make(chan job.StartOptions),
+				opt: job.StartOptions{
+					Framework:   espresso.Kind,
+					DisplayName: "Dummy Test",
+					SmartRetry: job.SmartRetry{
+						FailedOnly: true,
+					},
+					TestOptions: map[string]interface{}{},
+				},
+				previous: job.Job{
+					ID:    "fake-job-id",
+					IsRDC: false,
+				},
+			},
+			expected: job.StartOptions{
+				Framework:   espresso.Kind,
+				DisplayName: "Dummy Test",
+				// Only the valid Java class is retried; Cucumber display name is skipped.
+				TestOptions: map[string]interface{}{
+					"class": []string{"com.example.RealTest#testLogin"},
+				},
+				SmartRetry: job.SmartRetry{
+					FailedOnly: true,
+				},
+			},
+		},
+		{
 			name: "XCUITest: VDC retries only failed tests when JUnit has failures + SmartRetry",
 			init: init{
 				JobService: &mocks.FakeJobService{


### PR DESCRIPTION
…spresso)

## Description
Cucumber-on-Espresso generates JUnit classnames using Feature display
names (e.g. "Collect Elements") instead of Java class identifiers. When
smart retry passes these to Android's "am instrument -e class", the
spaces break shell argument parsing — older APIs silently run all tests,
newer APIs fail with "No instrumentation found".

Added isJavaClassName validation in getFailedEspressoTests to detect
invalid classnames and fall back to a full retry with a warning message
instead of sending a broken filter to the device.
