### PR TITLE
Add macOS 14 to the cypress platform schema

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -457,6 +457,7 @@
                     "macOS 11.00",
                     "macOS 12",
                     "macOS 13",
+                    "macOS 14",
                     "Windows 10",
                     "Windows 11"
                   ],

--- a/api/v1/framework/cypress.schema.json
+++ b/api/v1/framework/cypress.schema.json
@@ -119,6 +119,7 @@
               "macOS 11.00",
               "macOS 12",
               "macOS 13",
+              "macOS 14",
               "Windows 10",
               "Windows 11"
             ]


### PR DESCRIPTION
What this does

This adds macOS 14 to the platform list for cypress in both schema files. The files are api/v1/framework/cypress.schema.json and api/saucectl.schema.json.

Why

This is the first step for running cypress on Apple Silicon macOS for INT-246. It lets saucectl validate the platform macOS 14 for cypress suites. The same change was already made for playwright in an earlier PR.

Customer impact

None on its own. This only widens schema validation. No job runs on macOS 14 until test composer and image metadata service are updated and the runner and side disk are deployed. Those changes follow in separate ordered merge requests.