### PR TITLE
Add macOS 15 to Cypress platformName schema enum

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -458,6 +458,7 @@
                     "macOS 12",
                     "macOS 13",
                     "macOS 14",
+                    "macOS 15",
                     "Windows 10",
                     "Windows 11"
                   ],

--- a/api/v1/framework/cypress.schema.json
+++ b/api/v1/framework/cypress.schema.json
@@ -120,6 +120,7 @@
               "macOS 12",
               "macOS 13",
               "macOS 14",
+              "macOS 15",
               "Windows 10",
               "Windows 11"
             ]


### PR DESCRIPTION
Adds macOS 15 as an accepted platformName value for Cypress, matching the existing macOS 14 entry.

Changes
- api/v1/framework/cypress.schema.json: add macOS 15 to the platformName enum after macOS 14.
- api/saucectl.schema.json: add macOS 15 to the Cypress platformName enum after macOS 14 (Cypress block only; other framework blocks already list it).

Ordering follows the existing convention: macOS versions ascending, then Windows. armRequired is unchanged.

Follow up
- A saucectl version bump (git tag plus GitHub release) is required after merge so the published JSON schema includes macOS 15. The version is build and tag driven; there is no version field in source to edit.
- macOS 26 is out of scope for Cypress here and is a trivial follow on.
