### PR TITLE
fix: prevent corrupt env var payloads for XCUITest/XCTest jobs

### DIFF
--- a/internal/http/webdriver.go
+++ b/internal/http/webdriver.go
@@ -73,8 +73,10 @@ type SauceOpts struct {
 }
 
 type env struct {
-	Name  string `json:"name,omitempty"`
-	Value string `json:"value,omitempty"`
+	// Name and Value must not use omitempty: the backend requires both fields
+	// to be present and crashes the job on entries like {"name": "FOO"}.
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // Batch represents capabilities for batch frameworks.

--- a/internal/http/webdriver_test.go
+++ b/internal/http/webdriver_test.go
@@ -109,3 +109,33 @@ func TestWebdriver_StartJob(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want string
+	}{
+		{
+			name: "value is always serialized, even when empty",
+			in:   map[string]string{"WIDGETS_ENDPOINT": ""},
+			want: `[{"name":"WIDGETS_ENDPOINT","value":""}]`,
+		},
+		{
+			name: "regular entry",
+			in:   map[string]string{"FOO": "bar"},
+			want: `[{"name":"FOO","value":"bar"}]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.Marshal(formatEnv(tt.in))
+			if err != nil {
+				t.Fatalf("failed to marshal env: %v", err)
+			}
+			if string(b) != tt.want {
+				t.Errorf("formatEnv() serialized to %s, want %s", b, tt.want)
+			}
+		})
+	}
+}

--- a/internal/xctest/config.go
+++ b/internal/xctest/config.go
@@ -247,6 +247,18 @@ func Validate(p Project) error {
 			return err
 		}
 
+		for name, value := range suite.Env {
+			if name == "" {
+				return fmt.Errorf("suite %q: environment variable has an empty name", suite.Name)
+			}
+			if value == "" {
+				return fmt.Errorf(
+					"suite %q: environment variable %q has an empty value; check that any referenced variables (e.g. $%s) are set in your environment",
+					suite.Name, name, name,
+				)
+			}
+		}
+
 		for _, app := range suite.OtherApps {
 			if err := apps.Validate("other application", app, validAppExt); err != nil {
 				return err

--- a/internal/xctest/config_test.go
+++ b/internal/xctest/config_test.go
@@ -62,3 +62,38 @@ suites:
 		t.Errorf("NetworkConditions mismatch: %s", diff)
 	}
 }
+
+func TestValidate_Env(t *testing.T) {
+	dir := fs.NewDir(t, "xctest-config",
+		fs.WithFile("test.ipa", "", fs.WithMode(0655)),
+		fs.WithFile("test.xctestrun", "", fs.WithMode(0655)))
+	defer dir.Remove()
+	appF := filepath.Join(dir.Path(), "test.ipa")
+	xcTestRunFileF := filepath.Join(dir.Path(), "test.xctestrun")
+
+	newProject := func(env map[string]string) Project {
+		return Project{
+			Sauce: config.SauceConfig{Region: "us-west-1"},
+			Suites: []Suite{
+				{
+					Name:          "iphone",
+					App:           appF,
+					XCTestRunFile: xcTestRunFileF,
+					Env:           env,
+					Devices: []config.Device{
+						{Name: "iPhone.*"},
+					},
+				},
+			},
+		}
+	}
+
+	err := Validate(newProject(map[string]string{"": "some-value"}))
+	assert.EqualError(t, err, `suite "iphone": environment variable has an empty name`)
+
+	err = Validate(newProject(map[string]string{"WIDGETS_ENDPOINT": ""}))
+	assert.EqualError(t, err, `suite "iphone": environment variable "WIDGETS_ENDPOINT" has an empty value; check that any referenced variables (e.g. $WIDGETS_ENDPOINT) are set in your environment`)
+
+	err = Validate(newProject(map[string]string{"WIDGETS_ENDPOINT": "https://example.com"}))
+	assert.NoError(t, err)
+}

--- a/internal/xcuitest/config.go
+++ b/internal/xcuitest/config.go
@@ -247,6 +247,18 @@ func Validate(p Project) error {
 			return err
 		}
 
+		for name, value := range suite.Env {
+			if name == "" {
+				return fmt.Errorf("suite %q: environment variable has an empty name", suite.Name)
+			}
+			if value == "" {
+				return fmt.Errorf(
+					"suite %q: environment variable %q has an empty value; check that any referenced variables (e.g. $%s) are set in your environment",
+					suite.Name, name, name,
+				)
+			}
+		}
+
 		for _, app := range suite.OtherApps {
 			if err := apps.Validate("other application", app, validAppExt); err != nil {
 				return err

--- a/internal/xcuitest/config_test.go
+++ b/internal/xcuitest/config_test.go
@@ -95,6 +95,42 @@ func TestValidate(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name: "validating throws error on env var with empty name",
+			p: &Project{
+				Sauce: config.SauceConfig{Region: "us-west-1"},
+				Suites: []Suite{
+					{
+						Name:    "iphone",
+						App:     appF,
+						TestApp: testAppF,
+						Env:     map[string]string{"": "some-value"},
+						Devices: []config.Device{
+							{Name: "iPhone.*"},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New(`suite "iphone": environment variable has an empty name`),
+		},
+		{
+			name: "validating throws error on env var with empty value",
+			p: &Project{
+				Sauce: config.SauceConfig{Region: "us-west-1"},
+				Suites: []Suite{
+					{
+						Name:    "iphone",
+						App:     appF,
+						TestApp: testAppF,
+						Env:     map[string]string{"WIDGETS_ENDPOINT": ""},
+						Devices: []config.Device{
+							{Name: "iPhone.*"},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New(`suite "iphone": environment variable "WIDGETS_ENDPOINT" has an empty value; check that any referenced variables (e.g. $WIDGETS_ENDPOINT) are set in your environment`),
+		},
+		{
 			name: "validating passing with .app",
 			p: &Project{
 				Sauce: config.SauceConfig{Region: "us-west-1"},


### PR DESCRIPTION
## Description
Env vars with empty values were serialized without the 'value' field
due to the omitempty JSON tag, e.g. {"name": "WIDGETS_ENDPOINT"}. The
VM-side config parser requires both 'name' and 'value' on every entry
and fails such jobs at startup with an unhandled KeyError, surfacing
to the customer as a generic 500 Internal Server Error with no logs.

Empty values typically occur when a config references an unset
environment variable (saucectl expands unset $VARs to ""), e.g. a
missing CI secret.

- Remove omitempty from the env entry's name/value JSON tags so both
  fields are always serialized.
- Validate env vars for the xcuitest and xctest kinds at config load:
  an empty name or empty value now fails the run before any upload or
  VM allocation, with an error naming the suite and variable.

Other frameworks are unaffected; they do not transmit env through
this structure.

BREAKING CHANGE: XCUITest/XCTest configs with empty env var values,
which previously started jobs that failed on the VM, now fail fast at
config load.

Relates to DVI-5167.
