### PR TITLE
Add macOS 26 to config schema (Playwright, TestCafe)

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -1398,6 +1398,7 @@
                     "macOS 13",
                     "macOS 14",
                     "macOS 15",
+                    "macOS 26",
                     "Windows 10",
                     "Windows 11"
                   ]
@@ -1764,6 +1765,7 @@
                     "macOS 13",
                     "macOS 14",
                     "macOS 15",
+                    "macOS 26",
                     "Windows 10",
                     "Windows 11"
                   ],
@@ -2882,6 +2884,7 @@
                     "macOS 13",
                     "macOS 14",
                     "macOS 15",
+                    "macOS 26",
                     "Windows 10",
                     "Windows 11"
                   ]

--- a/api/v1alpha/framework/playwright-cucumberjs.schema.json
+++ b/api/v1alpha/framework/playwright-cucumberjs.schema.json
@@ -82,6 +82,7 @@
               "macOS 13",
               "macOS 14",
               "macOS 15",
+              "macOS 26",
               "Windows 10",
               "Windows 11"
             ]

--- a/api/v1alpha/framework/playwright.schema.json
+++ b/api/v1alpha/framework/playwright.schema.json
@@ -104,6 +104,7 @@
               "macOS 13",
               "macOS 14",
               "macOS 15",
+              "macOS 26",
               "Windows 10",
               "Windows 11"
             ]

--- a/api/v1alpha/framework/testcafe.schema.json
+++ b/api/v1alpha/framework/testcafe.schema.json
@@ -123,6 +123,7 @@
               "macOS 13",
               "macOS 14",
               "macOS 15",
+              "macOS 26",
               "Windows 10",
               "Windows 11"
             ],


### PR DESCRIPTION
Adds `macOS 26` to the `platformName` enum for Playwright, TestCafe, and Playwright-Cucumberjs, and regenerates the bundled `api/saucectl.schema.json`.

macOS 26 is ARM-only (routing is handled by auto-ARM detection, so `armRequired` stays optional). Without this, saucectl rejects a `macOS 26` config during local schema validation even though the platform is supported on Sauce.

Cypress is intentionally left out (its schema caps at macOS 14; tracked separately).
