### PR TITLE
feat: add hidden  command group for AI Test Authoring

### DIFF
--- a/cmd/saucectl/saucectl.go
+++ b/cmd/saucectl/saucectl.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/cmd/ai"
 	"github.com/saucelabs/saucectl/internal/cmd/apit"
 	"github.com/saucelabs/saucectl/internal/cmd/artifacts"
 	"github.com/saucelabs/saucectl/internal/cmd/builds"
@@ -73,6 +74,7 @@ func main() {
 		apit.Command(cmd.PersistentPreRun),
 		builds.Command(cmd.PersistentPreRun),
 		devices.Command(cmd.PersistentPreRun),
+		ai.Command(cmd.PersistentPreRun),
 	)
 
 	if err := cmd.ExecuteContext(newContext()); err != nil {

--- a/internal/aiauthoring/aiauthoring.go
+++ b/internal/aiauthoring/aiauthoring.go
@@ -1,0 +1,192 @@
+// Package aiauthoring defines the domain types and service interfaces for
+// the Sauce Labs AI Test Authoring backend.
+package aiauthoring
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// TestCase describes a saved AI-authored test case.
+type TestCase struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// The backend reports timestamps as createdAt/updatedAt or
+	// creationDate/lastUpdateDate depending on the endpoint. Use Created()
+	// and Updated() to read them uniformly.
+	CreatedAt       string       `json:"createdAt,omitempty"`
+	UpdatedAt       string       `json:"updatedAt,omitempty"`
+	CreationDate    string       `json:"creationDate,omitempty"`
+	LastUpdateDate  string       `json:"lastUpdateDate,omitempty"`
+	UserID          string       `json:"userId,omitempty"`
+	TeamID          string       `json:"teamId,omitempty"`
+	CreatorUserName string       `json:"creatorUserName,omitempty"`
+	Status          string       `json:"status,omitempty"`
+	Framework       string       `json:"framework,omitempty"`
+	Description     string       `json:"description,omitempty"`
+	TestSuiteID     string       `json:"testSuiteId,omitempty"`
+	TestSuiteName   string       `json:"testSuiteName,omitempty"`
+	RunSettings     *RunSettings `json:"runSettings,omitempty"`
+}
+
+// Created returns the creation timestamp, regardless of which field the
+// backend used to report it.
+func (t TestCase) Created() string {
+	if t.CreatedAt != "" {
+		return t.CreatedAt
+	}
+	return t.CreationDate
+}
+
+// Updated returns the last-update timestamp, regardless of which field the
+// backend used to report it.
+func (t TestCase) Updated() string {
+	if t.UpdatedAt != "" {
+		return t.UpdatedAt
+	}
+	return t.LastUpdateDate
+}
+
+// RunSettings holds the defaults a test case was authored with.
+type RunSettings struct {
+	TestURL string `json:"testUrl,omitempty"`
+	// SCTunnelName is a pointer to tell an absent tunnel (nil) apart from an
+	// authored-but-empty one (""). The backend rejects runs whose effective
+	// tunnel name is "" with SC_TUNNEL_NOT_FOUND, so an empty one has to be
+	// explicitly cleared when starting a run.
+	SCTunnelName  *string    `json:"scTunnelName,omitempty"`
+	PrimaryTarget *RunTarget `json:"primaryTarget,omitempty"`
+}
+
+// RunCapabilities is an opaque, W3C-style capabilities map. The backend owns
+// its schema; saucectl passes it through untouched.
+type RunCapabilities map[string]any
+
+// RunTarget is a single platform target for a test case run.
+type RunTarget struct {
+	Capabilities RunCapabilities `json:"capabilities"`
+}
+
+// ListOptions are the filters accepted by the test case listing endpoint.
+type ListOptions struct {
+	Search      string
+	Skip        int
+	Limit       int
+	StartDate   string
+	EndDate     string
+	UserID      string
+	TeamID      string
+	TestSuiteID string
+}
+
+// TestSuite describes a saved suite of AI-authored test cases. The test
+// cases themselves are listed via ListOptions.TestSuiteID.
+type TestSuite struct {
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	Tags            []string `json:"tags,omitempty"`
+	TestCaseCount   int      `json:"testCaseCount"`
+	RunCount        int      `json:"runCount"`
+	CreationDate    string   `json:"creationDate,omitempty"`
+	LastUpdate      string   `json:"lastUpdate,omitempty"`
+	CreatorUserName string   `json:"creatorUserName,omitempty"`
+}
+
+// List is one page of test cases.
+type List struct {
+	Items []TestCase `json:"items"`
+	Total int        `json:"total"`
+}
+
+// RunRequest is the payload for starting a cloud run of a saved test case.
+type RunRequest struct {
+	BuildName string `json:"buildName,omitempty"`
+	// SCTunnelName is the name of a Sauce Connect tunnel to run through.
+	// When empty, the test case's authored tunnel (if any) applies.
+	SCTunnelName string `json:"scTunnelName,omitempty"`
+	// ClearTunnel sends an explicit null tunnel, overriding a tunnel stored
+	// in the test case's authored run settings.
+	ClearTunnel bool `json:"-"`
+	// Targets are the platforms to run against. If empty, the backend
+	// decides based on the test case's authored settings.
+	Targets []RunTarget `json:"targets,omitempty"`
+}
+
+// MarshalJSON emits an explicit "scTunnelName": null when ClearTunnel is set
+// and no tunnel name is given; omitempty alone cannot express that.
+func (r RunRequest) MarshalJSON() ([]byte, error) {
+	m := map[string]any{}
+	if r.BuildName != "" {
+		m["buildName"] = r.BuildName
+	}
+	if r.SCTunnelName != "" {
+		m["scTunnelName"] = r.SCTunnelName
+	} else if r.ClearTunnel {
+		m["scTunnelName"] = nil
+	}
+	if len(r.Targets) > 0 {
+		m["targets"] = r.Targets
+	}
+	return json.Marshal(m)
+}
+
+// TestCaseRunJob is a single job spawned by a test case run. Its ID is
+// internal to the AI Authoring backend; SauceJobID, URL and Success are
+// filled in asynchronously while the run progresses.
+type TestCaseRunJob struct {
+	ID         string `json:"id"`
+	SauceJobID string `json:"sauceJobId,omitempty"`
+	Name       string `json:"name"`
+	Target     struct {
+		Capabilities RunCapabilities `json:"capabilities"`
+		IsRDC        bool            `json:"isRdc"`
+	} `json:"target"`
+	URL     string `json:"url,omitempty"`
+	Success *bool  `json:"success,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// Done returns true once the job reached a final state.
+func (j TestCaseRunJob) Done() bool {
+	return j.Success != nil || j.Error != ""
+}
+
+// Passed returns true if the job finished successfully.
+func (j TestCaseRunJob) Passed() bool {
+	return j.Success != nil && *j.Success
+}
+
+// TestCaseRun describes a started cloud run of a test case.
+type TestCaseRun struct {
+	ID           string           `json:"id"`
+	TestCaseID   string           `json:"testCaseId"`
+	Build        string           `json:"build,omitempty"`
+	Jobs         []TestCaseRunJob `json:"jobs"`
+	CreationDate string           `json:"creationDate,omitempty"`
+	TestURL      string           `json:"testUrl,omitempty"`
+}
+
+// TestCaseService manages saved test cases.
+type TestCaseService interface {
+	ListTestCases(ctx context.Context, opts ListOptions) (List, error)
+	GetTestCase(ctx context.Context, id string) (TestCase, error)
+	RenameTestCase(ctx context.Context, id, name string) (TestCase, error)
+	DeleteTestCase(ctx context.Context, id string) error
+}
+
+// TestSuiteReader fetches saved test suites.
+type TestSuiteReader interface {
+	GetTestSuite(ctx context.Context, id string) (TestSuite, error)
+}
+
+// TestCaseRunner starts and observes cloud runs of saved test cases.
+type TestCaseRunner interface {
+	RunTestCase(ctx context.Context, id string, req RunRequest) (TestCaseRun, error)
+	GetTestCaseRun(ctx context.Context, testCaseID, runID string) (TestCaseRun, error)
+}
+
+// EntitlementReader reports whether AI Test Authoring is enabled for an
+// organization. The feature is gated fail-closed on this entitlement.
+type EntitlementReader interface {
+	IsAIAuthoringEnabled(ctx context.Context, orgID string) (bool, error)
+}

--- a/internal/aiauthoring/aiauthoring_test.go
+++ b/internal/aiauthoring/aiauthoring_test.go
@@ -1,0 +1,47 @@
+package aiauthoring
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRunRequest_MarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name string
+		req  RunRequest
+		want string
+	}{
+		{
+			name: "tunnel omitted when unset",
+			req:  RunRequest{BuildName: "b"},
+			want: `{"buildName":"b"}`,
+		},
+		{
+			name: "tunnel name set",
+			req:  RunRequest{SCTunnelName: "my-tunnel"},
+			want: `{"scTunnelName":"my-tunnel"}`,
+		},
+		{
+			name: "explicit null tunnel when cleared",
+			req:  RunRequest{ClearTunnel: true},
+			want: `{"scTunnelName":null}`,
+		},
+		{
+			name: "tunnel name wins over clearing",
+			req:  RunRequest{SCTunnelName: "my-tunnel", ClearTunnel: true},
+			want: `{"scTunnelName":"my-tunnel"}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(tc.req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/ai/README.md
+++ b/internal/cmd/ai/README.md
@@ -1,0 +1,150 @@
+# saucectl ai — AI Test Authoring from the CLI
+
+`saucectl ai` brings [Sauce Labs AI Test Authoring](https://docs.saucelabs.com/) to the
+command line: manage test cases that were authored in natural language (via the web UI or
+the VS Code / IntelliJ plugins) and run them in the Sauce Labs cloud with CI-grade exit
+codes.
+
+> **Status: experimental.** The command group is hidden (`saucectl ai` does not appear in
+> `saucectl --help`) until the feature is ready for release. The underlying backend API is
+> not yet a public, versioned contract.
+
+## Prerequisites
+
+- **Credentials** — the usual saucectl credentials, via `saucectl configure`,
+  `~/.sauce/credentials.yml`, or `SAUCE_USERNAME`/`SAUCE_ACCESS_KEY`.
+- **Entitlement** — your organization needs `ai_authoring.enabled` in its plan. Every
+  `saucectl ai` command checks this first and fails closed:
+  - `AI Test Authoring is not enabled for your organization` → contact your Sauce Labs
+    account executive.
+  - `unable to verify the AI Test Authoring entitlement` → transient problem (network,
+    credentials); the feature may still be in your plan.
+- **A build of this branch** — the feature is not in released saucectl binaries yet:
+
+  ```bash
+  git checkout feat/ai-authoring-phase1
+  go build -o bin/saucectl ./cmd/saucectl
+  ./bin/saucectl ai --help
+  ```
+
+  During development, `go run ./cmd/saucectl ai …` works too.
+
+All commands accept `--region` / `-r` (default `us-west-1`; also `us-east-4`,
+`eu-central-1`).
+
+## Finding ids
+
+Both id types appear in app URLs and in `saucectl ai testcases list`:
+
+| Resource | URL | id format |
+|---|---|---|
+| Test case | `app.saucelabs.com/test-authoring/chat/<id>` | 24 hex chars, e.g. `6a86100da038f44fd9cdaec4` |
+| Test suite | `app.saucelabs.com/test-authoring/test-suites/<id>` | 32 hex chars, e.g. `bfb5e37bc38a408c89b2c4feb207944d` |
+
+`ai run` and `ai run-suite` validate the id format and point you to the other command if
+you mix them up.
+
+## Managing test cases
+
+```bash
+saucectl ai testcases list                          # table: ID, Name, Status, Created, Creator
+saucectl ai testcases list -o json                  # machine-readable
+saucectl ai testcases list --search "login" --limit 10 --skip 20
+
+saucectl ai testcases get <testCaseID>              # details incl. authored target and test URL
+saucectl ai testcases get <testCaseID> -o json      # full object, incl. runSettings
+
+saucectl ai testcases rename <testCaseID> --name "New name"
+saucectl ai testcases delete <testCaseID>           # permanent, no confirmation prompt
+```
+
+`testcases` is also available as the alias `tc`.
+
+## Running a single test case
+
+```bash
+saucectl ai run <testCaseID>
+```
+
+This starts a cloud run, waits for it to finish (polling every 15 s), prints a results
+table with the Sauce Labs job link, and exits `0` if the run passed, non-zero otherwise —
+so it can be a CI step as-is.
+
+```
+Started run f0620714-… of test case 6a86100da038f44fd9cdaec4 with 1 job(s)
+ Name                              Status  URL
+ Filter notes by keyword - …       passed  https://app.saucelabs.com/tests/4cbb0f37…
+ 1 of 1 job(s) passed
+```
+
+### Flags
+
+| Flag | Meaning |
+|---|---|
+| `--async` | Start the run and exit immediately without waiting for the result. |
+| `--build <name>` | Associate the run with a build name. The backend suffixes duplicates (`name - 2`). |
+| `--tunnel-name <name>` | Run through a Sauce Connect tunnel. |
+| `--browser`, `--browser-version`, `--platform` | Override the target platform (e.g. `--browser chrome --platform "Windows 11"`). |
+| `--timeout <dur>` | Max time to wait for the result (default `30m`). On expiry the cloud run keeps going; the CLI prints the build URL and exits non-zero. |
+| `-o text\|json` | Output format. `json` emits the final job results (or the started run(s) with `--async`). |
+
+### Target selection
+
+The run target is chosen in this order:
+
+1. `--browser` / `--platform` flags, if given;
+2. otherwise the test case's **authored** target (`runSettings.primaryTarget` — what you
+   see in `testcases get`), which may be a desktop browser or a real mobile device;
+3. otherwise the backend's default for the test case.
+
+## Running a whole test suite
+
+```bash
+saucectl ai run-suite <testSuiteID>
+```
+
+The backend has no suite-level run endpoint, so saucectl fans the suite out client-side:
+it lists the suite's test cases, starts one run per case (each with its own authored
+target, unless overridden by flags), polls all runs **concurrently**, and prints one
+aggregated table. The exit code is non-zero if *any* case fails — including cases that
+fail to start; one broken case never prevents the others from running.
+
+```
+Running test suite "Example Test Suite" with 3 test case(s)
+ Name                                    Status  URL
+ New vt test case login + add backpack   passed  https://app.saucelabs.com/tests/…
+ Log in test                             passed  https://app.saucelabs.com/tests/…
+ Failing test                            error
+ 2 of 3 job(s) passed
+Error: some test case jobs have failed
+```
+
+`run-suite` takes the same flags as `run`. Note that `--browser`/`--platform` overrides
+apply to **every** case in the suite.
+
+## Behavior notes & known quirks
+
+These reflect observed backend behavior; they are handled by the CLI but useful to know:
+
+- **Run progress lives on the run resource.** The job ids returned when a run starts are
+  internal to the AI Authoring backend and cannot be looked up via the regular Sauce job
+  APIs. saucectl polls `GET …/testcases/{id}/runs/{runId}`, where the real Sauce job id,
+  URL, and pass/fail appear as the run progresses.
+- **VDC job URLs are constructed.** The backend omits `url` for virtual-device jobs (it
+  sets it for real-device jobs); saucectl builds the dashboard link from the Sauce job id.
+- **Authored empty tunnel names are neutralized.** A test case saved with an *empty*
+  (rather than absent) tunnel name in its run settings would fail to start with
+  `SC_TUNNEL_NOT_FOUND`; saucectl detects this and clears the tunnel by sending an
+  explicit `scTunnelName: null` (unless you pass `--tunnel-name`).
+- **Suites can contain unrunnable drafts.** A test case with no saved revision fails to
+  start with `TEST_CASE_REVISION_NOT_FOUND`; it is reported as an `error` row while the
+  rest of the suite runs.
+- **Device allocation takes time.** A run can sit in allocation for a few minutes before
+  test steps execute; the default 30 m timeout accounts for this.
+
+## What this feature does not do (yet)
+
+Planned in later phases: authoring new test cases from the CLI (`ai generate`, `ai new`,
+WebSocket streaming), exporting generated code (`ai targets`, `ai export`), and a
+`kind: ai` config file so plain `saucectl run` can drive these runs with suites,
+reporters, and artifact download.

--- a/internal/cmd/ai/cmd.go
+++ b/internal/cmd/ai/cmd.go
@@ -1,0 +1,100 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/saucelabs/saucectl/internal/aiauthoring"
+	"github.com/saucelabs/saucectl/internal/credentials"
+	"github.com/saucelabs/saucectl/internal/http"
+	"github.com/saucelabs/saucectl/internal/iam"
+	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/usage"
+	"github.com/spf13/cobra"
+)
+
+var (
+	testCaseService   aiauthoring.TestCaseService
+	testCaseRunner    aiauthoring.TestCaseRunner
+	testSuiteReader   aiauthoring.TestSuiteReader
+	entitlementReader aiauthoring.EntitlementReader
+	userService       iam.UserService
+	appURL            string
+	aiTimeout         = 1 * time.Minute
+)
+
+func Command(preRun func(cmd *cobra.Command, args []string)) *cobra.Command {
+	var regio string
+
+	cmd := &cobra.Command{
+		Use:   "ai",
+		Short: "Interact with Sauce Labs AI Test Authoring",
+		// TODO: Unhide once AI Test Authoring support is ready for release.
+		Hidden:           true,
+		SilenceUsage:     true,
+		TraverseChildren: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if preRun != nil {
+				preRun(cmd, args)
+			}
+
+			reg := region.FromString(regio)
+			if reg == region.None {
+				return errors.New("invalid region")
+			}
+			if reg == region.Staging {
+				usage.DefaultClient.Enabled = false
+			}
+			appURL = reg.AppBaseURL()
+
+			creds := credentials.Get()
+			if !creds.IsSet() {
+				return errors.New("no credentials set; run `saucectl configure` to set them up")
+			}
+
+			aiService := http.NewAIAuthoringService(reg, creds, aiTimeout)
+			testCaseService = &aiService
+			testCaseRunner = &aiService
+			testSuiteReader = &aiService
+			entitlementReader = &aiService
+
+			us := http.NewUserService(reg.APIBaseURL(), creds, aiTimeout)
+			userService = &us
+
+			return checkEntitlement(cmd.Context())
+		},
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.StringVarP(&regio, "region", "r", "us-west-1", "The Sauce Labs region. Options: us-west-1, us-east-4, eu-central-1.")
+
+	cmd.AddCommand(
+		TestCasesCommand(),
+		RunCommand(),
+		RunSuiteCommand(),
+	)
+
+	return cmd
+}
+
+// checkEntitlement verifies that AI Test Authoring is part of the
+// organization's plan. The gate fails closed, but distinguishes "not in your
+// plan" from a failure to verify.
+func checkEntitlement(ctx context.Context) error {
+	user, err := userService.User(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to verify the AI Test Authoring entitlement: %w", err)
+	}
+
+	enabled, err := entitlementReader.IsAIAuthoringEnabled(ctx, user.Organization.ID)
+	if err != nil {
+		return fmt.Errorf("unable to verify the AI Test Authoring entitlement: %w", err)
+	}
+	if !enabled {
+		return errors.New("AI Test Authoring is not enabled for your organization; contact your Sauce Labs account executive to add it to your plan")
+	}
+
+	return nil
+}

--- a/internal/cmd/ai/run.go
+++ b/internal/cmd/ai/run.go
@@ -1,0 +1,454 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/rs/zerolog/log"
+	"github.com/saucelabs/saucectl/internal/aiauthoring"
+	"github.com/saucelabs/saucectl/internal/job"
+	"github.com/saucelabs/saucectl/internal/tables"
+	"github.com/spf13/cobra"
+)
+
+// runPollInterval matches the polling cadence of saucectl run.
+const runPollInterval = 15 * time.Second
+
+// testCaseIDLength is the length of a test case id (a hex object id), while
+// test suite ids are 32 hex characters. Used to give a helpful hint when an
+// id is passed to the wrong command.
+const (
+	testCaseIDLength  = 24
+	testSuiteIDLength = 32
+)
+
+// runResult is the final state of one job of a test case run.
+type runResult struct {
+	Name       string `json:"name"`
+	SauceJobID string `json:"sauceJobId,omitempty"`
+	Status     string `json:"status"`
+	Passed     bool   `json:"passed"`
+	URL        string `json:"url,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+// runOptions are the settings shared by test case and suite runs.
+type runOptions struct {
+	Targets   []aiauthoring.RunTarget
+	Build     string
+	Tunnel    string
+	Async     bool
+	Timeout   time.Duration
+	OutFormat string
+}
+
+// runFlags are the flags shared by 'ai run' and 'ai run-suite'.
+type runFlags struct {
+	out            string
+	build          string
+	tunnelName     string
+	browser        string
+	browserVersion string
+	platform       string
+	async          bool
+	timeout        time.Duration
+}
+
+func (f *runFlags) register(cmd *cobra.Command) {
+	flags := cmd.Flags()
+	flags.StringVarP(&f.out, "out", "o", "text", "Output format to the console. Options: text, json.")
+	flags.StringVar(&f.build, "build", "", "Associates the run with a build name.")
+	flags.StringVar(&f.tunnelName, "tunnel-name", "", "Runs the test through a Sauce Connect tunnel with the given name.")
+	flags.StringVar(&f.browser, "browser", "", "The browser to run against, e.g. chrome. Overrides the authored target.")
+	flags.StringVar(&f.browserVersion, "browser-version", "", "The browser version to run against, e.g. latest.")
+	flags.StringVar(&f.platform, "platform", "", "The platform to run against, e.g. \"Windows 11\". Overrides the authored target.")
+	flags.BoolVar(&f.async, "async", false, "Starts the run without waiting for the result.")
+	flags.DurationVar(&f.timeout, "timeout", 30*time.Minute, "The maximum time to wait for the run to finish.")
+}
+
+func (f *runFlags) toOptions() (runOptions, error) {
+	if f.out != JSONOutput && f.out != TextOutput {
+		return runOptions{}, errors.New("unknown output format")
+	}
+
+	var targets []aiauthoring.RunTarget
+	if f.browser != "" || f.platform != "" {
+		caps := aiauthoring.RunCapabilities{}
+		if f.browser != "" {
+			caps["browserName"] = f.browser
+		}
+		if f.browserVersion != "" {
+			caps["browserVersion"] = f.browserVersion
+		}
+		if f.platform != "" {
+			caps["platformName"] = f.platform
+		}
+		targets = []aiauthoring.RunTarget{{Capabilities: caps}}
+	}
+
+	return runOptions{
+		Targets:   targets,
+		Build:     f.build,
+		Tunnel:    f.tunnelName,
+		Async:     f.async,
+		Timeout:   f.timeout,
+		OutFormat: f.out,
+	}, nil
+}
+
+func RunCommand() *cobra.Command {
+	var flags runFlags
+
+	cmd := &cobra.Command{
+		Use:   "run <testCaseID>",
+		Short: "Runs a saved test case in the Sauce Labs cloud",
+		Long: `Runs a saved AI-authored test case in the Sauce Labs cloud and waits for the
+result, like 'saucectl run' does for framework tests. To run a whole test
+suite, use 'saucectl ai run-suite'.
+
+The target platform is taken from --browser/--platform when given, otherwise
+from the test case's authored run settings, otherwise the backend picks its
+default. Use --async to start the run without waiting for it to finish.`,
+		SilenceUsage: true,
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) != 1 || args[0] == "" {
+				return errors.New("no test case ID specified")
+			}
+			if len(args[0]) == testSuiteIDLength {
+				return fmt.Errorf("%q looks like a test suite ID; use `saucectl ai run-suite` to run a test suite", args[0])
+			}
+			return nil
+		},
+		PreRun: collectUsage,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts, err := flags.toOptions()
+			if err != nil {
+				return err
+			}
+			return runTestCase(cmd.Context(), args[0], opts)
+		},
+	}
+
+	flags.register(cmd)
+
+	return cmd
+}
+
+func RunSuiteCommand() *cobra.Command {
+	var flags runFlags
+
+	cmd := &cobra.Command{
+		Use:   "run-suite <testSuiteID>",
+		Short: "Runs all test cases of a saved test suite in the Sauce Labs cloud",
+		Long: `Runs every test case of a saved AI-authored test suite in the Sauce Labs
+cloud and aggregates the results. The test cases run concurrently, each as
+its own Sauce Labs job.
+
+The target platform is taken from --browser/--platform when given, otherwise
+from each test case's authored run settings, otherwise the backend picks its
+default. Use --async to start the runs without waiting for the results.`,
+		SilenceUsage: true,
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) != 1 || args[0] == "" {
+				return errors.New("no test suite ID specified")
+			}
+			if len(args[0]) == testCaseIDLength {
+				return fmt.Errorf("%q looks like a test case ID; use `saucectl ai run` to run a single test case", args[0])
+			}
+			return nil
+		},
+		PreRun: collectUsage,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts, err := flags.toOptions()
+			if err != nil {
+				return err
+			}
+			return runSuite(cmd.Context(), args[0], opts)
+		},
+	}
+
+	flags.register(cmd)
+
+	return cmd
+}
+
+func runTestCase(ctx context.Context, id string, opts runOptions) error {
+	tc, err := testCaseService.GetTestCase(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	run, err := startRun(ctx, tc, opts)
+	if err != nil {
+		return err
+	}
+
+	if opts.OutFormat == TextOutput {
+		fmt.Printf("Started run %s of test case %s with %d job(s)\n", run.ID, run.TestCaseID, len(run.Jobs))
+		if run.TestURL != "" {
+			fmt.Printf("Build URL: %s\n", run.TestURL)
+		}
+	}
+
+	if opts.Async {
+		if opts.OutFormat == JSONOutput {
+			return renderJSON(run)
+		}
+		return nil
+	}
+
+	final, err := pollRun(ctx, id, run, opts.Timeout)
+	if err != nil {
+		return err
+	}
+
+	return reportResults(toRunResults(final), opts.OutFormat)
+}
+
+func runSuite(ctx context.Context, suiteID string, opts runOptions) error {
+	suite, err := testSuiteReader.GetTestSuite(ctx, suiteID)
+	if err != nil {
+		return err
+	}
+
+	list, err := testCaseService.ListTestCases(ctx, aiauthoring.ListOptions{TestSuiteID: suiteID})
+	if err != nil {
+		return fmt.Errorf("failed to list the test cases of suite %q: %w", suite.Name, err)
+	}
+	if len(list.Items) == 0 {
+		return fmt.Errorf("test suite %q has no test cases", suite.Name)
+	}
+
+	if opts.OutFormat == TextOutput {
+		fmt.Printf("Running test suite %q with %d test case(s)\n", suite.Name, len(list.Items))
+	}
+
+	// A suite is run client-side: the backend has no suite-level run
+	// endpoint, so every test case is started individually.
+	type startedRun struct {
+		tc  aiauthoring.TestCase
+		run aiauthoring.TestCaseRun
+		err error
+	}
+	started := make([]startedRun, 0, len(list.Items))
+	for _, tc := range list.Items {
+		run, err := startRun(ctx, tc, opts)
+		started = append(started, startedRun{tc: tc, run: run, err: err})
+		if err != nil {
+			log.Error().Err(err).Str("testCase", tc.Name).Msg("Failed to start the test case run.")
+			continue
+		}
+		if opts.OutFormat == TextOutput {
+			fmt.Printf("Started run %s of test case %q\n", run.ID, tc.Name)
+		}
+	}
+
+	if opts.Async {
+		if opts.OutFormat == JSONOutput {
+			runs := make([]aiauthoring.TestCaseRun, 0, len(started))
+			for _, s := range started {
+				if s.err == nil {
+					runs = append(runs, s.run)
+				}
+			}
+			return renderJSON(runs)
+		}
+		return nil
+	}
+
+	// Poll all runs concurrently; they execute concurrently in the cloud.
+	results := make([][]runResult, len(started))
+	var wg sync.WaitGroup
+	for i, s := range started {
+		if s.err != nil {
+			results[i] = []runResult{{
+				Name:   s.tc.Name,
+				Status: job.StateError,
+				Error:  s.err.Error(),
+			}}
+			continue
+		}
+
+		wg.Add(1)
+		go func(i int, s startedRun) {
+			defer wg.Done()
+			final, err := pollRun(ctx, s.tc.ID, s.run, opts.Timeout)
+			if err != nil {
+				results[i] = []runResult{{
+					Name:   s.tc.Name,
+					Status: job.StateError,
+					Error:  err.Error(),
+				}}
+				return
+			}
+			results[i] = toRunResults(final)
+		}(i, s)
+	}
+	wg.Wait()
+
+	var merged []runResult
+	for _, r := range results {
+		merged = append(merged, r...)
+	}
+
+	return reportResults(merged, opts.OutFormat)
+}
+
+// startRun starts a run of the given test case, targeting the flag-provided
+// platforms if any, otherwise the test case's authored target.
+func startRun(ctx context.Context, tc aiauthoring.TestCase, opts runOptions) (aiauthoring.TestCaseRun, error) {
+	targets := opts.Targets
+	clearTunnel := false
+	if tc.RunSettings != nil {
+		if targets == nil && tc.RunSettings.PrimaryTarget != nil {
+			targets = []aiauthoring.RunTarget{*tc.RunSettings.PrimaryTarget}
+		}
+		// A test case authored with an empty (rather than absent) tunnel
+		// name fails to start with SC_TUNNEL_NOT_FOUND unless the tunnel is
+		// explicitly cleared.
+		if opts.Tunnel == "" && tc.RunSettings.SCTunnelName != nil && *tc.RunSettings.SCTunnelName == "" {
+			log.Debug().Str("testCase", tc.Name).Msg("Clearing the empty tunnel name stored in the test case's run settings.")
+			clearTunnel = true
+		}
+	}
+
+	run, err := testCaseRunner.RunTestCase(ctx, tc.ID, aiauthoring.RunRequest{
+		BuildName:    opts.Build,
+		SCTunnelName: opts.Tunnel,
+		ClearTunnel:  clearTunnel,
+		Targets:      targets,
+	})
+	if err != nil {
+		return aiauthoring.TestCaseRun{}, fmt.Errorf("failed to start the test case run: %w", err)
+	}
+	return run, nil
+}
+
+// pollRun polls the run until every job reaches a final state or the timeout
+// expires. The job ids returned by the run request are internal to the AI
+// Authoring backend and are not resolvable via the regular job APIs; the run
+// resource itself is the authoritative source of job progress, including the
+// Sauce job id and URL, which it reports once the job has been scheduled.
+func pollRun(ctx context.Context, testCaseID string, run aiauthoring.TestCaseRun, timeout time.Duration) (aiauthoring.TestCaseRun, error) {
+	log.Info().Str("runID", run.ID).Msg("Waiting for the run to finish. Device allocation can take a few minutes.")
+
+	ticker := time.NewTicker(runPollInterval)
+	defer ticker.Stop()
+	deathclock := time.NewTimer(timeout)
+	defer deathclock.Stop()
+
+	current := run
+	for {
+		if runDone(current) {
+			return current, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return current, ctx.Err()
+		case <-deathclock.C:
+			return current, fmt.Errorf("run did not finish within %s; check its status at %s", timeout, current.TestURL)
+		case <-ticker.C:
+			r, err := testCaseRunner.GetTestCaseRun(ctx, testCaseID, run.ID)
+			if err != nil {
+				// Transient lookup errors should not kill a run that is
+				// still executing in the cloud.
+				log.Warn().Err(err).Msg("Unable to fetch the run status. Retrying.")
+				continue
+			}
+			current = r
+		}
+	}
+}
+
+func runDone(run aiauthoring.TestCaseRun) bool {
+	for _, j := range run.Jobs {
+		if !j.Done() {
+			return false
+		}
+	}
+	return len(run.Jobs) > 0
+}
+
+func toRunResults(run aiauthoring.TestCaseRun) []runResult {
+	var results []runResult
+	for _, j := range run.Jobs {
+		status := job.StateFailed
+		if j.Passed() {
+			status = job.StatePassed
+		} else if j.Error != "" {
+			status = job.StateError
+		}
+
+		// The backend omits the job URL for VDC jobs; construct it from the
+		// Sauce job id instead.
+		u := j.URL
+		if u == "" && j.SauceJobID != "" {
+			u = fmt.Sprintf("%s/tests/%s", appURL, j.SauceJobID)
+		}
+
+		results = append(results, runResult{
+			Name:       j.Name,
+			SauceJobID: j.SauceJobID,
+			Status:     status,
+			Passed:     j.Passed(),
+			URL:        u,
+			Error:      j.Error,
+		})
+	}
+	return results
+}
+
+func reportResults(results []runResult, outFormat string) error {
+	if outFormat == JSONOutput {
+		if err := renderJSON(results); err != nil {
+			return err
+		}
+	} else {
+		renderRunResults(results)
+	}
+
+	for _, r := range results {
+		if !r.Passed {
+			return errors.New("some test case jobs have failed")
+		}
+	}
+
+	return nil
+}
+
+func renderRunResults(results []runResult) {
+	t := table.NewWriter()
+	t.SetStyle(tables.DefaultTableStyle)
+	t.SuppressEmptyColumns()
+
+	t.AppendHeader(table.Row{
+		"Name", "Status", "URL",
+	})
+
+	errCount := 0
+	for _, r := range results {
+		// the order of values must match the order of the header
+		t.AppendRow(table.Row{
+			r.Name,
+			r.Status,
+			r.URL,
+		})
+		if !r.Passed {
+			errCount++
+		}
+		if r.Error != "" {
+			log.Error().Str("name", r.Name).Msg(r.Error)
+		}
+	}
+
+	t.AppendFooter(table.Row{
+		fmt.Sprintf("%d of %d job(s) passed", len(results)-errCount, len(results)),
+	})
+
+	fmt.Println(t.Render())
+}

--- a/internal/cmd/ai/testcases.go
+++ b/internal/cmd/ai/testcases.go
@@ -1,0 +1,272 @@
+package ai
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/saucelabs/saucectl/internal/aiauthoring"
+	cmds "github.com/saucelabs/saucectl/internal/cmd"
+	"github.com/saucelabs/saucectl/internal/tables"
+	"github.com/saucelabs/saucectl/internal/usage"
+	"github.com/spf13/cobra"
+)
+
+const (
+	JSONOutput = "json"
+	TextOutput = "text"
+)
+
+func TestCasesCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "testcases",
+		Aliases: []string{
+			"tc",
+		},
+		Short:        "Manage saved AI-authored test cases",
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(
+		ListTestCasesCommand(),
+		GetTestCaseCommand(),
+		RenameTestCaseCommand(),
+		DeleteTestCaseCommand(),
+	)
+
+	return cmd
+}
+
+func ListTestCasesCommand() *cobra.Command {
+	var out string
+	var search string
+	var limit int
+	var skip int
+
+	cmd := &cobra.Command{
+		Use: "list",
+		Aliases: []string{
+			"ls",
+		},
+		Short:        "Returns the list of saved test cases",
+		SilenceUsage: true,
+		PreRun:       collectUsage,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if out != JSONOutput && out != TextOutput {
+				return errors.New("unknown output format")
+			}
+
+			list, err := testCaseService.ListTestCases(cmd.Context(), aiauthoring.ListOptions{
+				Search: search,
+				Limit:  limit,
+				Skip:   skip,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to list test cases: %w", err)
+			}
+
+			if out == JSONOutput {
+				return renderJSON(list)
+			}
+			renderTestCasesTable(list)
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&out, "out", "o", "text", "Output format to the console. Options: text, json.")
+	flags.StringVar(&search, "search", "", "Filter test cases by a search term.")
+	flags.IntVar(&limit, "limit", 0, "Maximum number of test cases to return.")
+	flags.IntVar(&skip, "skip", 0, "Number of test cases to skip, for paging.")
+
+	return cmd
+}
+
+func GetTestCaseCommand() *cobra.Command {
+	var out string
+
+	cmd := &cobra.Command{
+		Use:          "get <testCaseID>",
+		Short:        "Returns the details of a saved test case",
+		SilenceUsage: true,
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) != 1 || args[0] == "" {
+				return errors.New("no test case ID specified")
+			}
+			return nil
+		},
+		PreRun: collectUsage,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if out != JSONOutput && out != TextOutput {
+				return errors.New("unknown output format")
+			}
+
+			tc, err := testCaseService.GetTestCase(cmd.Context(), args[0])
+			if err != nil {
+				return fmt.Errorf("failed to get test case: %w", err)
+			}
+
+			if out == JSONOutput {
+				return renderJSON(tc)
+			}
+			renderTestCase(tc)
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&out, "out", "o", "text", "Output format to the console. Options: text, json.")
+
+	return cmd
+}
+
+func RenameTestCaseCommand() *cobra.Command {
+	var name string
+
+	cmd := &cobra.Command{
+		Use:          "rename <testCaseID>",
+		Short:        "Renames a saved test case",
+		SilenceUsage: true,
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) != 1 || args[0] == "" {
+				return errors.New("no test case ID specified")
+			}
+			return nil
+		},
+		PreRun: collectUsage,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			tc, err := testCaseService.RenameTestCase(cmd.Context(), args[0], name)
+			if err != nil {
+				return fmt.Errorf("failed to rename test case: %w", err)
+			}
+
+			fmt.Printf("Renamed test case %s to %q\n", tc.ID, tc.Name)
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&name, "name", "n", "", "The new name for the test case.")
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func DeleteTestCaseCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "delete <testCaseID>",
+		Short:        "Deletes a saved test case",
+		SilenceUsage: true,
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) != 1 || args[0] == "" {
+				return errors.New("no test case ID specified")
+			}
+			return nil
+		},
+		PreRun: collectUsage,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := testCaseService.DeleteTestCase(cmd.Context(), args[0]); err != nil {
+				return fmt.Errorf("failed to delete test case: %w", err)
+			}
+
+			fmt.Printf("Deleted test case %s\n", args[0])
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func collectUsage(cmd *cobra.Command, _ []string) {
+	tracker := usage.DefaultClient
+
+	go func() {
+		tracker.Collect(
+			cmds.FullName(cmd),
+			usage.Flags(cmd.Flags()),
+		)
+		_ = tracker.Close()
+	}()
+}
+
+func renderJSON(val any) error {
+	return json.NewEncoder(os.Stdout).Encode(val)
+}
+
+func renderTestCasesTable(list aiauthoring.List) {
+	if len(list.Items) == 0 {
+		println("No test cases found")
+		return
+	}
+
+	t := table.NewWriter()
+	t.SetStyle(tables.DefaultTableStyle)
+	t.SuppressEmptyColumns()
+
+	t.AppendHeader(table.Row{
+		"ID", "Name", "Status", "Created", "Creator",
+	})
+
+	for _, item := range list.Items {
+		// the order of values must match the order of the header
+		t.AppendRow(table.Row{
+			item.ID,
+			item.Name,
+			item.Status,
+			item.Created(),
+			item.CreatorUserName,
+		})
+	}
+
+	t.AppendFooter(table.Row{
+		fmt.Sprintf("showing %d of %d test cases", len(list.Items), list.Total),
+	})
+
+	fmt.Println(t.Render())
+}
+
+func renderTestCase(tc aiauthoring.TestCase) {
+	fields := []struct {
+		label string
+		value string
+	}{
+		{"ID", tc.ID},
+		{"Name", tc.Name},
+		{"Status", tc.Status},
+		{"Description", tc.Description},
+		{"Framework", tc.Framework},
+		{"Created", tc.Created()},
+		{"Updated", tc.Updated()},
+		{"Creator", tc.CreatorUserName},
+		{"Team", tc.TeamID},
+		{"Suite", suiteLabel(tc)},
+		{"Test URL", testURL(tc)},
+	}
+
+	for _, f := range fields {
+		if f.value == "" {
+			continue
+		}
+		fmt.Printf("%-12s %s\n", f.label+":", f.value)
+	}
+}
+
+func suiteLabel(tc aiauthoring.TestCase) string {
+	if tc.TestSuiteName != "" {
+		return tc.TestSuiteName
+	}
+	return tc.TestSuiteID
+}
+
+func testURL(tc aiauthoring.TestCase) string {
+	if tc.RunSettings == nil {
+		return ""
+	}
+	return tc.RunSettings.TestURL
+}

--- a/internal/http/aiauthoring.go
+++ b/internal/http/aiauthoring.go
@@ -1,0 +1,406 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/saucelabs/saucectl/internal/aiauthoring"
+	"github.com/saucelabs/saucectl/internal/iam"
+	"github.com/saucelabs/saucectl/internal/region"
+	"github.com/saucelabs/saucectl/internal/version"
+)
+
+const aiAuthoringEntitlementKey = "ai_authoring.enabled"
+
+// AIAuthoringAPIError is a structured error reported by the AI Authoring
+// API, e.g. SC_TUNNEL_NOT_FOUND or TEST_CASE_REVISION_NOT_FOUND.
+type AIAuthoringAPIError struct {
+	StatusCode int
+	Code       string
+	Detail     string
+}
+
+func (e *AIAuthoringAPIError) Error() string {
+	if e.Detail != "" && e.Code != "" {
+		return fmt.Sprintf("%s (%s)", e.Detail, e.Code)
+	}
+	if e.Detail != "" {
+		return e.Detail
+	}
+	return fmt.Sprintf("unexpected server response (%d)", e.StatusCode)
+}
+
+// AIAuthoringService is a client for the Sauce Labs AI Test Authoring API.
+type AIAuthoringService struct {
+	// Client is used for idempotent (GET) requests and retries on
+	// connection errors, 429 and 5xx responses.
+	Client *retryablehttp.Client
+	// HTTPClient is used for non-idempotent (POST, DELETE) requests, which
+	// are never retried.
+	HTTPClient  *http.Client
+	URL         string
+	Credentials iam.Credentials
+}
+
+// NewAIAuthoringService returns a new AIAuthoringService for the given region.
+func NewAIAuthoringService(r region.Region, creds iam.Credentials, timeout time.Duration) AIAuthoringService {
+	return AIAuthoringService{
+		Client: newAIRetryableClient(timeout),
+		HTTPClient: &http.Client{
+			Timeout:   timeout,
+			Transport: &http.Transport{Proxy: http.ProxyFromEnvironment},
+		},
+		URL:         r.APIBaseURL(),
+		Credentials: creds,
+	}
+}
+
+// newAIRetryableClient is like NewRetryableClient, but does not retry 404s:
+// for test case lookups a 404 is a definitive "not found" answer.
+func newAIRetryableClient(timeout time.Duration) *retryablehttp.Client {
+	return &retryablehttp.Client{
+		HTTPClient: &http.Client{
+			Timeout:   timeout,
+			Transport: &http.Transport{Proxy: http.ProxyFromEnvironment},
+		},
+		RetryWaitMin: 1 * time.Second,
+		RetryWaitMax: 10 * time.Second,
+		RetryMax:     3,
+		CheckRetry:   retryablehttp.DefaultRetryPolicy,
+		Backoff:      retryablehttp.DefaultBackoff,
+		ErrorHandler: retryablehttp.PassthroughErrorHandler,
+	}
+}
+
+// ListTestCases returns saved test cases matching the given options.
+func (c *AIAuthoringService) ListTestCases(ctx context.Context, opts aiauthoring.ListOptions) (aiauthoring.List, error) {
+	u := fmt.Sprintf("%s/v1/ai-authoring/testcases", c.URL)
+	if q := listQuery(opts); q != "" {
+		u += "?" + q
+	}
+
+	body, err := c.get(ctx, u)
+	if err != nil {
+		return aiauthoring.List{}, err
+	}
+
+	return parseTestCaseList(body)
+}
+
+// GetTestCase fetches a single saved test case by its id.
+func (c *AIAuthoringService) GetTestCase(ctx context.Context, id string) (aiauthoring.TestCase, error) {
+	u := fmt.Sprintf("%s/v1/ai-authoring/testcases/%s", c.URL, url.PathEscape(id))
+
+	body, err := c.get(ctx, u)
+	if err != nil {
+		return aiauthoring.TestCase{}, testCaseErr(id, err)
+	}
+
+	return parseData[aiauthoring.TestCase](body)
+}
+
+// RenameTestCase renames a saved test case.
+func (c *AIAuthoringService) RenameTestCase(ctx context.Context, id, name string) (aiauthoring.TestCase, error) {
+	u := fmt.Sprintf("%s/v1/ai-authoring/testcases/%s/rename", c.URL, url.PathEscape(id))
+
+	payload, err := json.Marshal(struct {
+		Name string `json:"name"`
+	}{Name: name})
+	if err != nil {
+		return aiauthoring.TestCase{}, err
+	}
+
+	body, err := c.do(ctx, http.MethodPost, u, bytes.NewReader(payload))
+	if err != nil {
+		return aiauthoring.TestCase{}, testCaseErr(id, err)
+	}
+	if len(body) == 0 {
+		return aiauthoring.TestCase{ID: id, Name: name}, nil
+	}
+
+	return parseData[aiauthoring.TestCase](body)
+}
+
+// RunTestCase starts a cloud run of a saved test case. The returned run
+// holds one ordinary Sauce Labs job per target.
+func (c *AIAuthoringService) RunTestCase(ctx context.Context, id string, r aiauthoring.RunRequest) (aiauthoring.TestCaseRun, error) {
+	u := fmt.Sprintf("%s/v1/ai-authoring/testcases/%s/run", c.URL, url.PathEscape(id))
+
+	payload, err := json.Marshal(r)
+	if err != nil {
+		return aiauthoring.TestCaseRun{}, err
+	}
+
+	body, err := c.do(ctx, http.MethodPost, u, bytes.NewReader(payload))
+	if err != nil {
+		return aiauthoring.TestCaseRun{}, testCaseErr(id, err)
+	}
+
+	return parseData[aiauthoring.TestCaseRun](body)
+}
+
+// GetTestSuite fetches a single saved test suite by its id.
+func (c *AIAuthoringService) GetTestSuite(ctx context.Context, id string) (aiauthoring.TestSuite, error) {
+	u := fmt.Sprintf("%s/v1/ai-authoring/testsuites/%s", c.URL, url.PathEscape(id))
+
+	body, err := c.get(ctx, u)
+	if err != nil {
+		var apiErr *AIAuthoringAPIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return aiauthoring.TestSuite{}, fmt.Errorf("test suite %q not found", id)
+		}
+		return aiauthoring.TestSuite{}, err
+	}
+
+	return parseData[aiauthoring.TestSuite](body)
+}
+
+// GetTestCaseRun fetches the current state of a test case run. Job details
+// (sauceJobId, url, success) are filled in by the backend as the run
+// progresses.
+func (c *AIAuthoringService) GetTestCaseRun(ctx context.Context, testCaseID, runID string) (aiauthoring.TestCaseRun, error) {
+	u := fmt.Sprintf("%s/v1/ai-authoring/testcases/%s/runs/%s",
+		c.URL, url.PathEscape(testCaseID), url.PathEscape(runID))
+
+	body, err := c.get(ctx, u)
+	if err != nil {
+		return aiauthoring.TestCaseRun{}, err
+	}
+
+	return parseData[aiauthoring.TestCaseRun](body)
+}
+
+// DeleteTestCase deletes a saved test case.
+func (c *AIAuthoringService) DeleteTestCase(ctx context.Context, id string) error {
+	u := fmt.Sprintf("%s/v1/ai-authoring/testcases/%s", c.URL, url.PathEscape(id))
+
+	_, err := c.do(ctx, http.MethodDelete, u, nil)
+	return testCaseErr(id, err)
+}
+
+// testCaseErr converts a generic 404 into a friendly, test-case-specific
+// error, preserving the backend's detail when it reported one.
+func testCaseErr(id string, err error) error {
+	var apiErr *AIAuthoringAPIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+		if apiErr.Detail != "" {
+			return fmt.Errorf("test case %q: %s", id, apiErr)
+		}
+		return fmt.Errorf("test case %q not found", id)
+	}
+	return err
+}
+
+// IsAIAuthoringEnabled reports whether the ai_authoring.enabled entitlement
+// is granted to the given organization.
+func (c *AIAuthoringService) IsAIAuthoringEnabled(ctx context.Context, orgID string) (bool, error) {
+	if orgID == "" {
+		return false, errors.New("orgID is required to fetch entitlements")
+	}
+	u := fmt.Sprintf("%s/v2/entitlements/entities/org/%s?entitlements=%s",
+		c.URL, url.PathEscape(orgID), url.QueryEscape(aiAuthoringEntitlementKey))
+
+	body, err := c.get(ctx, u)
+	if err != nil {
+		return false, err
+	}
+
+	var resp struct {
+		Entitlements []struct {
+			Name  string `json:"name"`
+			Value any    `json:"value"`
+		} `json:"entitlements"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return false, fmt.Errorf("unexpected entitlements response: %w", err)
+	}
+
+	for _, e := range resp.Entitlements {
+		if e.Name != aiAuthoringEntitlementKey {
+			continue
+		}
+		switch v := e.Value.(type) {
+		case bool:
+			return v, nil
+		case string:
+			return v == "true", nil
+		}
+	}
+
+	// The entitlement gate fails closed.
+	return false, nil
+}
+
+// get performs a retryable GET request and returns the response body.
+func (c *AIAuthoringService) get(ctx context.Context, url string) ([]byte, error) {
+	req, err := NewRetryableRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.applyHeaders(req.Header)
+	req.SetBasicAuth(c.Credentials.Username, c.Credentials.AccessKey)
+
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return readResponse(resp)
+}
+
+// do performs a non-retryable request and returns the response body.
+func (c *AIAuthoringService) do(ctx context.Context, method, url string, body io.Reader) ([]byte, error) {
+	req, err := NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	c.applyHeaders(req.Header)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.SetBasicAuth(c.Credentials.Username, c.Credentials.AccessKey)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return readResponse(resp)
+}
+
+func (c *AIAuthoringService) applyHeaders(h http.Header) {
+	// The AI Authoring backend identifies clients by this header.
+	h.Set("requested-by", "saucectl/"+version.Version)
+	h.Set("Accept", "application/json")
+}
+
+func readResponse(resp *http.Response) ([]byte, error) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return body, nil
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return nil, fmt.Errorf("Sauce Labs rejected the provided credentials (%d); run `saucectl configure` to update them", resp.StatusCode)
+	}
+
+	apiErr := AIAuthoringAPIError{StatusCode: resp.StatusCode}
+	var envelope struct {
+		Error struct {
+			Code   string `json:"code"`
+			Detail string `json:"detail"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil {
+		apiErr.Code = envelope.Error.Code
+		apiErr.Detail = envelope.Error.Detail
+	}
+	if apiErr.Detail == "" && len(body) > 0 && resp.StatusCode != http.StatusNotFound {
+		apiErr.Detail = string(body)
+	}
+
+	return nil, &apiErr
+}
+
+func listQuery(opts aiauthoring.ListOptions) string {
+	q := url.Values{}
+	if opts.Search != "" {
+		q.Set("search", opts.Search)
+	}
+	if opts.Skip > 0 {
+		q.Set("skip", strconv.Itoa(opts.Skip))
+	}
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.StartDate != "" {
+		q.Set("startDate", opts.StartDate)
+	}
+	if opts.EndDate != "" {
+		q.Set("endDate", opts.EndDate)
+	}
+	if opts.UserID != "" {
+		q.Set("userId", opts.UserID)
+	}
+	if opts.TeamID != "" {
+		q.Set("teamId", opts.TeamID)
+	}
+	if opts.TestSuiteID != "" {
+		q.Set("testSuiteId", opts.TestSuiteID)
+	}
+	return q.Encode()
+}
+
+// parseTestCaseList normalizes the listing response. The backend returns
+// either a bare array or an envelope ({items|results|testcases: [...],
+// total|count: n}), optionally nested one level under "data".
+func parseTestCaseList(data []byte) (aiauthoring.List, error) {
+	var items []aiauthoring.TestCase
+	if err := json.Unmarshal(data, &items); err == nil {
+		return aiauthoring.List{Items: items, Total: len(items)}, nil
+	}
+
+	var env struct {
+		Items     []aiauthoring.TestCase `json:"items"`
+		Results   []aiauthoring.TestCase `json:"results"`
+		TestCases []aiauthoring.TestCase `json:"testcases"`
+		Total     *int                   `json:"total"`
+		Count     *int                   `json:"count"`
+		Data      json.RawMessage        `json:"data"`
+	}
+	if err := json.Unmarshal(data, &env); err != nil {
+		return aiauthoring.List{}, fmt.Errorf("unexpected test case list response: %w", err)
+	}
+
+	switch {
+	case env.Items != nil:
+		items = env.Items
+	case env.Results != nil:
+		items = env.Results
+	case env.TestCases != nil:
+		items = env.TestCases
+	case len(env.Data) > 0:
+		return parseTestCaseList(env.Data)
+	}
+
+	total := len(items)
+	if env.Total != nil {
+		total = *env.Total
+	} else if env.Count != nil {
+		total = *env.Count
+	}
+
+	return aiauthoring.List{Items: items, Total: total}, nil
+}
+
+// parseData unwraps the optional {"data": {...}} envelope the AI Authoring
+// API wraps around single resources.
+func parseData[T any](data []byte) (T, error) {
+	var env struct {
+		Data *T `json:"data"`
+	}
+	if err := json.Unmarshal(data, &env); err == nil && env.Data != nil {
+		return *env.Data, nil
+	}
+
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		var zero T
+		return zero, fmt.Errorf("unexpected server response: %w", err)
+	}
+	return v, nil
+}

--- a/internal/http/aiauthoring_test.go
+++ b/internal/http/aiauthoring_test.go
@@ -1,0 +1,413 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/saucelabs/saucectl/internal/aiauthoring"
+	"github.com/saucelabs/saucectl/internal/iam"
+)
+
+func newTestAIAuthoringService(url string) AIAuthoringService {
+	c := newAIRetryableClient(10 * time.Second)
+	c.RetryMax = 0
+
+	return AIAuthoringService{
+		Client:     c,
+		HTTPClient: &http.Client{Timeout: 10 * time.Second},
+		URL:        url,
+		Credentials: iam.Credentials{
+			Username:  "user",
+			AccessKey: "key",
+		},
+	}
+}
+
+func TestAIAuthoringService_ListTestCases(t *testing.T) {
+	testCases := []struct {
+		name      string
+		opts      aiauthoring.ListOptions
+		wantQuery string
+		response  string
+		want      aiauthoring.List
+		wantErr   bool
+	}{
+		{
+			name:     "bare array response",
+			response: `[{"id":"tc1","name":"Cart"},{"id":"tc2","name":"Login"}]`,
+			want: aiauthoring.List{
+				Items: []aiauthoring.TestCase{
+					{ID: "tc1", Name: "Cart"},
+					{ID: "tc2", Name: "Login"},
+				},
+				Total: 2,
+			},
+		},
+		{
+			name:      "items envelope with total and query params",
+			opts:      aiauthoring.ListOptions{Search: "cart", Limit: 10, Skip: 5, TestSuiteID: "suite1"},
+			wantQuery: "limit=10&search=cart&skip=5&testSuiteId=suite1",
+			response:  `{"items":[{"id":"tc1","name":"Cart"}],"total":42}`,
+			want: aiauthoring.List{
+				Items: []aiauthoring.TestCase{{ID: "tc1", Name: "Cart"}},
+				Total: 42,
+			},
+		},
+		{
+			name:     "results nested under data with count",
+			response: `{"data":{"results":[{"id":"tc1","name":"Cart"}],"count":7}}`,
+			want: aiauthoring.List{
+				Items: []aiauthoring.TestCase{{ID: "tc1", Name: "Cart"}},
+				Total: 7,
+			},
+		},
+		{
+			name:     "empty object response",
+			response: `{}`,
+			want:     aiauthoring.List{},
+		},
+		{
+			name:     "malformed response",
+			response: `"nope"`,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/ai-authoring/testcases" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				if r.URL.RawQuery != tc.wantQuery {
+					t.Errorf("query = %q, want %q", r.URL.RawQuery, tc.wantQuery)
+				}
+				if user, pass, _ := r.BasicAuth(); user != "user" || pass != "key" {
+					t.Errorf("unexpected basic auth: %s:%s", user, pass)
+				}
+				if rb := r.Header.Get("requested-by"); rb == "" {
+					t.Error("requested-by header is not set")
+				}
+				fmt.Fprint(w, tc.response)
+			}))
+			defer ts.Close()
+
+			c := newTestAIAuthoringService(ts.URL)
+			got, err := c.ListTestCases(context.Background(), tc.opts)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %t", err, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAIAuthoringService_GetTestCase(t *testing.T) {
+	testCases := []struct {
+		name     string
+		id       string
+		status   int
+		response string
+		want     aiauthoring.TestCase
+		wantErr  string
+	}{
+		{
+			name:     "plain response",
+			id:       "tc1",
+			status:   http.StatusOK,
+			response: `{"id":"tc1","name":"Cart","status":"SAVED"}`,
+			want:     aiauthoring.TestCase{ID: "tc1", Name: "Cart", Status: "SAVED"},
+		},
+		{
+			name:     "data envelope",
+			id:       "tc1",
+			status:   http.StatusOK,
+			response: `{"data":{"id":"tc1","name":"Cart","runSettings":{"testUrl":"https://example.com"}}}`,
+			want: aiauthoring.TestCase{
+				ID:          "tc1",
+				Name:        "Cart",
+				RunSettings: &aiauthoring.RunSettings{TestURL: "https://example.com"},
+			},
+		},
+		{
+			name:    "not found",
+			id:      "nope",
+			status:  http.StatusNotFound,
+			wantErr: `test case "nope" not found`,
+		},
+		{
+			name:     "not found with backend detail",
+			id:       "draft",
+			status:   http.StatusNotFound,
+			response: `{"error":{"code":"TEST_CASE_REVISION_NOT_FOUND","detail":"Test case revision not found."}}`,
+			wantErr:  `test case "draft": Test case revision not found. (TEST_CASE_REVISION_NOT_FOUND)`,
+		},
+		{
+			name:    "unauthorized",
+			id:      "tc1",
+			status:  http.StatusUnauthorized,
+			wantErr: "rejected the provided credentials",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if want := "/v1/ai-authoring/testcases/" + tc.id; r.URL.Path != want {
+					t.Errorf("path = %s, want %s", r.URL.Path, want)
+				}
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, tc.response)
+			}))
+			defer ts.Close()
+
+			c := newTestAIAuthoringService(ts.URL)
+			got, err := c.GetTestCase(context.Background(), tc.id)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error, got none")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %q, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAIAuthoringService_RenameTestCase(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if want := "/v1/ai-authoring/testcases/tc1/rename"; r.URL.Path != want {
+			t.Errorf("path = %s, want %s", r.URL.Path, want)
+		}
+		var body struct {
+			Name string `json:"name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("failed to decode body: %v", err)
+		}
+		if body.Name != "New Name" {
+			t.Errorf("name = %q, want %q", body.Name, "New Name")
+		}
+		fmt.Fprintf(w, `{"id":"tc1","name":%q}`, body.Name)
+	}))
+	defer ts.Close()
+
+	c := newTestAIAuthoringService(ts.URL)
+	got, err := c.RenameTestCase(context.Background(), "tc1", "New Name")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "New Name" {
+		t.Errorf("name = %q, want %q", got.Name, "New Name")
+	}
+}
+
+func TestAIAuthoringService_RunTestCase(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if want := "/v1/ai-authoring/testcases/tc1/run"; r.URL.Path != want {
+			t.Errorf("path = %s, want %s", r.URL.Path, want)
+		}
+		var req aiauthoring.RunRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode body: %v", err)
+		}
+		if req.BuildName != "my-build" || req.SCTunnelName != "my-tunnel" {
+			t.Errorf("unexpected request: %+v", req)
+		}
+		if len(req.Targets) != 1 || req.Targets[0].Capabilities["browserName"] != "chrome" {
+			t.Errorf("unexpected targets: %+v", req.Targets)
+		}
+		fmt.Fprint(w, `{"data":{"id":"run1","testCaseId":"tc1","build":"my-build",
+			"jobs":[{"id":"job1","name":"Chrome","target":{"capabilities":{"browserName":"chrome"},"isRdc":false},"url":"https://app/tests/job1"}],
+			"testUrl":"https://app/builds/b1"}}`)
+	}))
+	defer ts.Close()
+
+	c := newTestAIAuthoringService(ts.URL)
+	run, err := c.RunTestCase(context.Background(), "tc1", aiauthoring.RunRequest{
+		BuildName:    "my-build",
+		SCTunnelName: "my-tunnel",
+		Targets: []aiauthoring.RunTarget{
+			{Capabilities: aiauthoring.RunCapabilities{"browserName": "chrome"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if run.ID != "run1" || len(run.Jobs) != 1 || run.Jobs[0].ID != "job1" {
+		t.Errorf("unexpected run: %+v", run)
+	}
+	if run.Jobs[0].Target.IsRDC {
+		t.Error("job must not be flagged as RDC")
+	}
+}
+
+func TestAIAuthoringService_GetTestSuite(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if want := "/v1/ai-authoring/testsuites/suite1"; r.URL.Path != want {
+			t.Errorf("path = %s, want %s", r.URL.Path, want)
+		}
+		fmt.Fprint(w, `{"data":{"id":"suite1","name":"Example Test Suite","testCaseCount":3,"runCount":1}}`)
+	}))
+	defer ts.Close()
+
+	c := newTestAIAuthoringService(ts.URL)
+	suite, err := c.GetTestSuite(context.Background(), "suite1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if suite.Name != "Example Test Suite" || suite.TestCaseCount != 3 {
+		t.Errorf("unexpected suite: %+v", suite)
+	}
+}
+
+func TestAIAuthoringService_GetTestCaseRun(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if want := "/v1/ai-authoring/testcases/tc1/runs/run1"; r.URL.Path != want {
+			t.Errorf("path = %s, want %s", r.URL.Path, want)
+		}
+		fmt.Fprint(w, `{"data":{"id":"run1","testCaseId":"tc1",
+			"jobs":[{"id":"internal1","sauceJobId":"57c325ee","name":"Pixel 7",
+			"url":"https://app.saucelabs.com/tests/57c325ee","success":true,
+			"target":{"capabilities":{"platformName":"Android"},"isRdc":true}}]}}`)
+	}))
+	defer ts.Close()
+
+	c := newTestAIAuthoringService(ts.URL)
+	run, err := c.GetTestCaseRun(context.Background(), "tc1", "run1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(run.Jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(run.Jobs))
+	}
+	j := run.Jobs[0]
+	if j.SauceJobID != "57c325ee" || !j.Done() || !j.Passed() || !j.Target.IsRDC {
+		t.Errorf("unexpected job: %+v", j)
+	}
+}
+
+func TestAIAuthoringService_DeleteTestCase(t *testing.T) {
+	testCases := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{name: "deleted", status: http.StatusNoContent},
+		{name: "not found", status: http.StatusNotFound, wantErr: true},
+		{name: "server error", status: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				if r.Method != http.MethodDelete {
+					t.Errorf("method = %s, want DELETE", r.Method)
+				}
+				w.WriteHeader(tc.status)
+			}))
+			defer ts.Close()
+
+			c := newTestAIAuthoringService(ts.URL)
+			err := c.DeleteTestCase(context.Background(), "tc1")
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %t", err, tc.wantErr)
+			}
+			if calls != 1 {
+				t.Errorf("delete must never be retried, got %d calls", calls)
+			}
+		})
+	}
+}
+
+func TestAIAuthoringService_IsAIAuthoringEnabled(t *testing.T) {
+	testCases := []struct {
+		name     string
+		orgID    string
+		response string
+		want     bool
+		wantErr  bool
+	}{
+		{
+			name:     "enabled as bool",
+			orgID:    "org1",
+			response: `{"entitlements":[{"name":"ai_authoring.enabled","value":true}]}`,
+			want:     true,
+		},
+		{
+			name:     "enabled as string",
+			orgID:    "org1",
+			response: `{"entitlements":[{"name":"ai_authoring.enabled","value":"true"}]}`,
+			want:     true,
+		},
+		{
+			name:     "disabled",
+			orgID:    "org1",
+			response: `{"entitlements":[{"name":"ai_authoring.enabled","value":false}]}`,
+			want:     false,
+		},
+		{
+			name:     "missing entitlement fails closed",
+			orgID:    "org1",
+			response: `{"entitlements":[]}`,
+			want:     false,
+		},
+		{
+			name:    "missing org id",
+			orgID:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if want := "/v2/entitlements/entities/org/" + tc.orgID; r.URL.Path != want {
+					t.Errorf("path = %s, want %s", r.URL.Path, want)
+				}
+				if got := r.URL.Query().Get("entitlements"); got != "ai_authoring.enabled" {
+					t.Errorf("entitlements param = %q", got)
+				}
+				fmt.Fprint(w, tc.response)
+			}))
+			defer ts.Close()
+
+			c := newTestAIAuthoringService(ts.URL)
+			got, err := c.IsAIAuthoringEnabled(context.Background(), tc.orgID)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %t", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("got %t, want %t", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
Adds a first CLI surface for Sauce Labs AI Test Authoring, backed by
the same REST backend the VS Code and IntelliJ plugins use:

- `saucectl ai testcases list|get|rename|delete` — manage saved test
  cases (-o text|json, --search/--limit/--skip filters)
- `saucectl ai run <testCaseID>` — run a saved test case in the cloud,
  poll to completion, and exit non-zero on failure (CI-friendly);
  --async, --build, --tunnel-name, --browser/--platform overrides
- `saucectl ai run-suite <testSuiteID>` — run every test case of a
  suite concurrently and aggregate the results (the backend has no
  suite-level run endpoint, so the suite is fanned out client-side)

Implementation notes:
- internal/aiauthoring holds the domain types and service interfaces;
  internal/http/aiauthoring.go is the REST client (Basic auth,
  requested-by client-identity header, retryable GETs, non-retried
  mutations, enveloped-response normalization, structured
  AIAuthoringAPIError with the backend's error code/detail).
- Commands are gated on the fail-closed ai_authoring.enabled org
  entitlement, distinguishing "not in plan" from verification failures.
- Run polling uses GET testcases/{id}/runs/{runId}: the job ids in the
  run-start response are internal to the backend and not resolvable via
  the Resto/RDC job APIs; sauceJobId, url, and success appear on the
  run resource as the run progresses. VDC job URLs are constructed
  from sauceJobId because the backend omits them.
- Test cases authored with an empty (rather than absent)
  runSettings.scTunnelName fail to start with SC_TUNNEL_NOT_FOUND; runs
  neutralize such tunnels by sending an explicit scTunnelName: null.

The `ai` group ships hidden until the feature is ready for release.
