### PR TITLE
Add macOS 26 to Cypress platformName schema enum

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -459,6 +459,7 @@
                     "macOS 13",
                     "macOS 14",
                     "macOS 15",
+                    "macOS 26",
                     "Windows 10",
                     "Windows 11"
                   ],

--- a/api/v1/framework/cypress.schema.json
+++ b/api/v1/framework/cypress.schema.json
@@ -121,6 +121,7 @@
               "macOS 13",
               "macOS 14",
               "macOS 15",
+              "macOS 26",
               "Windows 10",
               "Windows 11"
             ]


### PR DESCRIPTION
Adds `macOS 26` to the Cypress `platformName` schema enum in both the aggregate (`api/saucectl.schema.json`) and per-framework (`api/v1/framework/cypress.schema.json`) schemas, so the published schema accepts Cypress on macOS 26. Mirrors the macOS 15 change (#1092).

Part of Cypress on macOS 26 (INT-610, under INT-246). Draft — pairs with the IMS wiring; hold until the macOS 26 validation is confirmed.