### PR TITLE
chore: add July framework versions to schema (INT-542)

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -402,6 +402,7 @@
               "version": {
                 "enum": [
                   "package.json",
+                  "15.18.0",
                   "15.14.2",
                   "15.12.0",
                   "15.9.0",
@@ -1597,6 +1598,7 @@
               "version": {
                 "enum": [
                   "package.json",
+                  "1.61.1",
                   "1.60.0",
                   "1.58.2",
                   "1.58.1",
@@ -2468,6 +2470,7 @@
                 "description": "Which framework version to use.",
                 "enum": [
                   "package.json",
+                  "3.7.6",
                   "3.7.4",
                   "3.7.3",
                   "3.7.2",

--- a/api/v1/framework/cypress.schema.json
+++ b/api/v1/framework/cypress.schema.json
@@ -66,6 +66,7 @@
           "$ref": "../subschema/common.schema.json#/definitions/version",
           "enum": [
             "package.json",
+            "15.18.0",
             "15.14.2",
             "15.12.0",
             "15.9.0",

--- a/api/v1alpha/framework/playwright.schema.json
+++ b/api/v1alpha/framework/playwright.schema.json
@@ -54,6 +54,7 @@
           "$ref": "../subschema/common.schema.json#/definitions/version",
           "enum": [
             "package.json",
+            "1.61.1",
             "1.60.0",
             "1.58.2",
             "1.58.1",

--- a/api/v1alpha/framework/testcafe.schema.json
+++ b/api/v1alpha/framework/testcafe.schema.json
@@ -54,6 +54,7 @@
           "$ref": "../subschema/common.schema.json#/definitions/version",
           "enum": [
             "package.json",
+            "3.7.6",
             "3.7.4",
             "3.7.3",
             "3.7.2",


### PR DESCRIPTION
Adds the July framework versions to the saucectl config schemas now that they're live on test-composer (INT-542):

- cypress `15.18.0`
- playwright `1.61.1`
- testcafe `3.7.6`

Bundled schema regenerated via `make schema`. Follows the pattern of #1087.