### PR TITLE
Add asia-south-2 region

### DIFF
--- a/api/saucectl.schema.json
+++ b/api/saucectl.schema.json
@@ -617,7 +617,8 @@
                     "enum": [
                       "us-west-1",
                       "us-east-4",
-                      "eu-central-1"
+                      "eu-central-1",
+                      "asia-south-2"
                     ]
                   },
                   "sauceignore": {
@@ -1406,7 +1407,8 @@
                     "enum": [
                       "us-west-1",
                       "us-east-4",
-                      "eu-central-1"
+                      "eu-central-1",
+                      "asia-south-2"
                     ]
                   },
                   "sauceignore": {
@@ -1913,7 +1915,8 @@
                     "enum": [
                       "us-west-1",
                       "us-east-4",
-                      "eu-central-1"
+                      "eu-central-1",
+                      "asia-south-2"
                     ]
                   },
                   "sauceignore": {
@@ -2277,7 +2280,8 @@
                     "enum": [
                       "us-west-1",
                       "us-east-4",
-                      "eu-central-1"
+                      "eu-central-1",
+                      "asia-south-2"
                     ]
                   },
                   "sauceignore": {
@@ -2874,7 +2878,8 @@
                     "enum": [
                       "us-west-1",
                       "us-east-4",
-                      "eu-central-1"
+                      "eu-central-1",
+                      "asia-south-2"
                     ]
                   },
                   "sauceignore": {
@@ -3495,7 +3500,8 @@
                     "enum": [
                       "us-west-1",
                       "us-east-4",
-                      "eu-central-1"
+                      "eu-central-1",
+                      "asia-south-2"
                     ]
                   },
                   "sauceignore": {
@@ -4078,7 +4084,8 @@
                     "enum": [
                       "us-west-1",
                       "us-east-4",
-                      "eu-central-1"
+                      "eu-central-1",
+                      "asia-south-2"
                     ]
                   },
                   "sauceignore": {
@@ -4402,7 +4409,8 @@
                     "enum": [
                       "us-west-1",
                       "us-east-4",
-                      "eu-central-1"
+                      "eu-central-1",
+                      "asia-south-2"
                     ]
                   },
                   "sauceignore": {

--- a/api/v1alpha/subschema/sauce.schema.json
+++ b/api/v1alpha/subschema/sauce.schema.json
@@ -33,7 +33,8 @@
           "enum": [
             "us-west-1",
             "us-east-4",
-            "eu-central-1"
+            "eu-central-1",
+            "asia-south-2"
           ]
         },
         "sauceignore": {

--- a/internal/cmd/run/cypress.go
+++ b/internal/cmd/run/cypress.go
@@ -122,7 +122,7 @@ func runCypress(cmd *cobra.Command, cflags cypressFlags, isCLIDriven bool) (int,
 	}
 
 	regio := region.FromString(p.GetSauceCfg().Region)
-	if regio == region.USEast4 {
+	if regio == region.USEast4 || regio == region.AsiaSouth2 {
 		return 1, errors.New(msg.NoFrameworkSupport)
 	}
 

--- a/internal/cmd/run/playwright.go
+++ b/internal/cmd/run/playwright.go
@@ -130,7 +130,7 @@ func runPlaywright(cmd *cobra.Command, pf playwrightFlags, isCLIDriven bool) (in
 	}
 
 	regio := region.FromString(p.Sauce.Region)
-	if regio == region.USEast4 {
+	if regio == region.USEast4 || regio == region.AsiaSouth2 {
 		return 1, errors.New(msg.NoFrameworkSupport)
 	}
 

--- a/internal/cmd/run/replay.go
+++ b/internal/cmd/run/replay.go
@@ -90,7 +90,7 @@ func runReplay(cmd *cobra.Command, isCLIDriven bool) (int, error) {
 	p.Suites = ss
 
 	regio := region.FromString(p.Sauce.Region)
-	if regio == region.USEast4 {
+	if regio == region.USEast4 || regio == region.AsiaSouth2 {
 		return 1, errors.New(msg.NoFrameworkSupport)
 	}
 

--- a/internal/cmd/run/testcafe.go
+++ b/internal/cmd/run/testcafe.go
@@ -153,7 +153,7 @@ func runTestcafe(cmd *cobra.Command, tcFlags testcafeFlags, isCLIDriven bool) (i
 	}
 
 	regio := region.FromString(p.Sauce.Region)
-	if regio == region.USEast4 {
+	if regio == region.USEast4 || regio == region.AsiaSouth2 {
 		return 1, errors.New(msg.NoFrameworkSupport)
 	}
 

--- a/internal/espresso/config.go
+++ b/internal/espresso/config.go
@@ -208,7 +208,7 @@ func Validate(p Project) error {
 		if err := validateEmulators(suite.Name, suite.Emulators); err != nil {
 			return err
 		}
-		if regio == region.USEast4 && len(suite.Emulators) > 0 {
+		if (regio == region.USEast4 || regio == region.AsiaSouth2) && len(suite.Emulators) > 0 {
 			return errors.New(msg.NoEmulatorSupport)
 		}
 		if p.Sauce.Retries < suite.PassThreshold-1 {

--- a/internal/espresso/config_test.go
+++ b/internal/espresso/config_test.go
@@ -152,6 +152,52 @@ func TestValidateThrowsErrors(t *testing.T) {
 			},
 			expectedErr: errors.New("missing platform versions for emulator: Android GoogleApi Emulator. Suite name: no emulator device name. Emulators index: 0"),
 		},
+		{
+			// asia-south-2 (India) is real-device-only: its platform list is
+			// empty, so emulator suites must be rejected before any upload.
+			name: "validating throws error on emulators in asia-south-2",
+			p: &Project{
+				Sauce: config.SauceConfig{Region: "asia-south-2"},
+				Espresso: Espresso{
+					App:     appAPK,
+					TestApp: appAPK,
+				},
+				Suites: []Suite{
+					{
+						Name: "emulator suite",
+						Emulators: []config.Emulator{
+							{
+								Name:             "Android GoogleApi Emulator",
+								PlatformVersions: []string{"11.0"},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New("emulators are currently not supported in your specified region"),
+		},
+		{
+			name: "validating throws error on emulators in us-east-4",
+			p: &Project{
+				Sauce: config.SauceConfig{Region: "us-east-4"},
+				Espresso: Espresso{
+					App:     appAPK,
+					TestApp: appAPK,
+				},
+				Suites: []Suite{
+					{
+						Name: "emulator suite",
+						Emulators: []config.Emulator{
+							{
+								Name:             "Android GoogleApi Emulator",
+								PlatformVersions: []string{"11.0"},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New("emulators are currently not supported in your specified region"),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/region/region.go
+++ b/internal/region/region.go
@@ -48,6 +48,9 @@ const USEast4 Region = "us-east-4"
 // EUCentral1 is a sauce labs region in the EU, aka eu-central-1.
 const EUCentral1 Region = "eu-central-1"
 
+// AsiaSouth2 is a sauce labs region in India, aka asia-south-2.
+const AsiaSouth2 Region = "asia-south-2"
+
 // Staging is a sauce labs internal pre-production environment.
 const Staging Region = "staging"
 
@@ -80,6 +83,13 @@ var sauceRegionMetas = []regionMeta{
 		"https://api.eu-central-1.saucelabs.com",
 		"https://app.eu-central-1.saucelabs.com",
 		"https://ondemand.eu-central-1.saucelabs.com",
+		defaultCreds,
+	},
+	{
+		AsiaSouth2.String(),
+		"https://api.asia-south-2.saucelabs.com",
+		"https://app.asia-south-2.saucelabs.com",
+		"https://ondemand.asia-south-2.saucelabs.com",
 		defaultCreds,
 	},
 	{

--- a/internal/region/region_test.go
+++ b/internal/region/region_test.go
@@ -29,8 +29,30 @@ func TestFromString(t *testing.T) {
 			want: EUCentral1,
 		},
 		{
+			name: "us-east-4",
+			args: args{"us-east-4"},
+			want: USEast4,
+		},
+		{
+			name: "asia-south-2",
+			args: args{"asia-south-2"},
+			want: AsiaSouth2,
+		},
+		{
+			name: "staging",
+			args: args{"staging"},
+			want: Staging,
+		},
+		{
 			name: "wonderland",
 			args: args{"wonderland"},
+			want: None,
+		},
+		{
+			// asia-south-1 is GCP Mumbai, a plausible typo for the India region.
+			// It must not resolve to a region with silently empty URLs.
+			name: "asia-south-1",
+			args: args{"asia-south-1"},
 			want: None,
 		},
 	}
@@ -47,6 +69,75 @@ func TestString(t *testing.T) {
 	name := "staging"
 	r := FromString(name)
 	assert.Equal(t, name, r.String())
+}
+
+// TestRegionURLs guards the sauceRegionMetas table. Its entries are unkeyed
+// struct literals, so a field written out of order still compiles and would
+// silently point the CLI at the wrong host.
+func TestRegionURLs(t *testing.T) {
+	// init() may have loaded ~/.sauce/regions.yml, and user regions override
+	// the built-in ones. Isolate so this asserts the built-in table alone.
+	saved := userRegionMetas
+	userRegionMetas = nil
+	t.Cleanup(func() { userRegionMetas = saved })
+
+	tests := []struct {
+		region       Region
+		apiURL       string
+		appURL       string
+		webdriverURL string
+	}{
+		{None, "", "", ""},
+		{
+			USWest1,
+			"https://api.us-west-1.saucelabs.com",
+			// us-west-1 predates the per-region app host and keeps the bare one.
+			"https://app.saucelabs.com",
+			"https://ondemand.us-west-1.saucelabs.com",
+		},
+		{
+			USEast4,
+			"https://api.us-east-4.saucelabs.com",
+			"https://app.us-east-4.saucelabs.com",
+			"https://ondemand.us-east-4.saucelabs.com",
+		},
+		{
+			EUCentral1,
+			"https://api.eu-central-1.saucelabs.com",
+			"https://app.eu-central-1.saucelabs.com",
+			"https://ondemand.eu-central-1.saucelabs.com",
+		},
+		{
+			AsiaSouth2,
+			"https://api.asia-south-2.saucelabs.com",
+			"https://app.asia-south-2.saucelabs.com",
+			"https://ondemand.asia-south-2.saucelabs.com",
+		},
+		{
+			Staging,
+			"https://api.staging.saucelabs.net",
+			"https://app.staging.saucelabs.net",
+			"https://ondemand.staging.saucelabs.net",
+		},
+	}
+
+	if got := len(allRegionMetas(sauceRegionMetas, nil)); got != len(tests) {
+		t.Fatalf("sauceRegionMetas has %d entries but this table covers %d; add the new region's URLs here", got, len(tests))
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.region.String(), func(t *testing.T) {
+			if got := tt.region.APIBaseURL(); got != tt.apiURL {
+				t.Errorf("APIBaseURL() = %q, want %q", got, tt.apiURL)
+			}
+			if got := tt.region.AppBaseURL(); got != tt.appURL {
+				t.Errorf("AppBaseURL() = %q, want %q", got, tt.appURL)
+			}
+			if got := tt.region.WebDriverBaseURL(); got != tt.webdriverURL {
+				t.Errorf("WebDriverBaseURL() = %q, want %q", got, tt.webdriverURL)
+			}
+		})
+	}
 }
 
 func Test_mergeRegionMetas(t *testing.T) {


### PR DESCRIPTION
## Description

Adds the India GCP region (Noida / DEL1) so saucectl can target the new data centre. Jira: [INT-769](https://saucedev.atlassian.net/browse/INT-769), under epic [INT-336](https://saucedev.atlassian.net/browse/INT-336).

| Accessor | URL |
| --- | --- |
| `APIBaseURL` | `https://api.asia-south-2.saucelabs.com` |
| `AppBaseURL` | `https://app.asia-south-2.saucelabs.com` |
| `WebdriverBaseURL` | `https://ondemand.asia-south-2.saucelabs.com` |

The region name is not documented anywhere yet — the internal rollout page still carries a placeholder — so it was cross-checked against the live production host list and confirmed by DNS/HTTP probing before being written down.

### asia-south-2 is real-device-only, so the VDC frameworks are gated

`/rest/v1/info/platforms/all` returns an empty array for this region, versus 4375 entries for `eu-central-1` (2086 of them `* Emulator` / `* Simulator`). It has no browsers, no emulators and no simulators. Separately, test-composer is not routed there.

So cypress, playwright, testcafe, puppeteer-replay and espresso emulator suites are gated off, mirroring `us-east-4` — which has the identical signature and is already gated the same way.

This matters for UX, not just correctness. `playwright-cucumberjs` is the one VDC kind with no region gate, so it shows what an ungated run does:

| Same code path, ungated | Elapsed | Error |
| --- | --- | --- |
| `asia-south-2` | **10.4 s** | `unexpected status '404' from test-composer: ` — truncated, empty body |
| `eu-central-1` | 1.9 s | `unexpected status '401' from test-composer: {"detail":"Authorization failed"}` |

That is ~8.5 s of silence, because `internal/http/client.go` installs a `CheckRetry` that treats 404 as retryable (`RetryMax: 3`, backoff 1s/2s/4s, nil logger). Gated frameworks return at the ~1.1 s baseline with an actionable message instead.

**To un-gate later** — a five-line deletion, precedent `9491a68` (+0/−10) — once both of these hold:

```
curl -s -o /dev/null -w '%{http_code}\n' https://api.asia-south-2.saucelabs.com/v2/testcomposer/frameworks   # want 401, not 404
curl -s https://api.asia-south-2.saucelabs.com/rest/v1/info/platforms/all                                   # want non-empty
```

Keep `msg.NoFrameworkSupport` / `msg.NoEmulatorSupport` when doing so — `us-east-4` still needs them.

### Only the v1alpha region enum changes — deliberately

`api/v1/subschema/sauce.schema.json` is `$ref`'d by exactly one file, `api/v1/framework/cypress.schema.json`, and cypress is the only `apiVersion: v1` kind. Its enum listing just `us-west-1` and `eu-central-1` therefore *matches real behaviour*, since cypress is gated in `us-east-4` and now `asia-south-2`. Adding values there would make the schema accept a config the CLI then refuses, so it is intentionally untouched — please don't "fix" it separately.

The v1alpha subschema is the opposite case: shared by eight kinds, four of which (espresso, xcuitest, xctest, apitest) are ungated and must accept the region. Editing it produces 8 hunks in the generated bundle; the cypress block correctly stays at two values.

### New test

`TestRegionURLs` asserts `APIBaseURL()` / `AppBaseURL()` / `WebDriverBaseURL()` for every region. Nothing previously asserted any region's URLs, and `sauceRegionMetas` uses unkeyed struct literals — so a transposed field compiles and silently points at the wrong host. Verified by mutation: swapping the app and webdriver URLs makes it fail and name both fields. It also asserts its own length against the table, so the next region addition fails until its URLs are added, and pins `us-west-1`'s deliberately unprefixed `https://app.saucelabs.com`.

`TestFromString` gains `asia-south-2`, plus backfill for `us-east-4` and `staging`, and `asia-south-1 -> None` — GCP Mumbai is the likely typo for this region and must not resolve to one with empty URLs.

## Verification

`gofmt` clean · `go vet` clean · `golangci-lint run` 0 issues · `go test ./...` 51 packages ok · regenerated bundle byte-identical to a fresh regeneration.

**Verified against the live service with real credentials.** Every command authenticates against `asia-south-2` and routes correctly:

| Command | `asia-south-2` | `us-west-1` (control) |
| --- | --- | --- |
| `saucectl devices list` | `No devices found` | 399 devices |
| `saucectl storage list` | empty, no error | files listed |
| `saucectl jobs list` | `Cannot find any jobs` | 13 jobs |
| `GET /v1/rdc/devices` | HTTP **200**, `[]` | HTTP 200, 399 entries |

An xcuitest real-device run resolves the region and uploads the app to `asia-south-2` App Storage. Gate and error paths, all instant:

- cypress / playwright at `-r asia-south-2` → `this framework is currently not supported in your specified region`
- espresso with `emulators:` → `emulators are currently not supported in your specified region`, before any upload
- `-r asia-south-1` → `no sauce region set`; `storage list -r asia-south-1` → `invalid region`
- regression: cypress on `us-west-1` is unaffected and still proceeds past the gate

**Not verified: an actual green RDC job.** `GET /v1/rdc/devices` returns HTTP 200 with an empty array, so DEL1 has no real devices registered yet — that is device deployment (tracked around MDI-2719 / MOBA-8416), not anything in this repo. The region entry, URLs and routing are confirmed correct; a passing espresso/xcuitest run has to wait for devices.

### Two notes for maintainers

- **The pre-merge schema warning only fires when the region is in the config file.** `ValidateSchema` reads the file on disk, not the resolved region, so `-r asia-south-2` against a config whose `sauce.region` is something else produces no warning at all. With the region in the YAML: `- value must be one of "us-west-1", "us-east-4", "eu-central-1" in /sauce/region`. It is soft — the run continues — and it clears for every existing binary the moment this merges, since `internal/config/config.go` compiles the schema from `raw.githubusercontent.com/saucelabs/saucectl/main`.
- **`make schema` is broken on Linux**: the recipe uses `pushd`/`popd`, bash builtins, while `make` runs `/bin/sh` (dash). Use `cd scripts/json-schema-bundler && npm run bundle -- -s ../../api/global.schema.json -o ../../api/saucectl.schema.json`. Pre-existing, not introduced here.

## Known gaps, pre-existing and out of scope

Filed as follow-ups rather than widened into this PR:

1. `internal/cmd/run/cucumber.go` has no region gate at all, though `saucecloud/cucumber.go` uses the same test-composer lookup — so `playwright-cucumberjs` is already wrong for `us-east-4`. `internal/xcuitest/config.go` and `internal/xctest/config.go` likewise have no simulator gate.
2. `saucectl init` is unusable in RDC-only regions: `checkCredentials` calls test-composer and string-matches only the exact 401 message, so a 404 aborts `init` for every framework; `askEmulator` builds a select from an empty platform list. That is why `asia-south-2` is not added to the interactive picker.
3. Region error messages: the run path cannot distinguish "no region set" from "unrecognised region", so a typo reports `no sauce region set`. The subcommand groups return a bare `invalid region`. The 8 `--region` help strings still say "Options: us-west-1, eu-central-1", already wrong for `us-east-4`.

Neither 1 nor 3 is a regression introduced here.

## CI

16 checks pass, including all four core gates and the cypress, playwright, testcafe, puppeteer-replay, playwright-cucumberjs, espresso and xcuitest e2e jobs.

`xctest` fails, and it fails identically on `main`: the same assertion inside the bundled Flutter sample app (`RunnerTests.m`, `((success) is true) failed - Instance of 'FlutterErrorDetails'`), on a real device in `us-west-1`, 3 attempts. The last `test.yml` run on `main` (2026-07-29) failed the same way. This PR touches no xctest code path.


[INT-769]: https://saucedev.atlassian.net/browse/INT-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INT-336]: https://saucedev.atlassian.net/browse/INT-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ